### PR TITLE
Fix exit display and movement cost

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -18,7 +18,7 @@ from .objects import ObjectParent
 _IMMOBILE = ("sitting", "lying down", "unconscious", "sleeping")
 
 # base stamina cost of moving between rooms
-_MOVE_SP_BASE = 5
+_MOVE_SP_BASE = 1
 
 
 class Character(ObjectParent, ClothedCharacter):
@@ -179,13 +179,9 @@ class Character(ObjectParent, ClothedCharacter):
         carry_capacity = self.db.carry_capacity or 0
         carry_weight = self.db.carry_weight or 0
         cost = _MOVE_SP_BASE
-        if carry_weight > carry_capacity:
-            if carry_weight <= 1.5 * carry_capacity:
-                cost += 5
-            elif carry_weight <= 2.0 * carry_capacity:
-                cost += 10
-            else:
-                cost += 20
+        if carry_weight > carry_capacity and carry_capacity > 0:
+            excess = carry_weight - carry_capacity
+            cost += excess // 10
         if self.traits.stamina:
             self.traits.stamina.current = max(
                 self.traits.stamina.current - cost, 0

--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -67,6 +67,19 @@ class RoomParent(ObjectParent):
         else:
             return ""
 
+    def get_display_exits(self, looker, **kwargs):
+        """Return a list of exits visible to ``looker``."""
+
+        exits = [
+            ex.key.capitalize()
+            for ex in self.exits
+            if ex.access(looker, "view")
+        ]
+        if exits:
+            return "|wExits:|n " + ", ".join(exits)
+        else:
+            return "|wExits:|n None"
+
 
 class Room(RoomParent, DefaultRoom):
     """


### PR DESCRIPTION
## Summary
- show visible exits in room descriptions
- reduce movement stamina cost to 1 SP and scale by carried weight

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'evennia')*

------
https://chatgpt.com/codex/tasks/task_e_68416a07c698832ca9312d3d091b781b