### PR TITLE
Fix WOOD_LOG duplication

### DIFF
--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -298,14 +298,6 @@ DRIFTWOOD = {
     "spawn_proto": "WOOD_LOG",
     "gathers": lambda: randint(1, 3),
 }
-WOOD_LOG = {
-    "key": "log of wood",
-    "desc": "A decent-sized wooden log. Not so big you can't carry it.",
-    "tags": [
-        ("wood", "crafting_material"),
-    ],
-    "value": 1,
-}
 
 
 ### Mobs


### PR DESCRIPTION
## Summary
- remove the duplicate `WOOD_LOG` entry in `world/prototypes.py`
- keep gather nodes pointing to the single `WOOD_LOG` prototype

## Testing
- `pytest -q` *(fails: AttributeError: 'NoneType' object has no attribute 'data_out')*

------
https://chatgpt.com/codex/tasks/task_e_6840e59a64c0832ca6c17fcabe70a8ce