### PR TITLE
Fix stat refresh handling of missing base stats

### DIFF
--- a/typeclasses/tests/test_stat_manager.py
+++ b/typeclasses/tests/test_stat_manager.py
@@ -53,3 +53,11 @@ class TestStatManager(EvenniaTest):
         char.traits.DEX.base += 2
         stat_manager.refresh_stats(char)
         self.assertGreater(char.db.derived_stats.get("stealth"), base_stealth)
+
+    def test_refresh_stats_handles_missing_base_stats(self):
+        char = self.char1
+        char.db.base_primary_stats = None
+        stat_manager.refresh_stats(char)
+        self.assertIsInstance(char.db.base_primary_stats, dict)
+        for key in stats.CORE_STAT_KEYS:
+            self.assertIn(key, char.db.base_primary_stats)

--- a/world/system/stat_manager.py
+++ b/world/system/stat_manager.py
@@ -114,7 +114,9 @@ def refresh_stats(obj) -> None:
 
     # cache base stat values on first run so repeated refreshes don't
     # continue stacking static bonuses like race or class modifiers
-    if not hasattr(obj.db, "base_primary_stats"):
+    if not hasattr(obj.db, "base_primary_stats") or not isinstance(
+        obj.db.base_primary_stats, dict
+    ):
         obj.db.base_primary_stats = {
             key: (obj.traits.get(key).base if obj.traits.get(key) else 0)
             for key in PRIMARY_STATS


### PR DESCRIPTION
## Summary
- guard against `base_primary_stats` being `None` in `refresh_stats`
- test `refresh_stats` initialization when base stats are missing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68414cfb476c832caf498cc2871266bf