### PR TITLE
Remove leftover chargen placeholders

### DIFF
--- a/world/chargen_menu.py
+++ b/world/chargen_menu.py
@@ -29,6 +29,11 @@ def menunode_welcome(caller):
     if not hasattr(caller, "ndb"):
         caller.ndb = {}
 
+    # clean up any unfinished placeholder characters
+    for leftover in caller.characters.filter_family(db_key__iexact="In Progress"):
+        leftover.account = None
+        leftover.delete()
+
     if not caller.ndb.new_char:
         new_char = create_object(PlayerCharacter, key="In Progress", location=None)
         caller.ndb.new_char = new_char


### PR DESCRIPTION
## Summary
- clean up stale `In Progress` character objects before chargen

## Testing
- `evennia test typeclasses.tests` *(fails: settings.DEFAULT_HOME does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_684120ca3610832c9ccf902bbe43e831