### PR TITLE
Fix character not assigned to account

### DIFF
--- a/world/chargen_menu.py
+++ b/world/chargen_menu.py
@@ -194,6 +194,11 @@ def menunode_finish(caller, **kwargs):
         char.home = start_room[0]
         char.db.prelogout_location = start_room[0]
 
+    # assign the newly created character to this account
+    char.account = caller
+    caller.characters.add(char)
+    char.save()
+
     caller.db._last_puppet = char
     caller.ndb.new_char = None
     caller.msg("|gCharacter Created! You can now use |wic <name>|g to enter the game.|n")


### PR DESCRIPTION
## Summary
- assign account to newly created characters
- add characters to the account's playable list

## Testing
- `pytest -q` *(fails: AttributeError 'NoneType' object has no attribute 'data_out')*

------
https://chatgpt.com/codex/tasks/task_e_6840d5ca602c832cbf506278b62a8880