### PR TITLE
Ensure characters are puppetable after chargen

### DIFF
--- a/world/chargen_menu.py
+++ b/world/chargen_menu.py
@@ -266,6 +266,15 @@ def menunode_finish(caller, **kwargs):
     # assign the newly created character to this account
     account = getattr(caller, "account", None) or getattr(caller, "dbobj", caller)
     char.account = account
+    char.locks.add(
+        ";".join(
+            [
+                f"puppet:id({char.id}) or pid({account.id}) or perm(Developer) or pperm(Developer)",
+                f"delete:id({account.id}) or perm(Admin)",
+                f"edit:pid({account.id}) or perm(Admin)",
+            ]
+        )
+    )
     account.characters.add(char)
     char.save()
 


### PR DESCRIPTION
## Summary
- give new characters puppet/delete/edit locks once assigned to an account in `menunode_finish`

## Testing
- `pytest -q` *(fails: django.db.utils.OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68411ef6a6cc832c8f09271070dc097d