### PR TITLE
Enable command abbreviations

### DIFF
--- a/server/conf/settings.py
+++ b/server/conf/settings.py
@@ -32,6 +32,12 @@ SERVERNAME = "MiniMUD the RPG"
 # Defines the base character type as PlayerCharacter instead of Character
 BASE_CHARACTER_TYPECLASS = "typeclasses.characters.PlayerCharacter"
 
+# Enable command abbreviation matching
+CMD_IGNORE_INVALID_ABBREVIATIONS = False
+
+# Use our local base Command class for default commands
+COMMAND_DEFAULT_CLASS = "commands.command.Command"
+
 ######################################################################
 # Config for contrib packages
 ######################################################################


### PR DESCRIPTION
## Summary
- support fuzzy command matching by enabling command abbreviations
- set our custom command class as default

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'evennia')*

------
https://chatgpt.com/codex/tasks/task_e_6840ba226808832c86739e8eb422f9e7