### PR TITLE
Fix stat refresh stacking bonuses

### DIFF
--- a/world/chargen_menu.py
+++ b/world/chargen_menu.py
@@ -270,6 +270,12 @@ def menunode_finish(caller, **kwargs):
         # remove the temporary value stored on the attribute handler
         char.attributes.remove(stat.lower())
 
+    # cache the finalized core stats so future refreshes won't
+    # repeatedly reapply static bonuses
+    char.db.base_primary_stats = {
+        stat: char.traits.get(stat).base for stat in STAT_LIST
+    }
+
     from world.system import stat_manager
     stat_manager.refresh_stats(char)
 


### PR DESCRIPTION
## Summary
- store core stats once when finishing character creation
- stop re-applying static race/class bonuses each prompt refresh

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'evennia')*

------
https://chatgpt.com/codex/tasks/task_e_68414b6d453c832c851a95cce6eac927