### PR TITLE
Fix sc alias collision

### DIFF
--- a/commands/info.py
+++ b/commands/info.py
@@ -10,7 +10,7 @@ from .command import Command
 
 
 class CmdScore(Command):
-    """View your character sheet."""
+    """View your character sheet (alias \"sc\")."""
 
     key = "score"
     aliases = ("sheet", "sc")

--- a/commands/skills.py
+++ b/commands/skills.py
@@ -19,11 +19,12 @@ SKILL_DICT = {
 
 class CmdStatSheet(Command):
     """
-    View your character's current stats.
+    View your character's current stats and known skills.
+    (aliases: "sheet", "skills")
     """
 
     key = "stats"
-    aliases = ("sheet", "skills", "sc")
+    aliases = ("sheet", "skills")
 
     def func(self):
         caller = self.caller

--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -42,7 +42,7 @@ class TestInfoCommands(EvenniaTest):
         self.assertIn("Tester", args)
 
 
-    def test_stats_alias_sc(self):
+    def test_score_alias_sc(self):
         self.char1.execute_cmd("sc")
         self.assertTrue(self.char1.msg.called)
 


### PR DESCRIPTION
## Summary
- reserve `sc` alias for the score command
- tweak stats command aliases and help text
- update command tests for alias change

## Testing
- `pytest -q` *(fails: AttributeError: 'NoneType' object has no attribute 'data_out')*

------
https://chatgpt.com/codex/tasks/task_e_6840e3647314832c8a8ca5c806cccae0