### PR TITLE
Add area building commands

### DIFF
--- a/commands/areas.py
+++ b/commands/areas.py
@@ -1,0 +1,155 @@
+from evennia.objects.models import ObjectDB
+from evennia.utils.evtable import EvTable
+from evennia import CmdSet
+
+from .command import Command
+from world.areas import Area, get_areas, save_area, update_area, find_area
+
+
+class CmdAreas(Command):
+    """List all registered areas."""
+
+    key = "alist"
+    aliases = ("areas",)
+    locks = "cmd:perm(Builder)"
+    help_category = "Building"
+
+    def func(self):
+        areas = get_areas()
+        if not areas:
+            self.msg("No areas registered.")
+            return
+        table = EvTable("Name", "Range", border="cells")
+        for area in areas:
+            table.add_row(area.key, f"{area.start}-{area.end}")
+        self.msg(str(table))
+
+
+class CmdAMake(Command):
+    """Register a new area."""
+
+    key = "amake"
+    locks = "cmd:perm(Builder)"
+    help_category = "Building"
+
+    def func(self):
+        if not self.args:
+            self.msg("Usage: amake <name> <start>-<end>")
+            return
+        try:
+            name, rng = self.args.split(None, 1)
+        except ValueError:
+            self.msg("Usage: amake <name> <start>-<end>")
+            return
+        try:
+            start, end = [int(x) for x in rng.split("-", 1)]
+        except ValueError:
+            self.msg("Range must be two integers joined by '-'")
+            return
+        if start > end:
+            start, end = end, start
+        areas = get_areas()
+        for area in areas:
+            if not (end < area.start or start > area.end):
+                self.msg(f"Range overlaps with {area.key} ({area.start}-{area.end})")
+                return
+        new_area = Area(key=name, start=start, end=end)
+        save_area(new_area)
+        self.msg(f"Area '{name}' registered for rooms {start}-{end}.")
+
+
+class CmdASet(Command):
+    """Update an existing area's info."""
+
+    key = "aset"
+    locks = "cmd:perm(Builder)"
+    help_category = "Building"
+
+    def func(self):
+        if not self.args:
+            self.msg("Usage: aset <area> <property> <value>")
+            return
+        parts = self.args.split(None, 2)
+        if len(parts) < 3:
+            self.msg("Usage: aset <area> <property> <value>")
+            return
+        area_name, prop, value = parts
+        idx, area = find_area(area_name)
+        if area is None:
+            self.msg("Unknown area.")
+            return
+        prop = prop.lower()
+        if prop in ("name", "key"):
+            area.key = value
+        elif prop in ("range",):
+            try:
+                start, end = [int(x) for x in value.split("-", 1)]
+            except ValueError:
+                self.msg("Range must be two integers joined by '-'")
+                return
+            if start > end:
+                start, end = end, start
+            areas = get_areas()
+            for other in areas:
+                if other is area:
+                    continue
+                if not (end < other.start or start > other.end):
+                    self.msg(
+                        f"Range overlaps with {other.key} ({other.start}-{other.end})"
+                    )
+                    return
+            area.start = start
+            area.end = end
+        elif prop in ("desc", "description"):
+            area.desc = value
+        else:
+            self.msg("Unknown property. Use name, range or desc.")
+            return
+        update_area(idx, area)
+        self.msg(f"Area '{area.key}' updated.")
+
+
+class CmdRooms(Command):
+    """List rooms in the current area."""
+
+    key = "rooms"
+    aliases = ("roomsall",)
+    locks = "cmd:perm(Builder)"
+    help_category = "Building"
+
+    def func(self):
+        location = self.caller.location
+        if not location:
+            self.msg("You have no location.")
+            return
+        areas = get_areas()
+        current = None
+        for area in areas:
+            if area.start <= location.id <= area.end:
+                current = area
+                break
+        if not current:
+            self.msg("This room is not within a registered area.")
+            return
+        objs = ObjectDB.objects.filter(id__gte=current.start, id__lte=current.end)
+        rooms = {obj.id: obj for obj in objs if obj.is_typeclass("evennia.objects.objects.DefaultRoom", exact=False)}
+        show_all = self.cmdstring.lower() == "roomsall"
+        lines = []
+        for num in range(current.start, current.end + 1):
+            if num in rooms:
+                lines.append(f"{num}: {rooms[num].key}")
+            elif show_all:
+                lines.append(f"{num}: (unbuilt)")
+        header = f"Rooms in {current.key} ({current.start}-{current.end})"
+        self.msg("\n".join([header] + lines))
+
+
+class AreaCmdSet(CmdSet):
+    key = "Area CmdSet"
+
+    def at_cmdset_creation(self):
+        super().at_cmdset_creation()
+        self.add(CmdAreas)
+        self.add(CmdAMake)
+        self.add(CmdASet)
+        self.add(CmdRooms)

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -33,6 +33,7 @@ from commands.guilds import GuildCmdSet
 from commands.rest import RestCmdSet
 from commands.who import CmdWho
 from commands.building import CmdDig
+from commands.areas import AreaCmdSet
 
 
 class CharacterCmdSet(default_cmds.CharacterCmdSet):
@@ -64,6 +65,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(RestCmdSet)
         self.add(GuildCmdSet)
         self.add(CmdDig)
+        self.add(AreaCmdSet)
 
 
 class AccountCmdSet(default_cmds.AccountCmdSet):

--- a/world/areas.py
+++ b/world/areas.py
@@ -1,0 +1,68 @@
+from dataclasses import dataclass, asdict
+from typing import List, Dict
+
+from evennia.server.models import ServerConfig
+
+
+@dataclass
+class Area:
+    """Simple data container for an area."""
+
+    key: str
+    start: int
+    end: int
+    desc: str = ""
+
+    @classmethod
+    def from_dict(cls, data: Dict) -> "Area":
+        return cls(
+            key=data.get("key", ""),
+            start=int(data.get("start", 0)),
+            end=int(data.get("end", 0)),
+            desc=data.get("desc", ""),
+        )
+
+    def to_dict(self) -> Dict:
+        return asdict(self)
+
+
+_REGISTRY_KEY = "area_registry"
+
+
+def _load_registry() -> List[Dict]:
+    return ServerConfig.objects.conf(_REGISTRY_KEY, default=list)
+
+
+def _save_registry(registry: List[Dict]):
+    ServerConfig.objects.conf(_REGISTRY_KEY, value=registry)
+
+
+def get_areas() -> List[Area]:
+    """Return all stored areas."""
+    return [Area.from_dict(data) for data in _load_registry()]
+
+
+def save_area(area: Area):
+    """Add a new area to the registry."""
+    registry = _load_registry()
+    registry.append(area.to_dict())
+    _save_registry(registry)
+
+
+def update_area(index: int, area: Area):
+    """Update area at index."""
+    registry = _load_registry()
+    registry[index] = area.to_dict()
+    _save_registry(registry)
+
+
+def find_area(name: str) -> tuple[int, Optional[Area]]:
+    """Return index and area matching name (case-insensitive)."""
+    registry = _load_registry()
+    for i, data in enumerate(registry):
+        area = Area.from_dict(data)
+        if area.key.lower() == name.lower():
+            return i, area
+    return -1, None
+
+


### PR DESCRIPTION
## Summary
- manage persistent room areas in `world/areas.py`
- implement builder-only commands `alist`, `amake`, `aset`, and `rooms`
- expose new commands to builders via `AreaCmdSet`

## Testing
- `pytest -q` *(fails: OperationalError no such table)*

------
https://chatgpt.com/codex/tasks/task_e_68416f30a36c832c9f2bffa9a4be1be7