### PR TITLE
Add effect keys to stat bonuses

### DIFF
--- a/commands/info.py
+++ b/commands/info.py
@@ -254,10 +254,15 @@ class CmdAffects(Command):
             rows.append((name, dur, desc))
 
         for stat, entries in (caller.db.temp_bonuses or {}).items():
-            effect = EFFECTS.get(stat)
             for entry in entries:
-                name = effect.name if effect else f"{stat.capitalize()} Bonus"
-                desc = effect.desc if effect else f"Temporary bonus to {stat}."
+                ekey = entry.get("key") or stat
+                effect = EFFECTS.get(ekey) or EFFECTS.get(stat)
+                if effect:
+                    name = effect.name
+                    desc = effect.desc
+                else:
+                    name = ekey if entry.get("key") else f"{stat.capitalize()} Bonus"
+                    desc = f"Temporary bonus to {stat}."
                 rows.append((name, entry.get("duration"), desc))
 
         if not rows:

--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -132,6 +132,18 @@ class TestInfoCommands(EvenniaTest):
         self.assertIn("5", out)
         self.assertIn("3", out)
 
+    def test_affects_uses_effect_key_for_stat_bonus(self):
+        self.char1.msg.reset_mock()
+        from world.system import state_manager
+
+        state_manager.add_temp_stat_bonus(
+            self.char1, "STR", 2, 3, effect_key="speed"
+        )
+        self.char1.execute_cmd("affects")
+        out = self.char1.msg.call_args[0][0]
+        self.assertIn("Speed Boost", out)
+        self.assertNotIn("Strength Bonus", out)
+
     def test_guild(self):
         self.char1.db.guild = "Adventurers Guild"
         self.char1.execute_cmd("guild")

--- a/typeclasses/tests/test_state_manager.py
+++ b/typeclasses/tests/test_state_manager.py
@@ -32,3 +32,12 @@ class TestStateManager(EvenniaTest):
         self.assertTrue(char.cooldowns.time_left("test", use_int=True))
         state_manager.remove_cooldown(char, "test")
         self.assertEqual(char.cooldowns.time_left("test", use_int=True), 0)
+
+    def test_temp_bonus_effect_key_preserved(self):
+        char = self.char1
+        state_manager.add_temp_stat_bonus(char, "STR", 5, 2, effect_key="speed")
+        entry = char.db.temp_bonuses["STR"][0]
+        self.assertEqual(entry["key"], "speed")
+        state_manager.tick_character(char)
+        entry_after = char.db.temp_bonuses["STR"][0]
+        self.assertEqual(entry_after["key"], "speed")


### PR DESCRIPTION
## Summary
- extend temporary stat bonus handling with optional effect key
- show effect key info in `affects` command
- test preservation of effect keys and output

## Testing
- `evennia migrate`
- `pytest -q` *(fails: ObjectDB.DoesNotExist: settings.DEFAULT_HOME (= '#2') does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_684165a0bfb0832cba0076c2d172eabb