### PR TITLE
Add affects command with effect registry

### DIFF
--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -113,8 +113,24 @@ class TestInfoCommands(EvenniaTest):
         self.assertTrue(self.char1.msg.called)
         self.char1.msg.reset_mock()
         self.char1.tags.add("speed", category="buff")
+        self.char1.db.temp_bonuses = {"STR": [{"amount": 5, "duration": 3}]}
         self.char1.execute_cmd("buffs")
-        self.assertTrue(self.char1.msg.called)
+        out = self.char1.msg.call_args[0][0]
+        self.assertIn("Speed Boost", out)
+        self.assertIn("Strength Bonus", out)
+        self.assertIn("3", out)
+
+    def test_affects(self):
+        self.char1.db.status_effects = {"stunned": 5}
+        self.char1.tags.add("speed", category="buff")
+        self.char1.db.temp_bonuses = {"STR": [{"amount": 5, "duration": 3}]}
+        self.char1.execute_cmd("affects")
+        out = self.char1.msg.call_args[0][0]
+        self.assertIn("Stunned", out)
+        self.assertIn("Speed Boost", out)
+        self.assertIn("Strength Bonus", out)
+        self.assertIn("5", out)
+        self.assertIn("3", out)
 
     def test_guild(self):
         self.char1.db.guild = "Adventurers Guild"

--- a/world/effects.py
+++ b/world/effects.py
@@ -1,0 +1,58 @@
+from dataclasses import dataclass
+from typing import Dict
+
+
+@dataclass
+class Effect:
+    """Definition for a temporary effect."""
+
+    key: str
+    name: str
+    desc: str
+    type: str = "status"  # "buff" or "status"
+
+
+EFFECTS: Dict[str, Effect] = {
+    "speed": Effect(
+        key="speed",
+        name="Speed Boost",
+        desc="You move more quickly than normal.",
+        type="buff",
+    ),
+    "stunned": Effect(
+        key="stunned",
+        name="Stunned",
+        desc="You are unable to act.",
+        type="status",
+    ),
+    "STR": Effect(
+        key="STR",
+        name="Strength Bonus",
+        desc="Your strength is temporarily increased.",
+        type="buff",
+    ),
+    "sleeping": Effect(
+        key="sleeping",
+        name="Sleeping",
+        desc="You are fast asleep.",
+        type="status",
+    ),
+    "unconscious": Effect(
+        key="unconscious",
+        name="Unconscious",
+        desc="You are knocked out.",
+        type="status",
+    ),
+    "sitting": Effect(
+        key="sitting",
+        name="Sitting",
+        desc="You are sitting and resting.",
+        type="status",
+    ),
+    "lying down": Effect(
+        key="lying down",
+        name="Lying Down",
+        desc="You are sprawled on the ground.",
+        type="status",
+    ),
+}

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -86,4 +86,16 @@ HELP_ENTRY_DICTS = [
                 |wprompt [HP:{hp}/{hpmax}] [SP:{sp}/{spmax}] {enc}>|n
         """,
     },
+    {
+        "key": "affects",
+        "category": "General",
+        "text": """
+            View your active buffs and status effects.
+
+            Usage:
+                affects
+
+            Displays any active effects along with their remaining duration in ticks.
+        """,
+    },
 ]


### PR DESCRIPTION
## Summary
- add `Effect` dataclass and `EFFECTS` registry
- document `affects` command
- show effect info in new `CmdAffects`
- update `CmdBuffs` to format output and use registry
- expose affects command via `InfoCmdSet`
- test buffs/affects output

## Testing
- `evennia migrate` *(passed)*
- `pytest -q` *(failed: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6841630c9750832c93d2eb2c03465be3