### PR TITLE
Enhanced score scroll output

### DIFF
--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -59,11 +59,15 @@ class TestInfoCommands(EvenniaTest):
         self.assertTrue(self.char1.msg.called)
         args = self.char1.msg.call_args[0][0]
         self.assertIn("Tester", args)
+        self.assertIn("COIN POUCH", args)
         self.assertIn("Copper: 10", args)
-        self.assertIn("Silver: 2", args)
-        self.assertIn("Gold: 1", args)
         self.assertIn("Armor", args)
         self.assertIn("Attack Power", args)
+        self.assertIn("╔", args)
+        self.assertIn("╚", args)
+        self.assertIn("|g", args)
+        self.assertIn("|w", args)
+        self.assertIn("|c", args)
 
 
     def test_score_alias_sc(self):
@@ -71,6 +75,7 @@ class TestInfoCommands(EvenniaTest):
         self.assertTrue(self.char1.msg.called)
         out = self.char1.msg.call_args[0][0]
         self.assertIn("PRIMARY STATS", out)
+        self.assertIn("╔", out)
 
     def test_inventory(self):
         self.char1.execute_cmd("inventory")


### PR DESCRIPTION
## Summary
- redesign stats scroll using box drawing and color codes
- adjust score command tests for new format

## Testing
- `pytest -q` *(fails: OperationalError - settings.DEFAULT_HOME does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_684102ab6240832cb351e4c624106353