### PR TITLE
Implement effect-based stat modifiers

### DIFF
--- a/typeclasses/tests/test_stat_manager.py
+++ b/typeclasses/tests/test_stat_manager.py
@@ -61,3 +61,23 @@ class TestStatManager(EvenniaTest):
         self.assertIsInstance(char.db.base_primary_stats, dict)
         for key in stats.CORE_STAT_KEYS:
             self.assertIn(key, char.db.base_primary_stats)
+
+    def test_active_effect_modifiers(self):
+        char = self.char1
+        stat_manager.refresh_stats(char)
+        base = char.traits.STR.base
+        state_manager.add_effect(char, "STR", 2)
+        self.assertEqual(char.traits.STR.base, base + 5)
+        self.assertEqual(stat_manager.get_effective_stat(char, "STR"), base + 5)
+        state_manager.tick_character(char)
+        state_manager.tick_character(char)
+        self.assertEqual(char.traits.STR.base, base)
+
+    def test_debuff_modifiers(self):
+        char = self.char1
+        stat_manager.refresh_stats(char)
+        base = char.traits.DEX.base
+        state_manager.add_effect(char, "stunned", 1)
+        self.assertEqual(char.traits.DEX.base, base - 5)
+        state_manager.tick_character(char)
+        self.assertEqual(char.traits.DEX.base, base)

--- a/world/effects.py
+++ b/world/effects.py
@@ -1,5 +1,5 @@
-from dataclasses import dataclass
-from typing import Dict
+from dataclasses import dataclass, field
+from typing import Dict, Optional
 
 
 @dataclass
@@ -10,6 +10,7 @@ class Effect:
     name: str
     desc: str
     type: str = "status"  # "buff" or "status"
+    mods: Optional[Dict[str, int]] = field(default_factory=dict)
 
 
 EFFECTS: Dict[str, Effect] = {
@@ -18,18 +19,21 @@ EFFECTS: Dict[str, Effect] = {
         name="Speed Boost",
         desc="You move more quickly than normal.",
         type="buff",
+        mods={"DEX": 2},
     ),
     "stunned": Effect(
         key="stunned",
         name="Stunned",
         desc="You are unable to act.",
         type="status",
+        mods={"DEX": -5},
     ),
     "STR": Effect(
         key="STR",
         name="Strength Bonus",
         desc="Your strength is temporarily increased.",
         type="buff",
+        mods={"STR": 5},
     ),
     "sleeping": Effect(
         key="sleeping",

--- a/world/system/stat_manager.py
+++ b/world/system/stat_manager.py
@@ -93,8 +93,8 @@ def _gear_mods(obj) -> Dict[str, int]:  # pragma: no cover - placeholder
 
 
 def _buff_mods(obj) -> Dict[str, int]:  # pragma: no cover - placeholder
-    """Placeholder for buff/debuff bonus lookup."""
-    return {}
+    """Collect stat modifiers from active effects."""
+    return state_manager.get_effect_mods(obj)
 
 
 # -------------------------------------------------------------
@@ -186,6 +186,7 @@ def get_effective_stat(obj, key: str) -> int:
     elif hasattr(obj, "attributes"):
         base += obj.attributes.get(f"{key}_bonus", default=0)
     base += state_manager.get_temp_bonus(obj, key)
+    base += state_manager.get_effect_mods(obj).get(key, 0)
     return int(base)
 
 


### PR DESCRIPTION
## Summary
- extend `Effect` definitions to include stat modifiers
- track active effects in `state_manager`
- calculate modifiers from effects in stat refreshing
- expose modifiers via `get_effective_stat`
- test buff and debuff application

## Testing
- `pytest -q` *(fails: django.db.utils.OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68416774a1a0832ca6932dd4bdf6ba1c