### PR TITLE
Add boxed room display and movement auto-look

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -134,9 +134,11 @@ class Character(ObjectParent, ClothedCharacter):
 
     def at_post_move(self, source_location, **kwargs):
         """
-        optional post-move auto prompt
+        Send the room's appearance after moving and optional auto prompt.
         """
         super().at_post_move(source_location, **kwargs)
+        if self.location:
+            self.msg(self.location.return_appearance(self))
         # check if we have auto-prompt in settings
         if self.account and (settings := self.account.db.settings):
             if settings.get("auto prompt"):

--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -67,6 +67,14 @@ class RoomParent(ObjectParent):
         else:
             return ""
 
+    def return_appearance(self, looker, **kwargs):
+        """Return a formatted display of this room."""
+        from utils.room_display import get_room_display
+
+        if not looker:
+            return ""
+        return get_room_display(self, looker)
+
 
 class Room(RoomParent, DefaultRoom):
     """

--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -197,12 +197,25 @@ class TestCommandPrompt(EvenniaTest):
 
 class TestReturnAppearance(EvenniaTest):
     def test_room_return_appearance_format(self):
-        self.room1.appearance_template = (
-            "╔{name}\n{desc}\n{exits}\n{characters}\n{things}\n╚"
-        )
         output = self.room1.return_appearance(self.char1)
         self.assertIn("╔", output)
         self.assertIn("╚", output)
-        self.assertIn("|wExits:|n", output)
-        self.assertIn("|wCharacters:|n", output)
-        self.assertIn("|wYou see:|n", output)
+        self.assertIn("|wPlayers:|n", output)
+        self.assertIn("|wItems:|n", output)
+
+
+class TestRoomDisplay(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.char1.msg = MagicMock()
+
+    def test_look_uses_box_layout(self):
+        self.char1.execute_cmd("look")
+        out = self.char1.msg.call_args[0][0]
+        self.assertIn("╔", out)
+        self.assertIn("|wPlayers:|n", out)
+
+    def test_movement_sends_box_layout(self):
+        self.char1.execute_cmd("out")
+        calls = [c.args[0] for c in self.char1.msg.call_args_list if c.args]
+        self.assertTrue(any("╔" in c for c in calls))

--- a/utils/room_display.py
+++ b/utils/room_display.py
@@ -1,0 +1,87 @@
+import re
+from evennia.utils import iter_to_str
+
+_color_strip_re = re.compile(r"\|.")
+
+
+def _strip(text: str) -> str:
+    """Remove simple Evennia color codes for width calculations."""
+    return _color_strip_re.sub("", text)
+
+
+def _pad(text: str, width: int) -> str:
+    """Pad ``text`` with spaces to ``width`` accounting for color codes."""
+    return text + " " * (width - len(_strip(text)))
+
+
+INTERACTIVE_CMDSETS = {"Gather CmdSet", "Interact CmdSet"}
+
+
+def _is_interactive(obj) -> bool:
+    """Return True if ``obj`` should be displayed as an interactive object."""
+    try:
+        for key in INTERACTIVE_CMDSETS:
+            if obj.cmdset.has_cmdset(key, must_be_default=True):
+                return True
+    except Exception:
+        pass
+    return hasattr(obj, "at_gather")
+
+
+def get_room_display(room, looker) -> str:
+    """Return a boxed display of ``room`` as seen by ``looker``."""
+
+    lines = []
+
+    if header := room.get_display_header(looker):
+        lines.append(header)
+
+    lines.append(room.get_display_name(looker))
+
+    if desc := room.get_display_desc(looker):
+        lines.append(desc)
+
+    if exits := room.get_display_exits(looker):
+        lines.append(exits)
+
+    players = []
+    npcs = []
+    items = []
+    interactive = []
+
+    for char in room.filter_visible(room.contents_get(content_type="character"), looker):
+        name = char.get_display_name(looker)
+        if char.account:
+            players.append(name)
+        else:
+            npcs.append(name)
+
+    for obj in room.filter_visible(room.contents_get(content_type="object"), looker):
+        name = obj.get_display_name(looker)
+        if _is_interactive(obj):
+            interactive.append(name)
+        else:
+            items.append(name)
+
+    if players:
+        lines.append(f"|wPlayers:|n {iter_to_str(players)}")
+    if npcs:
+        lines.append(f"|wNPCs:|n {iter_to_str(npcs)}")
+    if items:
+        lines.append(f"|wItems:|n {iter_to_str(items)}")
+    if interactive:
+        lines.append(f"|wInteractive:|n {iter_to_str(interactive)}")
+
+    if footer := room.get_display_footer(looker):
+        lines.append(footer)
+
+    width = max(len(_strip(l)) for l in lines) if lines else 0
+    top = "╔" + "═" * (width + 2) + "╗"
+    bottom = "╚" + "═" * (width + 2) + "╝"
+
+    out = [top]
+    for line in lines:
+        out.append("║ " + _pad(line, width) + " ║")
+    out.append(bottom)
+
+    return "\n".join(out)


### PR DESCRIPTION
## Summary
- create `utils.room_display.get_room_display` to show a boxed view of rooms
- override `RoomParent.return_appearance` to use the new display
- show the room display after moving in `Character.at_post_move`
- test that looking and moving both include the boxed layout

## Testing
- `evennia migrate`
- `pytest -q` *(fails: settings.DEFAULT_HOME does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68414166b930832ca0834fba363ca1d0