### PR TITLE
Fix smithing chausses recipe

### DIFF
--- a/world/recipes/smithing.py
+++ b/world/recipes/smithing.py
@@ -302,7 +302,7 @@ class IronChainmailLegsRecipe(SkillRecipe):
     name = "iron chausses"
     tool_tags = ["wire_cutter", "pliers"]
     consumable_tags = ["heavy iron wire", "heavy iron wire", "heavy iron wire"]
-    output_prototypes = ["IRON_CHAUSES"]
+    output_prototypes = ["IRON_CHAUSSES"]
 
 
 class HeavyIronNeedle(SkillRecipe):

--- a/world/recipes/tests/test_smithing.py
+++ b/world/recipes/tests/test_smithing.py
@@ -6,6 +6,8 @@ Tests for smithing recipes
 from evennia.utils.test_resources import EvenniaTest
 from evennia.contrib.game_systems.crafting import crafting
 from world.recipes import smithing
+from unittest.mock import patch
+from django.conf import settings
 
 
 class TestSmithingRecipes(EvenniaTest):
@@ -16,8 +18,17 @@ class TestSmithingRecipes(EvenniaTest):
             "smithing", "Smithing", trait_type="counter", min=0, max=100
         )
         self.crafter.traits.smithing.base = 20
+        if "world.prototypes" not in settings.PROTOTYPE_MODULES:
+            settings.PROTOTYPE_MODULES.append("world.prototypes")
 
-    def test_ingot(self):
+    @patch("world.recipes.base.randint", return_value=1)
+    def test_ingot(self, mock_randint):
         tools, ingredients = smithing.SmeltIronRecipe.seed()
         results = crafting.craft(self.crafter, "iron ingot", *tools, *ingredients)
         self.assertEqual(results[0].key, "iron ingot")
+
+    @patch("world.recipes.base.randint", return_value=1)
+    def test_chainmail_legs(self, mock_randint):
+        tools, ingredients = smithing.IronChainmailLegsRecipe.seed()
+        results = crafting.craft(self.crafter, "iron chausses", *tools, *ingredients)
+        self.assertEqual(results[0].key, "iron chausses")


### PR DESCRIPTION
## Summary
- fix typo in `IronChainmailLegsRecipe`
- patch smithing tests to ensure crafting succeeds

## Testing
- `evennia test world.recipes.tests.test_smithing --settings settings.py --verbosity 2`


------
https://chatgpt.com/codex/tasks/task_e_6840e69d5d44832c83f2a144925fa235