### PR TITLE
Add rest/sleep/wake actions

### DIFF
--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -30,6 +30,7 @@ from commands.account import AccountOptsCmdSet
 from commands.shops import CmdMoney
 from commands.info import InfoCmdSet
 from commands.guilds import GuildCmdSet
+from commands.rest import RestCmdSet
 from commands.who import CmdWho
 
 
@@ -59,6 +60,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(SkillCmdSet)
         self.add(InteractCmdSet)
         self.add(InfoCmdSet)
+        self.add(RestCmdSet)
         self.add(GuildCmdSet)
 
 

--- a/commands/rest.py
+++ b/commands/rest.py
@@ -1,0 +1,81 @@
+from evennia import CmdSet
+from evennia.commands.default.general import CmdLook as DefaultCmdLook
+
+from .command import Command
+
+
+class CmdRest(Command):
+    """Sit down and rest."""
+
+    key = "rest"
+    aliases = ("relax",)
+    help_category = "general"
+
+    def func(self):
+        caller = self.caller
+        if caller.tags.has("sitting", category="status"):
+            caller.msg("You are already resting.")
+            return
+        caller.tags.remove("sleeping", category="status")
+        caller.tags.remove("lying down", category="status")
+        caller.tags.add("sitting", category="status")
+        caller.at_emote("$conj(sits) down to rest.")
+
+
+class CmdSleep(Command):
+    """Lie down and go to sleep."""
+
+    key = "sleep"
+    help_category = "general"
+
+    def func(self):
+        caller = self.caller
+        if caller.tags.has("sleeping", category="status"):
+            caller.msg("You are already sleeping.")
+            return
+        caller.tags.remove("sitting", category="status")
+        caller.tags.add("lying down", category="status")
+        caller.tags.add("sleeping", category="status")
+        caller.at_emote("$conj(closes) $pron(your) eyes and drifts to sleep.")
+
+
+class CmdWake(Command):
+    """Stand up and wake from rest or sleep."""
+
+    key = "wake"
+    aliases = ("stand",)
+    help_category = "general"
+
+    def func(self):
+        caller = self.caller
+        if not any(
+            caller.tags.has(tag, category="status")
+            for tag in ("sleeping", "lying down", "sitting")
+        ):
+            caller.msg("You are already standing.")
+            return
+        caller.tags.remove("sleeping", category="status")
+        caller.tags.remove("lying down", category="status")
+        caller.tags.remove("sitting", category="status")
+        caller.at_emote("$conj(stands) up.")
+
+
+class CmdLook(DefaultCmdLook):
+    """Look around, unless you are sleeping."""
+
+    def func(self):
+        if self.caller.tags.has("sleeping", category="status"):
+            self.caller.msg("You can't see anything with your eyes closed.")
+            return
+        super().func()
+
+
+class RestCmdSet(CmdSet):
+    key = "Rest CmdSet"
+
+    def at_cmdset_creation(self):
+        super().at_cmdset_creation()
+        self.add(CmdRest)
+        self.add(CmdSleep)
+        self.add(CmdWake)
+        self.add(CmdLook)

--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -206,3 +206,32 @@ class TestReturnAppearance(EvenniaTest):
         self.assertIn("|wExits:|n", output)
         self.assertIn("|wCharacters:|n", output)
         self.assertIn("|wYou see:|n", output)
+
+
+class TestRestCommands(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.char1.msg = MagicMock()
+
+    def test_rest_adds_status(self):
+        self.char1.execute_cmd("rest")
+        self.assertTrue(self.char1.tags.has("sitting", category="status"))
+
+    def test_sleep_adds_statuses(self):
+        self.char1.execute_cmd("sleep")
+        self.assertTrue(self.char1.tags.has("sleeping", category="status"))
+        self.assertTrue(self.char1.tags.has("lying down", category="status"))
+
+    def test_wake_removes_statuses(self):
+        self.char1.tags.add("sleeping", category="status")
+        self.char1.tags.add("lying down", category="status")
+        self.char1.tags.add("sitting", category="status")
+        self.char1.execute_cmd("wake")
+        self.assertFalse(self.char1.tags.has("sleeping", category="status"))
+        self.assertFalse(self.char1.tags.has("lying down", category="status"))
+        self.assertFalse(self.char1.tags.has("sitting", category="status"))
+
+    def test_look_while_sleeping(self):
+        self.char1.tags.add("sleeping", category="status")
+        self.char1.execute_cmd("look")
+        self.char1.msg.assert_any_call("You can't see anything with your eyes closed.")


### PR DESCRIPTION
## Summary
- allow players to rest, sleep, or wake/stand
- block `look` while sleeping
- test that resting states modify status

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684154934e7c832c8ff353bb01d13168