### PR TITLE
Fix ASCII characters in class descriptions

### DIFF
--- a/world/scripts/classes.py
+++ b/world/scripts/classes.py
@@ -41,7 +41,7 @@ CLASS_LIST = [
     },
     {
         "name": "Priest",
-        "desc": "Wielder of holy light or shadow—healer, protector, or punisher.",
+        "desc": "Wielder of holy light or shadow--healer, protector, or punisher.",
         "stat_mods": {"WIS": 3, "CON": 1}
     },
     {
@@ -51,7 +51,7 @@ CLASS_LIST = [
     },
     {
         "name": "Druid",
-        "desc": "A wild shape-shifter bonded with nature’s essence.",
+        "desc": "A wild shape-shifter bonded with nature's essence.",
         "stat_mods": {"WIS": 2, "CON": 2}
     },
     {


### PR DESCRIPTION
## Summary
- replace smart quotes in `world/scripts/classes.py` with ASCII equivalents

## Testing
- `python -m compileall -q world/scripts/classes.py`

------
https://chatgpt.com/codex/tasks/task_e_6841235c2334832cb69f310cd1cdb19a