### PR TITLE
Allow 'finger self' and fix bounty display

### DIFF
--- a/commands/info.py
+++ b/commands/info.py
@@ -55,12 +55,12 @@ class CmdFinger(Command):
     help_category = "general"
 
     def func(self):
-        if not self.args:
-            self.msg("Finger whom?")
-            return
-        target = self.caller.search(self.args.strip(), global_search=True)
-        if not target:
-            return
+        if not self.args or self.args.strip().lower() in {"self", "me"}:
+            target = self.caller
+        else:
+            target = self.caller.search(self.args.strip(), global_search=True)
+            if not target:
+                return
         desc = target.db.desc or "They have no description."
         stat_parts = []
         for key in CORE_STAT_KEYS:
@@ -77,7 +77,8 @@ class CmdFinger(Command):
             rank = get_rank_title(guild, honor)
             self.msg(f"Guild: {guild} ({rank})")
             self.msg(f"Honor: {honor}")
-        if bounty := target.db.get("bounty"):
+        bounty = target.attributes.get("bounty", 0)
+        if bounty > 0:
             self.msg(f"Bounty: {bounty}")
 
 

--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -25,6 +25,15 @@ class TestInfoCommands(EvenniaTest):
         self.char1.execute_cmd(f"finger {self.char2.key}")
         self.assertTrue(self.char1.msg.called)
 
+    def test_finger_self(self):
+        self.char1.execute_cmd("finger self")
+        self.assertTrue(self.char1.msg.called)
+
+    def test_finger_bounty(self):
+        self.char2.attributes.add("bounty", 10)
+        self.char1.execute_cmd(f"finger {self.char2.key}")
+        self.assertTrue(self.char1.msg.called)
+
     def test_score(self):
         self.char1.execute_cmd("score")
         self.assertTrue(self.char1.msg.called)


### PR DESCRIPTION
## Summary
- update `finger` command to allow self references and avoid db method conflicts
- show bounty when above zero
- add tests for self finger and bounty display

## Testing
- `pytest -q` *(fails: AttributeError: 'NoneType' object has no attribute 'data_out')*

------
https://chatgpt.com/codex/tasks/task_e_6840dcdb5728832c96e9091a1191ce2e