### PR TITLE
Add chargen menu tests

### DIFF
--- a/typeclasses/tests/test_chargen.py
+++ b/typeclasses/tests/test_chargen.py
@@ -1,0 +1,53 @@
+from evennia.utils.test_resources import EvenniaTest
+from evennia import create_object
+from django.test import override_settings
+from world import chargen_menu
+
+
+@override_settings(DEFAULT_HOME="#1")
+class TestChargen(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        # Create a placeholder character for the chargen process
+        self.char = create_object(
+            "typeclasses.characters.PlayerCharacter",
+            key="In Progress",
+            location=None,
+            home=self.room1,
+        )
+        self.account.ndb.new_char = self.char
+
+    def test_set_race_initializes_attributes(self):
+        chargen_menu._set_race(self.account, "", "Human")
+        self.assertEqual(self.char.db.race, "Human")
+        self.assertIsNone(self.char.db.charclass)
+        for stat in chargen_menu.STAT_LIST:
+            self.assertEqual(self.char.attributes.get(stat.lower()), 0)
+
+    def test_allocate_and_finalize(self):
+        chargen_menu._set_race(self.account, "", "Human")
+        chargen_menu._set_class(self.account, "", "Warrior")
+        chargen_menu._set_gender(self.account, "", "male")
+
+        chargen_menu._adjust_stat(self.account, "", "STR", 2)
+        chargen_menu._adjust_stat(self.account, "", "CON", 1)
+        chargen_menu._adjust_stat(self.account, "", "DEX", 1)
+        chargen_menu._adjust_stat(self.account, "", "INT", 1)
+        chargen_menu._adjust_stat(self.account, "", "WIS", 1)
+        chargen_menu._adjust_stat(self.account, "", "LUCK", 1)
+
+        expected = {
+            stat: self.char.attributes.get(stat.lower(), default=0)
+            for stat in chargen_menu.STAT_LIST
+        }
+
+        chargen_menu.menunode_finish(self.account)
+
+        for stat in chargen_menu.STAT_LIST:
+            trait = self.char.traits.get(stat)
+            self.assertIsNotNone(trait)
+            self.assertEqual(trait.base, expected[stat])
+
+        self.assertEqual(self.char.db.race, "Human")
+        self.assertEqual(self.char.db.charclass, "Warrior")
+        self.assertEqual(self.char.db.gender, "male")

--- a/world/chargen_menu.py
+++ b/world/chargen_menu.py
@@ -114,7 +114,7 @@ def menunode_stat_alloc(caller):
     race_mods = next((r["stat_mods"] for r in races.RACE_LIST if r["name"] == char.db.race), {})
     class_mods = next((c["stat_mods"] for c in classes.CLASS_LIST if c["name"] == char.db.charclass), {})
     base_stats = {s: race_mods.get(s, 0) + class_mods.get(s, 0) for s in STAT_LIST}
-    current = {s: char.db.get(s.lower(), 0) for s in STAT_LIST}
+    current = {s: char.attributes.get(s.lower(), default=0) for s in STAT_LIST}
     spent = sum(max(current[s] - base_stats[s], 0) for s in STAT_LIST)
     remaining = STAT_POINTS - spent
 
@@ -138,7 +138,7 @@ def menunode_stat_alloc(caller):
 
 def _adjust_stat(caller, raw_string, stat, change, **kwargs):
     char = caller.ndb.new_char
-    current_val = char.db.get(stat.lower(), 0)
+    current_val = char.attributes.get(stat.lower(), default=0)
     race_mods = next((r["stat_mods"] for r in races.RACE_LIST if r["name"] == char.db.race), {})
     class_mods = next((c["stat_mods"] for c in classes.CLASS_LIST if c["name"] == char.db.charclass), {})
     base_val = race_mods.get(stat, 0) + class_mods.get(stat, 0)
@@ -181,7 +181,7 @@ def menunode_confirm(caller, **kwargs):
     text = f"|wFinal Confirmation|n\n"
     text += f"Race: {char.db.race}\nClass: {char.db.charclass}\nGender: {char.db.gender}\n"
     for s in STAT_LIST:
-        text += f"{s}: {char.db.get(s.lower(), 0)}\n"
+        text += f"{s}: {char.attributes.get(s.lower(), default=0)}\n"
     text += f"Name: {char.key}\nDescription: {char.db.desc}\n\nIs everything correct?"
 
     options = [
@@ -201,7 +201,7 @@ def menunode_finish(caller, **kwargs):
     apply_stats(char)
 
     for stat in STAT_LIST:
-        value = char.db.get(stat.lower(), 0)
+        value = char.attributes.get(stat.lower(), default=0)
         trait = char.traits.get(stat)
         if trait:
             trait.base = value


### PR DESCRIPTION
## Summary
- add unit tests covering chargen menu logic
- use account's attribute storage for stats instead of db

## Testing
- `pytest typeclasses/tests/test_chargen.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68410c054bcc832c89379dc3092e0898