### PR TITLE
Fix stat allocation menu

### DIFF
--- a/typeclasses/tests/test_chargen.py
+++ b/typeclasses/tests/test_chargen.py
@@ -51,3 +51,16 @@ class TestChargen(EvenniaTest):
         self.assertEqual(self.char.db.race, "Human")
         self.assertEqual(self.char.db.charclass, "Warrior")
         self.assertEqual(self.char.db.gender, "male")
+
+    def test_adjust_stat_manual_adds_points(self):
+        chargen_menu._set_race(self.account, "", "Human")
+        chargen_menu._set_class(self.account, "", "Warrior")
+        chargen_menu._set_gender(self.account, "", "male")
+
+        base_str = self.char.attributes.get("str")
+        chargen_menu._adjust_stat_manual(self.account, "STR 5")
+        self.assertEqual(self.char.attributes.get("str"), base_str + 5)
+
+        # Reset should restore base values
+        chargen_menu._reset_stats(self.account)
+        self.assertEqual(self.char.attributes.get("str"), base_str)


### PR DESCRIPTION
## Summary
- interpret manual stat input as amount to add
- remove per-stat removal options and add a reset
- clarify menu prompt and add tests for manual allocation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684115da2ccc832c94705412202a1bd7