### PR TITLE
Add modular stats framework

### DIFF
--- a/commands/info.py
+++ b/commands/info.py
@@ -3,6 +3,7 @@ from evennia.utils.evtable import EvTable
 from evennia.utils import iter_to_str
 from evennia.contrib.game_systems.clothing.clothing import get_worn_clothes
 from world.guilds import get_rank_title
+from world.stats import CORE_STAT_KEYS
 
 from .command import Command
 
@@ -17,20 +18,13 @@ class CmdScore(Command):
     def func(self):
         caller = self.caller
         stats = []
-        for key, disp in (
-            ("STR", "STR"),
-            ("CON", "CON"),
-            ("DEX", "DEX"),
-            ("INT", "INT"),
-            ("WIS", "WIS"),
-            ("LUCK", "LUCK"),
-        ):
+        for key in CORE_STAT_KEYS:
             trait = caller.traits.get(key)
             base = trait.base if trait else 0
             mod = trait.modifier if trait else 0
             total = base + mod
             text = f"{base}" if not mod else f"{base} ({total})"
-            stats.append([disp, text])
+            stats.append([key, text])
         table = EvTable(table=list(zip(*stats)), border="none")
         caller.msg(str(table))
 
@@ -66,17 +60,10 @@ class CmdFinger(Command):
             return
         desc = target.db.desc or "They have no description."
         stat_parts = []
-        for key, label in (
-            ("STR", "STR"),
-            ("CON", "CON"),
-            ("DEX", "DEX"),
-            ("INT", "INT"),
-            ("WIS", "WIS"),
-            ("LUCK", "LUCK"),
-        ):
+        for key in CORE_STAT_KEYS:
             trait = target.traits.get(key)
             value = trait.value if trait else 0
-            stat_parts.append(f"{label} {value}")
+            stat_parts.append(f"{key} {value}")
         stats = ", ".join(stat_parts)
         self.msg(f"|w{target.key}|n - {desc}")
         self.msg(stats)

--- a/commands/skills.py
+++ b/commands/skills.py
@@ -1,5 +1,6 @@
 from evennia import CmdSet
 from evennia.utils.evtable import EvTable
+from world.stats import CORE_STAT_KEYS
 from .command import Command
 
 # A dict of all skills, with their associated stat as the value
@@ -35,17 +36,10 @@ class CmdStatSheet(Command):
         # display the primary stats
         self.msg("STATS")
         stats = []
-        for key, disp in (
-            ("STR", "STR"),
-            ("CON", "CON"),
-            ("DEX", "DEX"),
-            ("INT", "INT"),
-            ("WIS", "WIS"),
-            ("LUCK", "LUCK"),
-        ):
+        for key in CORE_STAT_KEYS:
             trait = caller.traits.get(key)
             value = trait.value if trait else 0
-            stats.append([disp, value])
+            stats.append([key, value])
         rows = list(zip(*stats))
         table = EvTable(table=rows, border="none")
         self.msg(str(table))

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -93,40 +93,12 @@ class Character(ObjectParent, ClothedCharacter):
         )
 
     def at_object_creation(self):
-        # core stats
-        for stat in ("STR", "CON", "DEX", "INT", "WIS", "LUCK"):
-            self.traits.add(stat, trait_type="counter", min=0, max=100, base=5)
-        # resource stats
-        self.traits.add(
-            "health",
-            "Health",
-            trait_type="gauge",
-            min=0,
-            max=100,
-            base=100,
-            rate=0.1,
-        )
-        self.traits.add(
-            "mana",
-            "Mana",
-            trait_type="gauge",
-            min=0,
-            max=100,
-            base=100,
-            rate=0.1,
-        )
-        self.traits.add(
-            "stamina",
-            "Stamina",
-            trait_type="gauge",
-            min=0,
-            max=100,
-            base=100,
-            rate=0.1,
-        )
-        self.traits.add(
-            "evasion", trait_type="counter", min=0, max=100, base=0, stat="DEX"
-        )
+        from world import stats
+
+        # Apply all default stats in a single modular step. If stats already
+        # exist on the character, `apply_stats` will not overwrite them.
+        stats.apply_stats(self)
+
         self.db.guild = ""
         self.db.guild_honor = 0
 

--- a/typeclasses/tests/test_stats.py
+++ b/typeclasses/tests/test_stats.py
@@ -1,0 +1,16 @@
+from evennia.utils.test_resources import EvenniaTest
+from world import stats
+
+
+class TestStats(EvenniaTest):
+    """Tests for the stats module."""
+
+    def test_apply_stats_idempotent(self):
+        char = self.char1
+        # apply stats once
+        stats.apply_stats(char)
+        initial = {key: char.traits.get(key).base for key in stats.CORE_STAT_KEYS}
+        # apply again - should not change values
+        stats.apply_stats(char)
+        again = {key: char.traits.get(key).base for key in stats.CORE_STAT_KEYS}
+        self.assertEqual(initial, again)

--- a/world/chargen_menu.py
+++ b/world/chargen_menu.py
@@ -8,8 +8,9 @@ from evennia import create_object
 from evennia.utils import dedent
 from typeclasses.characters import PlayerCharacter, Character
 from world.scripts import races, classes
+from world.stats import CORE_STAT_KEYS
 
-STAT_LIST = ["STR", "CON", "DEX", "INT", "WIS", "LUCK"]
+STAT_LIST = CORE_STAT_KEYS
 STAT_POINTS = 24
 
 # ---------------- Welcome ----------------

--- a/world/stats.py
+++ b/world/stats.py
@@ -1,0 +1,123 @@
+from dataclasses import dataclass
+from typing import List, Optional
+
+
+@dataclass
+class Stat:
+    key: str
+    display: str
+    trait_type: str = "counter"
+    base: int = 0
+    min: int = 0
+    max: int = 100
+    rate: Optional[float] = None
+    stat: Optional[str] = None
+
+
+# Core character attributes
+CORE_STATS: List[Stat] = [
+    Stat("STR", "STR", base=5),
+    Stat("CON", "CON", base=5),
+    Stat("DEX", "DEX", base=5),
+    Stat("INT", "INT", base=5),
+    Stat("WIS", "WIS", base=5),
+    Stat("LUCK", "LUCK", base=5),
+]
+
+# Primary resources
+RESOURCE_STATS: List[Stat] = [
+    Stat("health", "Health", trait_type="gauge", base=100, rate=0.1),
+    Stat("mana", "Mana", trait_type="gauge", base=100, rate=0.1),
+    Stat("stamina", "Stamina", trait_type="gauge", base=100, rate=0.1),
+]
+
+# Base skill for avoiding damage
+EVASION_STAT = Stat("evasion", "Evasion", stat="DEX")
+
+# Defense-oriented stats
+DEFENSE_STATS: List[Stat] = [
+    Stat("armor", "Armor"),
+    Stat("magic_resist", "Magic Resist"),
+    Stat("dodge", "Dodge"),
+    Stat("block_rate", "Block Rate"),
+    Stat("parry_rate", "Parry Rate"),
+    Stat("status_resist", "Status Resist"),
+    Stat("crit_resist", "Critical Resist"),
+]
+
+# Offense-oriented stats
+OFFENSE_STATS: List[Stat] = [
+    Stat("attack_power", "Attack Power"),
+    Stat("spell_power", "Spell Power"),
+    Stat("crit_chance", "Critical Chance"),
+    Stat("crit_bonus", "Critical Damage Bonus"),
+    Stat("accuracy", "Accuracy"),
+    Stat("piercing", "Armor Penetration"),
+    Stat("spell_penetration", "Spell Penetration"),
+]
+
+# Regeneration & sustain stats
+REGEN_STATS: List[Stat] = [
+    Stat("health_regen", "Health Regen"),
+    Stat("mana_regen", "Mana Regen"),
+    Stat("stamina_regen", "Stamina Regen"),
+    Stat("lifesteal", "Lifesteal"),
+    Stat("leech", "Leech"),
+]
+
+# Combat timing & tempo stats
+TEMPO_STATS: List[Stat] = [
+    Stat("cooldown_reduction", "Cooldown Reduction"),
+    Stat("initiative", "Initiative"),
+    Stat("gcd_speed", "Global Cooldown Speed"),
+]
+
+# Utility / miscellaneous stats
+UTILITY_STATS: List[Stat] = [
+    Stat("stealth", "Stealth"),
+    Stat("detection", "Detection"),
+    Stat("threat", "Threat"),
+    Stat("movement_speed", "Movement Speed", base=1),
+    Stat("craft_bonus", "Crafting Bonus"),
+]
+
+# PvP / guild-related stats
+PVP_STATS: List[Stat] = [
+    Stat("pvp_power", "PvP Power"),
+    Stat("pvp_resilience", "PvP Resilience"),
+    Stat("guild_honor_mod", "Guild Honor Rank Modifiers"),
+]
+
+
+ALL_STATS: List[Stat] = (
+    CORE_STATS
+    + RESOURCE_STATS
+    + [EVASION_STAT]
+    + DEFENSE_STATS
+    + OFFENSE_STATS
+    + REGEN_STATS
+    + TEMPO_STATS
+    + UTILITY_STATS
+    + PVP_STATS
+)
+
+# Convenience: list of only core stat keys
+CORE_STAT_KEYS = [stat.key for stat in CORE_STATS]
+
+
+def apply_stats(chara):
+    """Add default stats to a character if missing."""
+    for stat in ALL_STATS:
+        if chara.traits.get(stat.key):
+            continue
+        kwargs = {
+            "trait_type": stat.trait_type,
+            "min": stat.min,
+            "max": stat.max,
+            "base": stat.base,
+        }
+        if stat.trait_type == "gauge" and stat.rate is not None:
+            kwargs["rate"] = stat.rate
+        if stat.stat:
+            kwargs["stat"] = stat.stat
+        chara.traits.add(stat.key, stat.display, **kwargs)


### PR DESCRIPTION
## Summary
- introduce `world.stats` defining core/defensive/offensive/etc stats
- refactor `Character.at_object_creation` to use new stats module
- update commands and chargen to pull stat lists from `world.stats`
- add regression test for stats application

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6840cd1edfec832cbe397edbb93c6bed