### PR TITLE
Dynamic stat refresh hooks

### DIFF
--- a/commands/skills.py
+++ b/commands/skills.py
@@ -156,6 +156,8 @@ class CmdTrainSkill(Command):
         caller.db.exp -= exp_cost
         skill.base += levels
         self.msg(f"You practice your {to_train} and improve it to level {skill.base}.")
+        from world.system import stat_manager
+        stat_manager.refresh_stats(caller)
 
 
 class TrainCmdSet(CmdSet):

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -108,6 +108,11 @@ class Character(ObjectParent, ClothedCharacter):
         self.db.guild = ""
         self.db.guild_honor = 0
 
+    def at_post_puppet(self, **kwargs):
+        """Ensure stats refresh when a character is controlled."""
+        from world.system import stat_manager
+        stat_manager.refresh_stats(self)
+        
     def at_pre_move(self, destination, **kwargs):
         """
         Called by self.move_to when trying to move somewhere. If this returns
@@ -256,6 +261,8 @@ class Character(ObjectParent, ClothedCharacter):
 
         # update the character with the new wielded info
         self.db._wielded = wielded
+        from world.system import stat_manager
+        stat_manager.refresh_stats(self)
         # return the list of hands that are now holding the weapon
         return hands
 
@@ -284,6 +291,8 @@ class Character(ObjectParent, ClothedCharacter):
 
         # update the character with the new wielded info
         self.db._wielded = wielded
+        from world.system import stat_manager
+        stat_manager.refresh_stats(self)
         # return the list of hands that are no longer holding the weapon
         return freed
 
@@ -310,6 +319,9 @@ class Character(ObjectParent, ClothedCharacter):
         """
         Returns a quick view of the current status of this character
         """
+
+        from world.system import stat_manager
+        stat_manager.refresh_stats(self)
 
         chunks = []
         # prefix the status string with the character's name, if it's someone else checking

--- a/utils/stats_utils.py
+++ b/utils/stats_utils.py
@@ -11,6 +11,7 @@ from world.stats import (
     sum_bonus,
     apply_stats,
 )
+from world.system import stat_manager
 from utils.currency import from_copper
 import math
 import re
@@ -95,7 +96,7 @@ def _db_get(obj, key, default=None):
 def get_display_scroll(chara):
     """Return a formatted character sheet for ``chara``."""
 
-    apply_stats(chara)
+    stat_manager.refresh_stats(chara)
 
     lines = []
 

--- a/world/stats.py
+++ b/world/stats.py
@@ -44,6 +44,7 @@ DEFENSE_STATS: List[Stat] = [
     Stat("status_resist", "Status Resist", stat="CON"),
     Stat("crit_resist", "Critical Resist", stat="CON"),
 ]
+# TODO: implement usage of status_resist and crit_resist in combat rolls
 
 # Offense-oriented stats
 OFFENSE_STATS: List[Stat] = [

--- a/world/system/state_manager.py
+++ b/world/system/state_manager.py
@@ -2,6 +2,7 @@
 
 from typing import Dict, List
 from world import stats
+from world.system import stat_manager
 
 
 def _get_bonus_dict(chara) -> Dict[str, List[dict]]:
@@ -25,6 +26,7 @@ def add_temp_stat_bonus(chara, stat: str, amount: int, duration: int):
     bonuses = _get_bonus_dict(chara)
     bonuses.setdefault(stat, []).append({"amount": amount, "duration": duration})
     _save_bonus_dict(chara, bonuses)
+    stat_manager.refresh_stats(chara)
 
 
 def remove_temp_stat_bonus(chara, stat: str):
@@ -33,6 +35,7 @@ def remove_temp_stat_bonus(chara, stat: str):
     if stat in bonuses:
         del bonuses[stat]
         _save_bonus_dict(chara, bonuses)
+        stat_manager.refresh_stats(chara)
 
 
 def add_status_effect(chara, status: str, duration: int):
@@ -96,16 +99,21 @@ def tick_character(chara):
             changed = True
     if changed:
         _save_bonus_dict(chara, bonuses)
+        stat_manager.refresh_stats(chara)
 
     statuses = _get_status_dict(chara)
+    status_changed = False
     for status, dur in list(statuses.items()):
         dur -= 1
         if dur <= 0:
             del statuses[status]
             chara.tags.remove(status, category="status")
+            status_changed = True
         else:
             statuses[status] = dur
-    _save_status_dict(chara, statuses)
+    if status_changed:
+        _save_status_dict(chara, statuses)
+        stat_manager.refresh_stats(chara)
 
 
 def tick_all():


### PR DESCRIPTION
## Summary
- hook `refresh_stats` after puppeting and when wielding/unwielding weapons
- call `refresh_stats` from training and score helper
- update temporary-stat functions to refresh
- refresh stats when displaying status
- note unimplemented status-resist usage

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68413017672c832c8d13955b70973d21