### PR TITLE
Fix stat bonus retrieval

### DIFF
--- a/world/stats.py
+++ b/world/stats.py
@@ -133,16 +133,26 @@ def sum_bonus(obj, stat_key: str) -> int:
     # allow bonuses stored directly on the character
     if hasattr(obj, "attributes"):
         total += obj.attributes.get(f"{stat_key}_bonus", default=0)
-    elif hasattr(obj, "db") and hasattr(obj.db, "get"):
-        total += obj.db.get(f"{stat_key}_bonus", 0)
+    else:
+        get_bonus = getattr(getattr(obj, "db", None), "get", None)
+        if callable(get_bonus):
+            try:
+                total += get_bonus(f"{stat_key}_bonus", 0)
+            except Exception:
+                pass
     try:
         from evennia.contrib.game_systems.clothing.clothing import get_worn_clothes
 
         for item in get_worn_clothes(obj):
             if hasattr(item, "attributes"):
                 total += item.attributes.get(f"{stat_key}_bonus", default=0)
-            elif hasattr(item, "db") and hasattr(item.db, "get"):
-                total += item.db.get(f"{stat_key}_bonus", 0)
+            else:
+                item_get = getattr(getattr(item, "db", None), "get", None)
+                if callable(item_get):
+                    try:
+                        total += item_get(f"{stat_key}_bonus", 0)
+                    except Exception:
+                        pass
     except Exception:  # pragma: no cover - clothing contrib may not be loaded
         pass
     return total

--- a/world/system/stat_manager.py
+++ b/world/system/stat_manager.py
@@ -174,7 +174,14 @@ def get_effective_stat(obj, key: str) -> int:
     base = 0
     if trait := obj.traits.get(key):
         base = trait.value
-    base += obj.db.get(f"{key}_bonus", 0)
+    bonus_get = getattr(getattr(obj, "db", None), "get", None)
+    if callable(bonus_get):
+        try:
+            base += bonus_get(f"{key}_bonus", 0)
+        except Exception:
+            pass
+    elif hasattr(obj, "attributes"):
+        base += obj.attributes.get(f"{key}_bonus", default=0)
     base += state_manager.get_temp_bonus(obj, key)
     return int(base)
 


### PR DESCRIPTION
## Summary
- fix safe retrieval of stat bonuses

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6841495092d4832ca191b1b4f7328b0e