### PR TITLE
Add area metadata to rooms and update dig/amake

### DIFF
--- a/commands/areas.py
+++ b/commands/areas.py
@@ -55,6 +55,9 @@ class CmdAMake(Command):
                 return
         new_area = Area(key=name, start=start, end=end)
         save_area(new_area)
+        # tag the current room as the first room of this area
+        if location := self.caller.location:
+            location.set_area(name, start)
         self.msg(f"Area '{name}' registered for rooms {start}-{end}.")
 
 

--- a/commands/building.py
+++ b/commands/building.py
@@ -71,17 +71,27 @@ class CmdDig(Command):
 
     def func(self):
         caller = self.caller
-        direction = self.args.strip().lower()
-        if not direction:
-            caller.msg("Usage: dig <direction>")
+        args = self.args.strip().split()
+        if not args:
+            caller.msg("Usage: dig <direction> [area] [number]")
             return
-        direction = DIR_FULL.get(direction)
+        direction = DIR_FULL.get(args[0].lower())
         if not direction:
             caller.msg("Unknown direction.")
             return
+        area = args[1] if len(args) > 1 else caller.location.db.area
+        room_id = None
+        if len(args) > 2:
+            if args[2].isdigit():
+                room_id = int(args[2])
+            else:
+                caller.msg("Room id must be numeric.")
+                return
         opposite = OPPOSITE[direction]
 
         new_room = create_object(Room, key="Room")
+        if area:
+            new_room.set_area(area, room_id)
         exit_to = create_object(
             Exit,
             key=direction,

--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -51,6 +51,32 @@ class RoomParent(ObjectParent):
                     continue
                 obj.at_character_depart(mover, destination, **kwargs)
 
+    # metadata helpers --------------------------------------------------
+
+    def set_area(self, area, room_id=None):
+        """Set this room's area and optional id."""
+        self.db.area = area
+        if room_id is not None:
+            try:
+                self.db.room_id = int(room_id)
+            except (TypeError, ValueError):  # pragma: no cover - guard
+                self.db.room_id = None
+
+    def get_area(self):
+        """Return this room's area name."""
+        return self.db.area
+
+    def set_room_id(self, room_id):
+        """Set this room's numeric id inside its area."""
+        try:
+            self.db.room_id = int(room_id)
+        except (TypeError, ValueError):  # pragma: no cover - guard
+            self.db.room_id = None
+
+    def get_room_id(self):
+        """Return the room id inside its area."""
+        return self.db.room_id
+
     def get_display_footer(self, looker, **kwargs):
         """
         Shows a list of commands available here to the viewer.

--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -280,3 +280,18 @@ class TestDigCommand(EvenniaTest):
         self.assertEqual(self.char1.location, new_room)
         self.char1.execute_cmd("south")
         self.assertEqual(self.char1.location, start)
+
+    def test_dig_sets_area_and_room_id(self):
+        start = self.char1.location
+        start.set_area("test", 1)
+        self.char1.execute_cmd("dig east test 2")
+        new_room = start.exits.get(key="east").destination
+        self.assertEqual(new_room.db.area, "test")
+        self.assertEqual(new_room.db.room_id, 2)
+
+
+class TestAreaMakeCommand(EvenniaTest):
+    def test_amake_sets_area_on_room(self):
+        self.char1.execute_cmd("amake foo 1-5")
+        self.assertEqual(self.char1.location.db.area, "foo")
+        self.assertEqual(self.char1.location.db.room_id, 1)


### PR DESCRIPTION
## Summary
- allow rooms to store area info and area-based id numbers
- support assigning area metadata when making a new area
- update `dig` command to set optional area and room id
- test building commands for new metadata behavior

## Testing
- `pytest -q` *(fails: OperationalError no such table `accounts_accountdb`)*

------
https://chatgpt.com/codex/tasks/task_e_684170b41e84832c9aa9392cb37af0ca