### PR TITLE
Add command prompt refresh hook

### DIFF
--- a/commands/account.py
+++ b/commands/account.py
@@ -1,8 +1,6 @@
 from evennia import CmdSet
-from evennia.commands.default.muxcommand import MuxCommand
 from evennia.utils.evtable import EvTable
-
-from .command import Command
+from .command import MuxCommand
 
 
 class CmdSettings(MuxCommand):

--- a/commands/command.py
+++ b/commands/command.py
@@ -26,6 +26,12 @@ class Command(BaseCommand):
             session = to_obj.sessions.get() if to_obj != self.caller else self.session
         to_obj.msg(text, from_obj=from_obj, session=session, **kwargs)
 
+    def at_post_cmd(self):
+        """Hook called after command execution."""
+        super().at_post_cmd()
+        if hasattr(self.caller, "refresh_prompt"):
+            self.caller.refresh_prompt()
+
     # Each Command class implements the following methods, called in this order
     # (only func() is actually required):
     #
@@ -36,6 +42,15 @@ class Command(BaseCommand):
     #     - at_post_cmd(): Extra actions, often things done after
     #         every command, like prompts.
     #
+    pass
+
+
+from evennia.commands.default.muxcommand import MuxCommand as BaseMuxCommand
+
+
+class MuxCommand(Command, BaseMuxCommand):
+    """Project MUX command ensuring prompts refresh after execution."""
+
     pass
 
 

--- a/commands/who.py
+++ b/commands/who.py
@@ -1,8 +1,9 @@
-from evennia.commands.default.muxcommand import MuxCommand
 from evennia.server.sessionhandler import SESSIONS
 from evennia.utils.evtable import EvTable
 from evennia.utils.utils import time_format
 import time
+
+from .command import MuxCommand
 
 
 class CmdWho(MuxCommand):

--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -179,3 +179,13 @@ class TestBountyLarge(EvenniaTest):
         self.char2.at_damage(self.char1, 200)
         self.assertEqual(to_copper(self.char1.db.coins), 40)
         self.assertEqual(self.char2.db.bounty, 0)
+
+
+class TestCommandPrompt(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.char1.refresh_prompt = MagicMock()
+
+    def test_command_refreshes_prompt(self):
+        self.char1.execute_cmd("score")
+        self.char1.refresh_prompt.assert_called_once()


### PR DESCRIPTION
## Summary
- refresh prompt for caller after each command
- use project MuxCommand class in account and who commands
- test that commands trigger prompt refresh

## Testing
- `evennia migrate`
- `pytest -q` *(fails: settings.DEFAULT_HOME doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_684137d92e8c832cac36218409a72b6d