### PR TITLE
Update chargen to set player tag

### DIFF
--- a/world/chargen_menu.py
+++ b/world/chargen_menu.py
@@ -277,6 +277,8 @@ def menunode_finish(caller, **kwargs):
     )
     account.characters.add(char)
     char.save()
+    char.tags.add("player", category="role")
+    char.save()
 
     account.db._last_puppet = char
     caller.ndb.new_char = None


### PR DESCRIPTION
## Summary
- tag newly created characters as `player`

## Testing
- `evennia migrate`
- `pytest -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6841200b555c832c81e76bb225d1b4d6