### PR TITLE
Implement carry weight and prompt customization

### DIFF
--- a/commands/info.py
+++ b/commands/info.py
@@ -141,6 +141,14 @@ class CmdInventory(Command):
         for obj in items:
             table.add_row(obj.get_display_name(caller))
         caller.msg(str(table))
+        caller.update_carry_weight()
+        weight = caller.db.carry_weight or 0
+        capacity = caller.db.carry_capacity or 0
+        enc = caller.encumbrance_level()
+        line = f"Carry Weight: {weight} / {capacity}"
+        if enc:
+            line += f"  {enc}"
+        caller.msg(line)
 
 
 class CmdEquipment(Command):
@@ -199,6 +207,24 @@ class CmdTitle(Command):
             self.msg("Title updated.")
 
 
+class CmdPrompt(Command):
+    """View or set your command prompt."""
+
+    key = "prompt"
+    help_category = "general"
+
+    def func(self):
+        caller = self.caller
+        if not self.args:
+            current = caller.db.prompt_format or caller.get_resource_prompt()
+            caller.msg(f"Current prompt: {current}")
+            caller.msg("Set a new prompt with |wprompt <format>|n.")
+            return
+        caller.db.prompt_format = self.args.strip()
+        caller.msg("Prompt updated.")
+        caller.refresh_prompt()
+
+
 class InfoCmdSet(CmdSet):
     key = "Info CmdSet"
 
@@ -212,3 +238,4 @@ class InfoCmdSet(CmdSet):
         self.add(CmdEquipment)
         self.add(CmdBuffs)
         self.add(CmdTitle)
+        self.add(CmdPrompt)

--- a/server/conf/settings.py
+++ b/server/conf/settings.py
@@ -35,8 +35,8 @@ BASE_CHARACTER_TYPECLASS = "typeclasses.characters.PlayerCharacter"
 # Enable command abbreviation matching
 CMD_IGNORE_INVALID_ABBREVIATIONS = False
 
-# Use the Evennia MuxCommand as the default command base
-COMMAND_DEFAULT_CLASS = "evennia.commands.default.muxcommand.MuxCommand"
+# Use the project MuxCommand so prompts refresh after every command
+COMMAND_DEFAULT_CLASS = "commands.command.MuxCommand"
 
 ######################################################################
 # Config for contrib packages

--- a/typeclasses/objects.py
+++ b/typeclasses/objects.py
@@ -172,10 +172,16 @@ class Object(ObjectParent, DefaultObject):
      at_get(getter)            - called after object has been picked up.
                                  Does not stop pickup.
      at_drop(dropper)          - called when this object has been dropped.
-     at_say(speaker, message)  - by default, called if an object inside this
+    at_say(speaker, message)  - by default, called if an object inside this
                                  object speaks
 
     """
+
+    def at_object_creation(self):
+        """Set default attributes when object is first created."""
+        super().at_object_creation()
+        if self.db.weight is None:
+            self.db.weight = 1
 
     def at_drop(self, dropper, **kwargs):
         """
@@ -199,6 +205,7 @@ class GatherNode(Object):
         """
         Do some initial set-up
         """
+        super().at_object_creation()
         self.locks.add("get:false()")
         self.cmdset.add_default(GatherCmdSet)
 

--- a/utils/stats_utils.py
+++ b/utils/stats_utils.py
@@ -135,6 +135,14 @@ def get_display_scroll(chara):
         f"Copper: {copper}  Silver: {silver}  Gold: {gold}  Platinum: {platinum}"
     )
 
+    weight = chara.db.carry_weight or 0
+    capacity = chara.db.carry_capacity or 0
+    enc = chara.encumbrance_level() if hasattr(chara, "encumbrance_level") else ""
+    cw_line = f"Carry Weight: {weight} / {capacity}"
+    if enc:
+        cw_line += f"  {enc}"
+    lines.append(cw_line)
+
     guild = _db_get(chara, "guild", "")
     if guild:
         lines.append(f"Guild: {guild} ({chara.guild_rank})")

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -64,4 +64,26 @@ HELP_ENTRY_DICTS = [
 
         """,
     },
+    {
+        "key": "prompt",
+        "category": "General",
+        "text": """
+            Customize the information shown in your command prompt.
+
+            Use |wprompt|n to view your current prompt string.
+            Use |wprompt <format>|n to set a new one. The string may use the
+            following fields:
+
+            {hp}, {hpmax} - current and max health
+            {mp}, {mpmax} - current and max mana
+            {sp}, {spmax} - current and max stamina
+            {level}, {xp} - your level and experience points
+            {copper}, {silver}, {gold}, {platinum} - coins carried
+            {carry}, {capacity} - carry weight and capacity
+            {enc} - encumbrance level
+
+            Example:
+                |wprompt [HP:{hp}/{hpmax}] [SP:{sp}/{spmax}] {enc}>|n
+        """,
+    },
 ]

--- a/world/system/stat_manager.py
+++ b/world/system/stat_manager.py
@@ -165,6 +165,9 @@ def refresh_stats(obj) -> None:
         else:
             obj.traits.add(key, key, base=val)
 
+    if obj.traits.get("STR"):
+        obj.db.carry_capacity = get_effective_stat(obj, "STR") * 20
+
 
 def get_effective_stat(obj, key: str) -> int:
     """Return ``key`` value including temporary bonuses."""


### PR DESCRIPTION
## Summary
- change default command base to use project MuxCommand for prompts
- add default item weight and gather node fix
- compute carry capacity from Strength stat
- track carry weight and apply movement penalties
- customize inventory readout with weight
- allow players to set prompt format
- document prompt usage

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68414612f190832c9dcd131bcd6f1f6f