### PR TITLE
Implement basic dig command

### DIFF
--- a/commands/README.md
+++ b/commands/README.md
@@ -12,3 +12,15 @@ locations, you need to add the appropriate paths to
 Also remember that if you create new sub directories you must put
 (optionally empty) `__init__.py` files in there so that Python can
 find your modules.
+
+## Dig Command
+
+The `dig` command creates a new room in the given compass direction and
+links exits between the current location and the new room. Usage:
+
+```
+dig <direction>
+```
+
+For example, `dig north` will make a new room north of the current one
+and also create a south exit back.

--- a/commands/building.py
+++ b/commands/building.py
@@ -1,0 +1,99 @@
+from evennia import create_object
+from .command import Command
+from typeclasses.rooms import Room
+from typeclasses.exits import Exit
+
+
+DIR_FULL = {
+    "n": "north",
+    "north": "north",
+    "s": "south",
+    "south": "south",
+    "e": "east",
+    "east": "east",
+    "w": "west",
+    "west": "west",
+    "ne": "northeast",
+    "northeast": "northeast",
+    "nw": "northwest",
+    "northwest": "northwest",
+    "se": "southeast",
+    "southeast": "southeast",
+    "sw": "southwest",
+    "southwest": "southwest",
+    "u": "up",
+    "up": "up",
+    "d": "down",
+    "down": "down",
+    "i": "in",
+    "in": "in",
+    "o": "out",
+    "out": "out",
+}
+
+OPPOSITE = {
+    "north": "south",
+    "south": "north",
+    "east": "west",
+    "west": "east",
+    "northeast": "southwest",
+    "southwest": "northeast",
+    "northwest": "southeast",
+    "southeast": "northwest",
+    "up": "down",
+    "down": "up",
+    "in": "out",
+    "out": "in",
+}
+
+SHORT = {
+    "north": "n",
+    "south": "s",
+    "east": "e",
+    "west": "w",
+    "northeast": "ne",
+    "southwest": "sw",
+    "northwest": "nw",
+    "southeast": "se",
+    "up": "u",
+    "down": "d",
+    "in": "i",
+    "out": "o",
+}
+
+
+class CmdDig(Command):
+    """Dig a new room in a direction."""
+
+    key = "dig"
+    locks = "cmd:perm(Builder)"
+    help_category = "Building"
+
+    def func(self):
+        caller = self.caller
+        direction = self.args.strip().lower()
+        if not direction:
+            caller.msg("Usage: dig <direction>")
+            return
+        direction = DIR_FULL.get(direction)
+        if not direction:
+            caller.msg("Unknown direction.")
+            return
+        opposite = OPPOSITE[direction]
+
+        new_room = create_object(Room, key="Room")
+        exit_to = create_object(
+            Exit,
+            key=direction,
+            aliases=[SHORT[direction]],
+            location=caller.location,
+            destination=new_room,
+        )
+        exit_back = create_object(
+            Exit,
+            key=opposite,
+            aliases=[SHORT[opposite]],
+            location=new_room,
+            destination=caller.location,
+        )
+        caller.msg(f"You dig {direction} and create a new room.")

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -32,6 +32,7 @@ from commands.info import InfoCmdSet
 from commands.guilds import GuildCmdSet
 from commands.rest import RestCmdSet
 from commands.who import CmdWho
+from commands.building import CmdDig
 
 
 class CharacterCmdSet(default_cmds.CharacterCmdSet):
@@ -62,6 +63,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(InfoCmdSet)
         self.add(RestCmdSet)
         self.add(GuildCmdSet)
+        self.add(CmdDig)
 
 
 class AccountCmdSet(default_cmds.AccountCmdSet):

--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -235,3 +235,20 @@ class TestRestCommands(EvenniaTest):
         self.char1.tags.add("sleeping", category="status")
         self.char1.execute_cmd("look")
         self.char1.msg.assert_any_call("You can't see anything with your eyes closed.")
+
+
+class TestDigCommand(EvenniaTest):
+    def test_dig_creates_room_and_exits(self):
+        start = self.char1.location
+        self.char1.execute_cmd("dig north")
+        new_exit = start.exits.get(key="north")
+        self.assertIsNotNone(new_exit)
+        self.assertIn("n", list(new_exit.aliases.all()))
+        new_room = new_exit.destination
+        back_exit = new_room.exits.get(key="south")
+        self.assertIsNotNone(back_exit)
+        self.assertIn("s", list(back_exit.aliases.all()))
+        self.char1.execute_cmd("north")
+        self.assertEqual(self.char1.location, new_room)
+        self.char1.execute_cmd("south")
+        self.assertEqual(self.char1.location, start)


### PR DESCRIPTION
## Summary
- add a simple `dig` command that builds a room and exits
- wire `CmdDig` into the character cmdset
- document dig command in the command README
- test exit creation and travel

## Testing
- `evennia migrate`
- `pytest -q` *(fails: 49 failed, 4 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6841591331d8832cb4cf7b29c493576d