### PR TITLE
Switch to STR/CON/DEX/INT/WIS/LUCK stat system

### DIFF
--- a/commands/info.py
+++ b/commands/info.py
@@ -16,9 +16,17 @@ class CmdScore(Command):
     def func(self):
         caller = self.caller
         stats = []
-        for key, disp in (("str", "Strength"), ("agi", "Agility"), ("will", "Willpower")):
-            base = caller.attributes.get(key, 0)
-            mod = caller.attributes.get(f"{key}_mod", 0)
+        for key, disp in (
+            ("STR", "Strength"),
+            ("CON", "Constitution"),
+            ("DEX", "Dexterity"),
+            ("INT", "Intelligence"),
+            ("WIS", "Wisdom"),
+            ("LUCK", "Luck"),
+        ):
+            trait = caller.traits.get(key)
+            base = trait.base if trait else 0
+            mod = trait.modifier if trait else 0
             total = base + mod
             text = f"{base}" if not mod else f"{base} ({total})"
             stats.append([disp, text])
@@ -56,7 +64,19 @@ class CmdFinger(Command):
         if not target:
             return
         desc = target.db.desc or "They have no description."
-        stats = f"STR {target.db.str or 0}, AGI {target.db.agi or 0}, WILL {target.db.will or 0}"
+        stat_parts = []
+        for key, label in (
+            ("STR", "STR"),
+            ("CON", "CON"),
+            ("DEX", "DEX"),
+            ("INT", "INT"),
+            ("WIS", "WIS"),
+            ("LUCK", "LUCK"),
+        ):
+            trait = target.traits.get(key)
+            value = trait.value if trait else 0
+            stat_parts.append(f"{label} {value}")
+        stats = ", ".join(stat_parts)
         self.msg(f"|w{target.key}|n - {desc}")
         self.msg(stats)
 

--- a/commands/skills.py
+++ b/commands/skills.py
@@ -4,15 +4,15 @@ from .command import Command
 
 # A dict of all skills, with their associated stat as the value
 SKILL_DICT = {
-    "smithing": "str",
-    "tailoring": "agi",
-    "evasion": "agi",
-    "daggers": "agi",
-    "swords": "str",
-    "cooking": "will",
-    "carving": "str",
-    "unarmed": "agi",
-    "leatherwork": "will",
+    "smithing": "STR",
+    "tailoring": "DEX",
+    "evasion": "DEX",
+    "daggers": "DEX",
+    "swords": "STR",
+    "cooking": "WIS",
+    "carving": "STR",
+    "unarmed": "DEX",
+    "leatherwork": "WIS",
 }
 
 
@@ -34,11 +34,18 @@ class CmdStatSheet(Command):
 
         # display the primary stats
         self.msg("STATS")
-        stats = [
-            ["Strength", caller.db.str or 0],
-            ["Agility", caller.db.agi or 0],
-            ["Willpower", caller.db.will or 0],
-        ]
+        stats = []
+        for key, disp in (
+            ("STR", "Strength"),
+            ("CON", "Constitution"),
+            ("DEX", "Dexterity"),
+            ("INT", "Intelligence"),
+            ("WIS", "Wisdom"),
+            ("LUCK", "Luck"),
+        ):
+            trait = caller.traits.get(key)
+            value = trait.value if trait else 0
+            stats.append([disp, value])
         rows = list(zip(*stats))
         table = EvTable(table=rows, border="none")
         self.msg(str(table))

--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -319,7 +319,7 @@ ANGRY_BEAR = {
     "flee_at": 5,
     "armor": 20,
     "name_color": "r",
-    "str": 15,
+    "STR": 15,
     "natural_weapon": {
         "name": "claws",
         "damage_type": "slash",
@@ -342,8 +342,8 @@ COUGAR = {
     "flee_at": 15,
     "armor": 15,
     "name_color": "r",
-    "str": 8,
-    "agi": 15,
+    "STR": 8,
+    "DEX": 15,
     "natural_weapon": {
         "name": "claws",
         "damage_type": "slash",
@@ -384,7 +384,7 @@ DOE_DEER = {
     "gender": "female",
     "react_as": "timid",
     "armor": 10,
-    "agi": 15,
+    "DEX": 15,
     "can_attack": True,
     # randomly generate a list of drop prototype keys when the mob is spawned
     "drops": lambda: ["DEER_MEAT"] * randint(1, 3) + ["ANIMAL_HIDE"] * randint(0, 3),
@@ -396,7 +396,7 @@ STAG_DEER = {
     "desc": "A wary adult stag, sporting a full rack of antlers.",
     "gender": "male",
     "armor": 10,
-    "agi": 15,
+    "DEX": 15,
     "natural_weapon": {
         "name": "antlers",
         "damage_type": "pierce",


### PR DESCRIPTION
## Summary
- define STR, CON, DEX, INT, WIS and LUCK traits for characters
- base abilities now use DEX for evasion
- skills reference the new stats
- show the new stats in `score`, `stats`, and `finger`
- update NPC prototypes to use the new trait names

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'evennia')*

------
https://chatgpt.com/codex/tasks/task_e_6840a571a4c4832c9d472869c273cd50