### PR TITLE
Add currency round-trip tests

### DIFF
--- a/utils/tests/test_currency.py
+++ b/utils/tests/test_currency.py
@@ -1,0 +1,16 @@
+"""Tests for currency conversion utilities."""
+
+from evennia.utils.test_resources import EvenniaTest
+
+from utils.currency import from_copper, to_copper
+
+
+class TestCurrencyConversion(EvenniaTest):
+    """Ensure from_copper and to_copper are inverses."""
+
+    def test_round_trip_values(self):
+        amounts = [0, 50, 123456]
+        for amount in amounts:
+            wallet = from_copper(amount)
+            self.assertEqual(to_copper(wallet), amount)
+            self.assertEqual(from_copper(to_copper(wallet)), wallet)


### PR DESCRIPTION
## Summary
- add unit tests ensuring currency conversions are invertible

## Testing
- `pytest -q` *(fails: AttributeError: 'NoneType' object has no attribute 'data_out')*

------
https://chatgpt.com/codex/tasks/task_e_6840f6ef4464832ca1331f8fe64a29c2