### PR TITLE
Implement global tick system

### DIFF
--- a/server/conf/at_server_startstop.py
+++ b/server/conf/at_server_startstop.py
@@ -30,7 +30,11 @@ def at_server_start():
     This is called every time the server starts up, regardless of
     how it was shut down.
     """
-    pass
+    from evennia.utils import create
+    from evennia.scripts.models import ScriptDB
+
+    if not ScriptDB.objects.filter(db_key="global_tick").exists():
+        create.script("typeclasses.scripts.GlobalTick", key="global_tick")
 
 
 def at_server_stop():

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -342,6 +342,14 @@ class Character(ObjectParent, ClothedCharacter):
         """
         pass
 
+    def at_tick(self):
+        """Called by the global ticker."""
+        self.refresh_prompt()
+
+    def refresh_prompt(self):
+        """Refresh the player's prompt display."""
+        self.msg(prompt=self.get_display_status(self))
+
     def revive(self, reviver, **kwargs):
         """
         Revive a defeated character at partial health.
@@ -366,6 +374,7 @@ class PlayerCharacter(Character):
         super().at_object_creation()
         # initialize hands
         self.db._wielded = {"left": None, "right": None}
+        self.tags.add("tickable")
 
     def get_display_name(self, looker, **kwargs):
         """

--- a/typeclasses/scripts.py
+++ b/typeclasses/scripts.py
@@ -233,3 +233,22 @@ class RestockScript(Script):
                     obj.db.value = obj.db.value or 1
                     # add to the shop stock
                     self.obj.add_stock(obj)
+
+
+class GlobalTick(Script):
+    """A global ticker calling ``at_tick`` on tickable objects."""
+
+    def at_script_creation(self):
+        self.interval = 60
+        self.persistent = True
+
+    def at_repeat(self):
+        from evennia.utils.search import search_tag
+        from .characters import PlayerCharacter
+
+        for obj in search_tag(key="tickable"):
+            if hasattr(obj, "at_tick"):
+                obj.at_tick()
+
+        for pc in PlayerCharacter.objects.all():
+            pc.refresh_prompt()

--- a/typeclasses/tests/__init__.py
+++ b/typeclasses/tests/__init__.py
@@ -1,0 +1,8 @@
+"""Test package setup for Evennia."""
+
+import os
+import django
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "server.conf.settings")
+django.setup()
+

--- a/typeclasses/tests/test_characters.py
+++ b/typeclasses/tests/test_characters.py
@@ -70,3 +70,28 @@ class TestCharacterProperties(EvenniaTest):
         self.assertFalse(self.char1.in_combat)
         combat_script.add_combatant(self.char1, enemy=self.char2)
         self.assertTrue(self.char1.in_combat)
+
+
+class TestGlobalTick(EvenniaTest):
+    def test_interval(self):
+        from typeclasses.scripts import GlobalTick
+
+        script = GlobalTick()
+        script.at_script_creation()
+        self.assertEqual(script.interval, 60)
+        self.assertTrue(script.persistent)
+
+    def test_tick_triggers_prompt(self):
+        from typeclasses.scripts import GlobalTick
+
+        script = GlobalTick()
+        script.at_script_creation()
+
+        self.char1.tags.add("tickable")
+        self.char1.at_tick = MagicMock()
+        self.char1.refresh_prompt = MagicMock()
+
+        script.at_repeat()
+
+        self.char1.at_tick.assert_called_once()
+        self.char1.refresh_prompt.assert_called()


### PR DESCRIPTION
## Summary
- add a persistent GlobalTick script that calls `at_tick`
- refresh player prompts on each tick
- auto-tag new player characters as `tickable`
- start the GlobalTick script on server start
- provide Django setup for tests and verify global tick functionality

## Testing
- `python -m pytest -q` *(fails: AttributeError: 'NoneType' object has no attribute 'data_out')*

------
https://chatgpt.com/codex/tasks/task_e_6840bc3eaedc832cbf48dc1b1bd22813