### PR TITLE
Update score and finger displays

### DIFF
--- a/commands/info.py
+++ b/commands/info.py
@@ -52,13 +52,13 @@ class CmdFinger(Command):
                 return
         # gather lines of information
         lines = []
-        name_line = f"|w{target.key}|n"
-        if target.db.title:
-            name_line += f" - {target.db.title}"
-        lines.append(name_line)
+        title = target.db.title or ""
+        if title:
+            lines.append(f"|w{target.key}|n - {title}")
+        else:
+            lines.append(f"|w{target.key}|n")
 
         desc = target.db.desc or "They have no description."
-        lines.extend(desc.splitlines() or [desc])
 
         race = target.db.race or "Unknown"
         charclass = target.db.charclass or "Unknown"
@@ -76,6 +76,9 @@ class CmdFinger(Command):
             lines.append(f"Bounty: {bounty}")
         else:
             lines.append("No bounty.")
+
+        lines.append("")
+        lines.extend(desc.splitlines() or ["They have no description."])
 
         width = max(len(_strip_colors(l)) for l in lines)
         top = "+" + "=" * (width + 2) + "+"

--- a/utils/stats_utils.py
+++ b/utils/stats_utils.py
@@ -112,15 +112,16 @@ def get_display_scroll(chara):
     hp = chara.traits.get("health")
     mp = chara.traits.get("mana")
     sp = chara.traits.get("stamina")
+
     if hp and mp and sp:
-        hp_line = f"HP |g{int(round(hp.current))}|n/|g{int(round(hp.max))}|n"
-        mp_line = f"MP |c{int(round(mp.current))}|n/|c{int(round(mp.max))}|n"
-        sp_line = f"SP |w{int(round(sp.current))}|n/|w{int(round(sp.max))}|n"
+        hp_disp = f"{int(hp.current)}/{int(hp.max)}"
+        mp_disp = f"{int(mp.current)}/{int(mp.max)}"
+        sp_disp = f"{int(sp.current)}/{int(sp.max)}"
     else:
-        hp_line = mp_line = sp_line = "--/--"
+        hp_disp = mp_disp = sp_disp = "--/--"
 
     lines.append(
-        f"Lvl {level}  XP {xp}  {hp_line}  {mp_line}  {sp_line}"
+        f"|YLvl {level}|n  |CXP|n {xp}  |rHP|n {hp_disp}  |cMP|n {mp_disp}  |gSP|n {sp_disp}"
     )
 
     coins = _db_get(chara, "coins", 0)
@@ -130,10 +131,12 @@ def get_display_scroll(chara):
     silver = int(coins.get("silver", 0))
     gold = int(coins.get("gold", 0))
     platinum = int(coins.get("platinum", 0))
-    lines.append("COIN POUCH")
+    lines.append("")
+    lines.append("|YCOIN POUCH|n")
     lines.append(
         f"Copper: {copper}  Silver: {silver}  Gold: {gold}  Platinum: {platinum}"
     )
+    lines.append("")
 
     weight = chara.db.carry_weight or 0
     capacity = chara.db.carry_capacity or 0
@@ -141,7 +144,7 @@ def get_display_scroll(chara):
     cw_line = f"Carry Weight: {weight} / {capacity}"
     if enc:
         cw_line += f"  {enc}"
-    lines.append(cw_line)
+    lines.append(f"|Y{cw_line}|n")
 
     guild = _db_get(chara, "guild", "")
     if guild:
@@ -152,13 +155,15 @@ def get_display_scroll(chara):
     if buffs := chara.tags.get(category="buff", return_list=True):
         lines.append("Buffs: " + iter_to_str(sorted(buffs)))
 
-    lines.append("PRIMARY STATS")
+    lines.append("")
+    lines.append("|YPRIMARY STATS|n")
     primaries = "  ".join(
         f"{k}: |w{v}|n" for k, v in get_primary_stats(chara)
     )
     lines.append(primaries)
 
-    lines.append("SECONDARY STATS")
+    lines.append("")
+    lines.append("|YSECONDARY STATS|n")
     lines.extend(_columns(get_secondary_stats(chara)))
 
     width = max(len(_strip_colors(l)) for l in lines)


### PR DESCRIPTION
## Summary
- colorize headings and stat line in `get_display_scroll`
- insert blank lines for readability
- adjust `CmdFinger` to show name/title once and move description

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68416095975c832c98f3e543261be85a