### PR TITLE
Adjust coin ratios

### DIFF
--- a/utils/currency.py
+++ b/utils/currency.py
@@ -1,13 +1,23 @@
+"""Simple helpers for working with coins."""
+
+# Value of each coin type in copper pieces. One silver is worth 100 copper,
+# one gold is worth 10 silver (1000 copper) and one platinum is worth
+# 100 gold (100000 copper).
 COIN_VALUES = {
     "copper": 1,
-    "silver": 10,
-    "gold": 100,
-    "platinum": 1000,
+    "silver": 100,
+    "gold": 1000,
+    "platinum": 100000,
 }
 
 
 def to_copper(wallet) -> int:
-    """Convert a wallet to a value in copper."""
+    """Convert a wallet to its total value in copper.
+
+    The wallet is a mapping of coin names to amounts using the ratios in
+    :data:`COIN_VALUES` (1 silver = 100 copper, 1 gold = 1000 copper,
+    1 platinum = 100000 copper).
+    """
     if wallet is None:
         return 0
     if isinstance(wallet, int):
@@ -19,7 +29,11 @@ def to_copper(wallet) -> int:
 
 
 def from_copper(amount: int) -> dict:
-    """Convert an amount of copper to a wallet dict."""
+    """Break down a copper amount into coin denominations.
+
+    Uses :data:`COIN_VALUES` to determine how many platinum, gold, silver
+    and copper pieces make up the given ``amount``.
+    """
     remaining = int(amount)
     wallet = {}
     for coin, value in sorted(COIN_VALUES.items(), key=lambda kv: kv[1], reverse=True):


### PR DESCRIPTION
## Summary
- update the default conversion ratios between coin types
- clarify currency helper documentation

## Testing
- `pytest -q` *(fails: AttributeError: 'NoneType' object has no attribute 'data_out')*

------
https://chatgpt.com/codex/tasks/task_e_6840f5a62f90832cb4ebac988800b60f