### PR TITLE
Implement custom who command

### DIFF
--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -30,6 +30,7 @@ from commands.account import AccountOptsCmdSet
 from commands.shops import CmdMoney
 from commands.info import InfoCmdSet
 from commands.guilds import GuildCmdSet
+from commands.who import CmdWho
 
 
 class CharacterCmdSet(default_cmds.CharacterCmdSet):
@@ -81,6 +82,7 @@ class AccountCmdSet(default_cmds.AccountCmdSet):
         #
         self.add(ContribCmdCharCreate)
         self.add(AccountOptsCmdSet)
+        self.add(CmdWho)
 
 
 class UnloggedinCmdSet(default_cmds.UnloggedinCmdSet):

--- a/commands/who.py
+++ b/commands/who.py
@@ -1,0 +1,43 @@
+from evennia.commands.default.muxcommand import MuxCommand
+from evennia.server.sessionhandler import SESSIONS
+from evennia.utils.evtable import EvTable
+from evennia.utils.utils import time_format
+
+
+class CmdWho(MuxCommand):
+    """List who is online."""
+
+    key = "who"
+    aliases = ("online",)
+    account_caller = True
+
+    def func(self):
+        caller = self.caller
+        sessions = SESSIONS.get_sessions()
+        if not sessions:
+            caller.msg("No one is connected.")
+            return
+
+        is_admin = caller.check_permstring("Admins")
+        headers = ["Character", "Title", "Idle"]
+        if is_admin:
+            headers.insert(0, "Account")
+        table = EvTable(*headers, border="cells")
+
+        for sess in sessions:
+            if not sess.logged_in:
+                continue
+            account = sess.account
+            puppet = sess.puppet
+            idle = time_format(sess.idle(), 0)
+            title = puppet.db.title if puppet else ""
+            char = puppet.get_display_name(caller) if puppet else "None"
+            if not puppet and not is_admin:
+                continue
+            row = [char, title, idle]
+            if is_admin:
+                row.insert(0, account.key)
+            table.add_row(*row)
+
+        caller.msg(str(table))
+

--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -78,6 +78,13 @@ class TestInfoCommands(EvenniaTest):
         self.char1.execute_cmd("guildwho")
         self.assertTrue(self.char1.msg.called)
 
+    def test_who_hides_account(self):
+        self.char1.execute_cmd("who")
+        self.assertTrue(self.char1.msg.called)
+        out = self.char1.msg.call_args[0][0]
+        self.assertIn(self.char1.key, out)
+        self.assertNotIn(self.char1.account.key, out)
+
 class TestBountySmall(EvenniaTest):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
## Summary
- add new who command that displays character names and titles
- hide account names from non-admins
- load CmdWho in default cmdset
- test who hides account names

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6840ee254000832ca884fb99c0c10f08