### PR TITLE
Fix chargen menu for sessions

### DIFF
--- a/typeclasses/tests/test_chargen.py
+++ b/typeclasses/tests/test_chargen.py
@@ -64,3 +64,13 @@ class TestChargen(EvenniaTest):
         # Reset should restore base values
         chargen_menu._reset_stats(self.account)
         self.assertEqual(self.char.attributes.get("str"), base_str)
+
+    def test_menu_welcome_accepts_session(self):
+        """menunode_welcome should work when passed a Session."""
+        try:
+            text, options = chargen_menu.menunode_welcome(self.session)
+        except AttributeError as err:
+            self.fail(f"menunode_welcome raised AttributeError: {err}")
+
+        self.assertTrue(text)
+        self.assertTrue(options)

--- a/world/chargen_menu.py
+++ b/world/chargen_menu.py
@@ -20,7 +20,8 @@ STAT_POINTS = 24
 
 def menunode_welcome(caller):
     """Starting point of chargen."""
-    if len(caller.characters.all()) >= settings.MAX_NR_CHARACTERS:
+    account = getattr(caller, "account", caller)
+    if hasattr(account, "characters") and len(account.characters.all()) >= settings.MAX_NR_CHARACTERS:
         text = (
             f"You have reached the maximum allowed characters "
             f"({settings.MAX_NR_CHARACTERS}). Please delete one before creating another."
@@ -30,9 +31,10 @@ def menunode_welcome(caller):
         caller.ndb = {}
 
     # clean up any unfinished placeholder characters
-    for leftover in caller.characters.filter_family(db_key__iexact="In Progress"):
-        leftover.account = None
-        leftover.delete()
+    if hasattr(account, "characters"):
+        for leftover in Character.objects.filter_family(db_account=account, db_key__iexact="In Progress"):
+            leftover.account = None
+            leftover.delete()
 
     if not caller.ndb.new_char:
         new_char = create_object(PlayerCharacter, key="In Progress", location=None)


### PR DESCRIPTION
## Summary
- support `menunode_welcome` when passed a Session
- adjust references to account characters
- add regression test for session caller

## Testing
- `evennia migrate > /tmp/migrate.log && tail -n 20 /tmp/migrate.log`
- `pytest typeclasses/tests/test_chargen.py::TestChargen::test_menu_welcome_accepts_session -q`
- `pytest -q` *(fails: TestInfoCommands.test_finger, TestInfoCommands.test_finger_bounty, TestInfoCommands.test_finger_missing_info, TestInfoCommands.test_finger_self, TestInfoCommands.test_who_hides_account, TestStats.test_secondary_stats_follow_core)*

------
https://chatgpt.com/codex/tasks/task_e_6841256de868832c98818bcb2d4a75a6