### PR TITLE
Add stat manager system

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -98,10 +98,12 @@ class Character(ObjectParent, ClothedCharacter):
 
     def at_object_creation(self):
         from world import stats
+        from world.system import stat_manager
 
         # Apply all default stats in a single modular step. If stats already
         # exist on the character, `apply_stats` will not overwrite them.
         stats.apply_stats(self)
+        stat_manager.refresh_stats(self)
 
         self.db.guild = ""
         self.db.guild_honor = 0

--- a/typeclasses/tests/test_stat_manager.py
+++ b/typeclasses/tests/test_stat_manager.py
@@ -1,0 +1,37 @@
+from evennia.utils.test_resources import EvenniaTest
+from world.system import stat_manager, state_manager
+from world import stats
+
+
+class TestStatManager(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        stats.apply_stats(self.char1)
+
+    def test_refresh_stats_race_class(self):
+        char = self.char1
+        char.db.race = "Elf"
+        char.db.charclass = "Wizard"
+        stat_manager.refresh_stats(char)
+        self.assertEqual(char.traits.DEX.base, 7)
+        self.assertEqual(char.traits.INT.base, 9)
+        self.assertEqual(char.traits.STR.base, 4)
+        self.assertEqual(char.traits.CON.base, 4)
+        self.assertEqual(char.traits.WIS.base, 6)
+
+    def test_effective_stat_with_temp_bonus(self):
+        char = self.char1
+        stat_manager.refresh_stats(char)
+        base = char.traits.STR.value
+        state_manager.add_temp_stat_bonus(char, "STR", 3, 1)
+        self.assertEqual(stat_manager.get_effective_stat(char, "STR"), base + 3)
+
+    def test_display_stat_block(self):
+        char = self.char1
+        stat_manager.refresh_stats(char)
+        text = stat_manager.display_stat_block(char)
+        self.assertIn("╔", text)
+        self.assertIn("╚", text)
+        self.assertIn("STR", text)
+        self.assertIn("HP", text)
+

--- a/world/chargen_menu.py
+++ b/world/chargen_menu.py
@@ -270,6 +270,9 @@ def menunode_finish(caller, **kwargs):
         # remove the temporary value stored on the attribute handler
         char.attributes.remove(stat.lower())
 
+    from world.system import stat_manager
+    stat_manager.refresh_stats(char)
+
     # assign the newly created character to this account
     account = getattr(caller, "account", None) or getattr(caller, "dbobj", caller)
     char.account = account

--- a/world/system/__init__.py
+++ b/world/system/__init__.py
@@ -1,0 +1,6 @@
+"""Utility imports for world.system package."""
+
+from . import state_manager
+from . import stat_manager
+
+__all__ = ["state_manager", "stat_manager"]

--- a/world/system/stat_manager.py
+++ b/world/system/stat_manager.py
@@ -1,0 +1,182 @@
+# Stat manager for centralizing stat calculations and display
+
+from __future__ import annotations
+
+from typing import Dict
+import re
+
+from world import stats
+from world.system import state_manager
+from world.scripts import races, classes
+
+# Primary and secondary stat keys
+PRIMARY_STATS = stats.CORE_STAT_KEYS
+SECONDARY_STATS = ["HP", "MP", "SP", "ATK", "DEF", "ACC", "EVA"]
+
+# Mapping of derived stat keys to weighted primary stats
+STAT_SCALING: Dict[str, Dict[str, float]] = {
+    "HP": {"CON": 10, "STR": 2},
+    "MP": {"INT": 10, "WIS": 5},
+    "SP": {"CON": 5, "DEX": 5},
+    "ATK": {"STR": 2, "DEX": 1},
+    "DEF": {"CON": 2},
+    "ACC": {"DEX": 1, "LUCK": 0.5},
+    "EVA": {"DEX": 1, "LUCK": 0.5},
+}
+
+
+# -------------------------------------------------------------
+# Bonus collection helpers (stubs for future expansion)
+# -------------------------------------------------------------
+
+def _race_mods(obj) -> Dict[str, int]:
+    """Return stat modifiers from the character's race."""
+    race = getattr(obj.db, "race", None)
+    if not race:
+        return {}
+    for entry in races.RACE_LIST:
+        if entry["name"].lower() == str(race).lower():
+            return entry.get("stat_mods", {})
+    return {}
+
+
+def _class_mods(obj) -> Dict[str, int]:
+    """Return stat modifiers from the character's class."""
+    cls = getattr(obj.db, "charclass", None)
+    if not cls:
+        return {}
+    for entry in classes.CLASS_LIST:
+        if entry["name"].lower() == str(cls).lower():
+            return entry.get("stat_mods", {})
+    return {}
+
+
+def _gear_mods(obj) -> Dict[str, int]:  # pragma: no cover - placeholder
+    """Placeholder for gear bonus lookup."""
+    return {}
+
+
+def _buff_mods(obj) -> Dict[str, int]:  # pragma: no cover - placeholder
+    """Placeholder for buff/debuff bonus lookup."""
+    return {}
+
+
+# -------------------------------------------------------------
+# Core API
+# -------------------------------------------------------------
+
+def refresh_stats(obj) -> None:
+    """Recalculate and cache all stats for ``obj``."""
+
+    # ensure baseline traits exist
+    stats.apply_stats(obj)
+
+    race_bonus = _race_mods(obj)
+    class_bonus = _class_mods(obj)
+    gear_bonus = _gear_mods(obj)
+    buff_bonus = _buff_mods(obj)
+
+    primary_totals: Dict[str, int] = {}
+    for key in PRIMARY_STATS:
+        base = obj.traits.get(key).base if obj.traits.get(key) else 0
+        total = base
+        total += race_bonus.get(key, 0)
+        total += class_bonus.get(key, 0)
+        total += gear_bonus.get(key, 0)
+        total += buff_bonus.get(key, 0)
+        if obj.traits.get(key):
+            obj.traits.get(key).base = total
+        else:
+            obj.traits.add(key, key, base=total)
+        primary_totals[key] = total
+
+    derived: Dict[str, int] = {}
+    for dkey, mapping in STAT_SCALING.items():
+        value = 0
+        for pkey, weight in mapping.items():
+            value += primary_totals.get(pkey, 0) * weight
+        derived[dkey] = int(round(value))
+
+    obj.db.derived_stats = derived
+    obj.db.primary_stats = primary_totals
+
+    # update resource traits
+    if (hp := obj.traits.get("health")):
+        hp.base = derived.get("HP", hp.base)
+        if hp.current > hp.max:
+            hp.current = hp.max
+    if (mp := obj.traits.get("mana")):
+        mp.base = derived.get("MP", mp.base)
+        if mp.current > mp.max:
+            mp.current = mp.max
+    if (sp := obj.traits.get("stamina")):
+        sp.base = derived.get("SP", sp.base)
+        if sp.current > sp.max:
+            sp.current = sp.max
+
+    # update or add other derived traits
+    for key, val in derived.items():
+        if key in ("HP", "MP", "SP"):
+            continue
+        trait = obj.traits.get(key)
+        if trait:
+            trait.base = val
+        else:
+            obj.traits.add(key, key, base=val)
+
+
+def get_effective_stat(obj, key: str) -> int:
+    """Return ``key`` value including temporary bonuses."""
+    base = 0
+    if (trait := obj.traits.get(key)):
+        base = trait.value
+    base += obj.db.get(f"{key}_bonus", 0)
+    base += state_manager.get_temp_bonus(obj, key)
+    return int(base)
+
+
+def get_secondary_stat(obj, key: str) -> int:
+    """Return cached secondary stat value."""
+    data = obj.db.derived_stats or {}
+    return int(data.get(key, 0))
+
+
+# -------------------------------------------------------------
+# Display helpers
+# -------------------------------------------------------------
+_color_strip_re = re.compile(r"\|.")
+
+
+def _strip(text: str) -> str:
+    return _color_strip_re.sub("", text)
+
+
+def _pad(text: str, width: int) -> str:
+    return text + " " * (width - len(_strip(text)))
+
+
+def display_stat_block(obj) -> str:
+    """Return a formatted stat block for ``obj``."""
+
+    refresh_stats(obj)
+
+    lines = []
+    primaries = "  ".join(
+        f"{key}: |w{get_effective_stat(obj, key)}|n" for key in PRIMARY_STATS
+    )
+    lines.append(primaries)
+
+    secondaries = "  ".join(
+        f"{key}: |w{get_secondary_stat(obj, key)}|n" for key in SECONDARY_STATS
+    )
+    lines.append(secondaries)
+
+    width = max(len(_strip(l)) for l in lines)
+    top = "╔" + "═" * (width + 2) + "╗"
+    bottom = "╚" + "═" * (width + 2) + "╝"
+    out = [top]
+    for line in lines:
+        out.append("║ " + _pad(line, width) + " ║")
+    out.append(bottom)
+    return "\n".join(out)
+


### PR DESCRIPTION
## Summary
- implement `world/system/stat_manager.py` to compute stats and provide helpers
- expose new stat system via `world.system` package
- auto refresh stats after character creation and chargen finalize
- add tests for stat manager

## Testing
- `evennia migrate`
- `pytest -q` *(fails: OperationalError `no such table: accounts_accountdb`)*

------
https://chatgpt.com/codex/tasks/task_e_68412dc4e2f4832cb44feeddace4485b