### PR TITLE
Add tests for command prompt and room appearance

### DIFF
--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -189,3 +189,20 @@ class TestCommandPrompt(EvenniaTest):
     def test_command_refreshes_prompt(self):
         self.char1.execute_cmd("score")
         self.char1.refresh_prompt.assert_called_once()
+
+    def test_look_refreshes_prompt(self):
+        self.char1.execute_cmd("look")
+        self.char1.refresh_prompt.assert_called_once()
+
+
+class TestReturnAppearance(EvenniaTest):
+    def test_room_return_appearance_format(self):
+        self.room1.appearance_template = (
+            "╔{name}\n{desc}\n{exits}\n{characters}\n{things}\n╚"
+        )
+        output = self.room1.return_appearance(self.char1)
+        self.assertIn("╔", output)
+        self.assertIn("╚", output)
+        self.assertIn("|wExits:|n", output)
+        self.assertIn("|wCharacters:|n", output)
+        self.assertIn("|wYou see:|n", output)


### PR DESCRIPTION
## Summary
- ensure simple commands trigger prompt refresh
- verify room appearance includes borders and grouped sections

## Testing
- `evennia migrate`
- `evennia start` (to initialize database)
- `evennia stop`
- `pytest -q` *(fails: 15 failed, 31 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68413d01daac832cb821b834a8be75f6