### PR TITLE
Link secondary stats to core traits

### DIFF
--- a/typeclasses/tests/__init__.py
+++ b/typeclasses/tests/__init__.py
@@ -6,3 +6,9 @@ import django
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "server.conf.settings")
 django.setup()
 
+# Ensure Evennia fully initializes so SESSION_HANDLER and other globals exist
+import evennia
+
+if getattr(evennia, "SESSION_HANDLER", None) is None:
+    evennia._init()
+

--- a/typeclasses/tests/test_stats.py
+++ b/typeclasses/tests/test_stats.py
@@ -35,3 +35,17 @@ class TestStats(EvenniaTest):
 
         char.attributes.add("stealth_bonus", 7)
         self.assertEqual(stats.sum_bonus(dummy, "stealth"), char.traits.stealth.value + 7)
+
+    def test_secondary_stats_follow_core(self):
+        char = self.char1
+        stats.apply_stats(char)
+
+        # dodge depends on DEX
+        initial_dodge = stats.sum_bonus(char, "dodge")
+        char.traits.DEX.base += 5
+        self.assertGreater(stats.sum_bonus(char, "dodge"), initial_dodge)
+
+        # block_rate depends on STR
+        initial_block = stats.sum_bonus(char, "block_rate")
+        char.traits.STR.base += 5
+        self.assertGreater(stats.sum_bonus(char, "block_rate"), initial_block)

--- a/world/stats.py
+++ b/world/stats.py
@@ -36,57 +36,57 @@ EVASION_STAT = Stat("evasion", "Evasion", stat="DEX")
 
 # Defense-oriented stats
 DEFENSE_STATS: List[Stat] = [
-    Stat("armor", "Armor"),
-    Stat("magic_resist", "Magic Resist"),
-    Stat("dodge", "Dodge"),
-    Stat("block_rate", "Block Rate"),
-    Stat("parry_rate", "Parry Rate"),
-    Stat("status_resist", "Status Resist"),
-    Stat("crit_resist", "Critical Resist"),
+    Stat("armor", "Armor", stat="CON"),
+    Stat("magic_resist", "Magic Resist", stat="WIS"),
+    Stat("dodge", "Dodge", stat="DEX"),
+    Stat("block_rate", "Block Rate", stat="STR"),
+    Stat("parry_rate", "Parry Rate", stat="DEX"),
+    Stat("status_resist", "Status Resist", stat="CON"),
+    Stat("crit_resist", "Critical Resist", stat="CON"),
 ]
 
 # Offense-oriented stats
 OFFENSE_STATS: List[Stat] = [
-    Stat("attack_power", "Attack Power"),
-    Stat("spell_power", "Spell Power"),
-    Stat("crit_chance", "Critical Chance"),
-    Stat("crit_bonus", "Critical Damage Bonus"),
-    Stat("accuracy", "Accuracy"),
-    Stat("piercing", "Armor Penetration"),
-    Stat("spell_penetration", "Spell Penetration"),
+    Stat("attack_power", "Attack Power", stat="STR"),
+    Stat("spell_power", "Spell Power", stat="INT"),
+    Stat("crit_chance", "Critical Chance", stat="LUCK"),
+    Stat("crit_bonus", "Critical Damage Bonus", stat="STR"),
+    Stat("accuracy", "Accuracy", stat="DEX"),
+    Stat("piercing", "Armor Penetration", stat="STR"),
+    Stat("spell_penetration", "Spell Penetration", stat="INT"),
 ]
 
 # Regeneration & sustain stats
 REGEN_STATS: List[Stat] = [
-    Stat("health_regen", "Health Regen"),
-    Stat("mana_regen", "Mana Regen"),
-    Stat("stamina_regen", "Stamina Regen"),
-    Stat("lifesteal", "Lifesteal"),
-    Stat("leech", "Leech"),
+    Stat("health_regen", "Health Regen", stat="CON"),
+    Stat("mana_regen", "Mana Regen", stat="WIS"),
+    Stat("stamina_regen", "Stamina Regen", stat="CON"),
+    Stat("lifesteal", "Lifesteal", stat="STR"),
+    Stat("leech", "Leech", stat="INT"),
 ]
 
 # Combat timing & tempo stats
 TEMPO_STATS: List[Stat] = [
-    Stat("cooldown_reduction", "Cooldown Reduction"),
-    Stat("initiative", "Initiative"),
-    Stat("gcd_speed", "Global Cooldown Speed"),
+    Stat("cooldown_reduction", "Cooldown Reduction", stat="WIS"),
+    Stat("initiative", "Initiative", stat="DEX"),
+    Stat("gcd_speed", "Global Cooldown Speed", stat="DEX"),
 ]
 
 # Utility / miscellaneous stats
 UTILITY_STATS: List[Stat] = [
-    Stat("stealth", "Stealth"),
-    Stat("detection", "Detection"),
-    Stat("perception", "Perception", base=5),
-    Stat("threat", "Threat"),
-    Stat("movement_speed", "Movement Speed", base=1),
-    Stat("craft_bonus", "Crafting Bonus"),
+    Stat("stealth", "Stealth", stat="DEX"),
+    Stat("detection", "Detection", stat="WIS"),
+    Stat("perception", "Perception", base=5, stat="WIS"),
+    Stat("threat", "Threat", stat="STR"),
+    Stat("movement_speed", "Movement Speed", base=1, stat="DEX"),
+    Stat("craft_bonus", "Crafting Bonus", stat="INT"),
 ]
 
 # PvP / guild-related stats
 PVP_STATS: List[Stat] = [
-    Stat("pvp_power", "PvP Power"),
-    Stat("pvp_resilience", "PvP Resilience"),
-    Stat("guild_honor_mod", "Guild Honor Rank Modifiers"),
+    Stat("pvp_power", "PvP Power", stat="STR"),
+    Stat("pvp_resilience", "PvP Resilience", stat="CON"),
+    Stat("guild_honor_mod", "Guild Honor Rank Modifiers", stat="WIS"),
 ]
 
 


### PR DESCRIPTION
## Summary
- reference governing core stats for secondary traits
- initialise Evennia globals in tests
- verify secondary stats update with primary stat changes

## Testing
- `pytest -q` *(fails: ValueError: An Account with the name 'TestAccount' already exists)*

------
https://chatgpt.com/codex/tasks/task_e_6840ff00399c832ca780af91989a887a