### PR TITLE
Set Evennia MuxCommand as default

### DIFF
--- a/server/conf/settings.py
+++ b/server/conf/settings.py
@@ -35,8 +35,8 @@ BASE_CHARACTER_TYPECLASS = "typeclasses.characters.PlayerCharacter"
 # Enable command abbreviation matching
 CMD_IGNORE_INVALID_ABBREVIATIONS = False
 
-# Use our local base Command class for default commands
-COMMAND_DEFAULT_CLASS = "commands.command.Command"
+# Use the Evennia MuxCommand as the default command base
+COMMAND_DEFAULT_CLASS = "evennia.commands.default.muxcommand.MuxCommand"
 
 ######################################################################
 # Config for contrib packages


### PR DESCRIPTION
## Summary
- use `evennia.commands.default.muxcommand.MuxCommand` as the default base command

## Testing
- `pytest -q` *(fails: AttributeError: 'NoneType' object has no attribute 'data_out')*

------
https://chatgpt.com/codex/tasks/task_e_6840d8497198832c8e8a1ae2ceadd63f