### PR TITLE
Fix chargen stat storage

### DIFF
--- a/world/chargen_menu.py
+++ b/world/chargen_menu.py
@@ -61,8 +61,8 @@ def _set_race(caller, raw_string, race, **kwargs):
     char.db.race = race
     char.db.charclass = None
     for stat in STAT_LIST:
-        # store base values using the AttributeHandler
-        char.db.set(stat.lower(), 0)
+        # store base values using AttributeHandler or db assignment
+        char.attributes.add(stat.lower(), 0)
     return "menunode_choose_class"
 
 # ---------------- Class ----------------
@@ -89,8 +89,8 @@ def _apply_base_stats(caller):
     class_mods = next((c["stat_mods"] for c in classes.CLASS_LIST if c["name"] == char.db.charclass), {})
     for stat in STAT_LIST:
         base = race_mods.get(stat, 0) + class_mods.get(stat, 0)
-        # set starting stat values using AttributeHandler
-        char.db.set(stat.lower(), base)
+        # set starting stat values using AttributeHandler or db assignment
+        char.attributes.add(stat.lower(), base)
 
 # ---------------- Gender ----------------
 
@@ -144,8 +144,8 @@ def _adjust_stat(caller, raw_string, stat, change, **kwargs):
     base_val = race_mods.get(stat, 0) + class_mods.get(stat, 0)
     if current_val + change < base_val:
         return "menunode_stat_alloc"
-    # update the stat via AttributeHandler
-    char.db.set(stat.lower(), current_val + change)
+    # update the stat via AttributeHandler or db assignment
+    char.attributes.add(stat.lower(), current_val + change)
     return "menunode_stat_alloc"
 
 # ---------------- Name ----------------


### PR DESCRIPTION
## Summary
- store stat values with `char.attributes.add` instead of `db.set`
- update race, base stat setup and stat adjustment helpers

## Testing
- `pytest -q` *(fails: OperationalError no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684109c3b954832c8a1100be33a7a392