### PR TITLE
Switch stats displays to ASCII borders

### DIFF
--- a/commands/info.py
+++ b/commands/info.py
@@ -78,9 +78,9 @@ class CmdFinger(Command):
             lines.append("No bounty.")
 
         width = max(len(_strip_colors(l)) for l in lines)
-        top = "╔" + "═" * (width + 2) + "╗"
-        bottom = "╚" + "═" * (width + 2) + "╝"
-        boxed = [top] + [f"║ " + _pad(l, width) + " ║" for l in lines] + [bottom]
+        top = "+" + "=" * (width + 2) + "+"
+        bottom = "+" + "=" * (width + 2) + "+"
+        boxed = [top] + [f"| " + _pad(l, width) + " |" for l in lines] + [bottom]
         self.msg("\n".join(boxed))
 
 

--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -30,8 +30,8 @@ class TestInfoCommands(EvenniaTest):
         self.char1.execute_cmd(f"finger {self.char2.key}")
         self.assertTrue(self.char1.msg.called)
         output = self.char1.msg.call_args[0][0]
-        self.assertIn("╔", output)
-        self.assertIn("╚", output)
+        self.assertIn("+", output)
+        self.assertIn("=", output)
         self.assertIn("Another tester.", output)
         self.assertIn("Race: Human", output)
         self.assertIn("Class: Warrior", output)
@@ -41,7 +41,7 @@ class TestInfoCommands(EvenniaTest):
         self.char1.execute_cmd("finger self")
         self.assertTrue(self.char1.msg.called)
         output = self.char1.msg.call_args[0][0]
-        self.assertIn("╔", output)
+        self.assertIn("+", output)
         self.assertIn("Race: Elf", output)
         self.assertIn("Class: Mage", output)
 
@@ -82,8 +82,8 @@ class TestInfoCommands(EvenniaTest):
         self.assertIn("Copper: 10", args)
         self.assertIn("Armor", args)
         self.assertIn("Attack Power", args)
-        self.assertIn("╔", args)
-        self.assertIn("╚", args)
+        self.assertIn("+", args)
+        self.assertIn("=", args)
         self.assertIn("|g", args)
         self.assertIn("|w", args)
         self.assertIn("|c", args)
@@ -93,7 +93,7 @@ class TestInfoCommands(EvenniaTest):
         self.assertTrue(self.char1.msg.called)
         out = self.char1.msg.call_args[0][0]
         self.assertIn("PRIMARY STATS", out)
-        self.assertIn("╔", out)
+        self.assertIn("+", out)
 
     def test_inventory(self):
         self.char1.execute_cmd("inventory")

--- a/utils/stats_utils.py
+++ b/utils/stats_utils.py
@@ -162,10 +162,10 @@ def get_display_scroll(chara):
     lines.extend(_columns(get_secondary_stats(chara)))
 
     width = max(len(_strip_colors(l)) for l in lines)
-    top = "╔" + "═" * (width + 2) + "╗"
-    bottom = "╚" + "═" * (width + 2) + "╝"
+    top = "+" + "=" * (width + 2) + "+"
+    bottom = "+" + "=" * (width + 2) + "+"
     out = [top]
     for line in lines:
-        out.append("║ " + _pad(line, width) + " ║")
+        out.append("| " + _pad(line, width) + " |")
     out.append(bottom)
     return "\n".join(out)


### PR DESCRIPTION
## Summary
- use ASCII boxes in `get_display_scroll`
- use ASCII boxes in `CmdFinger`
- update tests to match new formatting

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6841574a652c832c85683e86868db0ce