### PR TITLE
Add teleport and improved dig

### DIFF
--- a/commands/building.py
+++ b/commands/building.py
@@ -1,7 +1,9 @@
 from evennia import create_object
+from evennia.objects.models import ObjectDB
 from .command import Command
 from typeclasses.rooms import Room
 from typeclasses.exits import Exit
+from world.areas import find_area
 
 
 DIR_FULL = {
@@ -71,22 +73,59 @@ class CmdDig(Command):
 
     def func(self):
         caller = self.caller
-        args = self.args.strip().split()
-        if not args:
-            caller.msg("Usage: dig <direction> [area] [number]")
+        argstr = self.args.strip()
+        if not argstr:
+            caller.msg("Usage: dig <direction>=<area>:<number>")
             return
-        direction = DIR_FULL.get(args[0].lower())
-        if not direction:
-            caller.msg("Unknown direction.")
-            return
-        area = args[1] if len(args) > 1 else caller.location.db.area
+        area = caller.location.db.area
         room_id = None
-        if len(args) > 2:
-            if args[2].isdigit():
-                room_id = int(args[2])
-            else:
-                caller.msg("Room id must be numeric.")
+
+        if "=" in argstr:
+            dir_part, rhs = (p.strip() for p in argstr.split("=", 1))
+            direction = DIR_FULL.get(dir_part.lower())
+            if not direction:
+                caller.msg("Unknown direction.")
                 return
+            if ":" in rhs:
+                area_part, num_part = (p.strip() for p in rhs.split(":", 1))
+                if area_part:
+                    area = area_part
+                if num_part:
+                    if num_part.isdigit():
+                        room_id = int(num_part)
+                    else:
+                        caller.msg("Room id must be numeric.")
+                        return
+            else:
+                if rhs:
+                    area = rhs
+        else:
+            parts = argstr.split()
+            direction = DIR_FULL.get(parts[0].lower())
+            if not direction:
+                caller.msg("Unknown direction.")
+                return
+            if len(parts) > 1:
+                area = parts[1]
+            if len(parts) > 2:
+                if parts[2].isdigit():
+                    room_id = int(parts[2])
+                else:
+                    caller.msg("Room id must be numeric.")
+                    return
+
+        if area:
+            _, area_data = find_area(area)
+            if area_data:
+                if room_id is not None and not (area_data.start <= room_id <= area_data.end):
+                    caller.msg("Number outside area range.")
+                    return
+            if room_id is not None:
+                objs = ObjectDB.objects.filter(db_attributes__db_key="area", db_attributes__db_strvalue__iexact=area)
+                for obj in objs:
+                    if obj.db.room_id == room_id:
+                        caller.msg("Room already exists.")
+                        return
         opposite = OPPOSITE[direction]
 
         new_room = create_object(Room, key="Room")
@@ -107,3 +146,41 @@ class CmdDig(Command):
             destination=caller.location,
         )
         caller.msg(f"You dig {direction} and create a new room.")
+
+
+class CmdTeleport(Command):
+    """Teleport to a room using ``<area>:<number>``."""
+
+    key = "@teleport"
+    locks = "cmd:perm(Builder)"
+    help_category = "Building"
+
+    def func(self):
+        if not self.args:
+            self.msg("Usage: @teleport <area>:<number>")
+            return
+
+        area_part, sep, num_part = self.args.strip().partition(":")
+        if not sep or not area_part or not num_part:
+            self.msg("Usage: @teleport <area>:<number>")
+            return
+        if not num_part.isdigit():
+            self.msg("Room number must be numeric.")
+            return
+        room_id = int(num_part)
+        _, area = find_area(area_part)
+        if area:
+            if not (area.start <= room_id <= area.end):
+                self.msg("Number outside area range.")
+                return
+        objs = ObjectDB.objects.filter(db_attributes__db_key="area", db_attributes__db_strvalue__iexact=area_part)
+        room = None
+        for obj in objs:
+            if obj.db.room_id == room_id and obj.is_typeclass(Room, exact=False):
+                room = obj
+                break
+        if not room:
+            self.msg("That room does not exist.")
+            return
+        self.caller.move_to(room, quiet=True, move_type="teleport")
+        self.msg(f"Teleported to {room.get_display_name(self.caller)}.")

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -32,7 +32,7 @@ from commands.info import InfoCmdSet
 from commands.guilds import GuildCmdSet
 from commands.rest import RestCmdSet
 from commands.who import CmdWho
-from commands.building import CmdDig
+from commands.building import CmdDig, CmdTeleport
 from commands.areas import AreaCmdSet
 
 
@@ -65,6 +65,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(RestCmdSet)
         self.add(GuildCmdSet)
         self.add(CmdDig)
+        self.add(CmdTeleport)
         self.add(AreaCmdSet)
 
 

--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -295,3 +295,27 @@ class TestAreaMakeCommand(EvenniaTest):
         self.char1.execute_cmd("amake foo 1-5")
         self.assertEqual(self.char1.location.db.area, "foo")
         self.assertEqual(self.char1.location.db.room_id, 1)
+
+
+class TestExtendedDigTeleport(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.char1.execute_cmd("amake test 1-5")
+
+    def test_dig_eq_syntax(self):
+        start = self.char1.location
+        self.char1.execute_cmd("dig north=test:2")
+        new_room = start.exits.get(key="north").destination
+        self.assertEqual(new_room.db.area, "test")
+        self.assertEqual(new_room.db.room_id, 2)
+
+    def test_teleport_to_area_room(self):
+        start = self.char1.location
+        self.char1.execute_cmd("dig east=test:3")
+        target = start.exits.get(key="east").destination
+        self.char1.execute_cmd("@teleport test:3")
+        self.assertEqual(self.char1.location, target)
+        # out of range should not move
+        self.char1.location = start
+        self.char1.execute_cmd("@teleport test:6")
+        self.assertEqual(self.char1.location, start)


### PR DESCRIPTION
## Summary
- allow `dig` to use `dir=area:number` syntax
- add an area-aware `@teleport` command
- expose new command in default cmdset
- test new dig syntax and teleport logic

## Testing
- `pytest -q` *(fails: OperationalError - no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68417266fc1c832cae63ce81382f9a12