### PR TITLE
Add room flag system

### DIFF
--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -34,6 +34,7 @@ from commands.rest import RestCmdSet
 from commands.who import CmdWho
 from commands.building import CmdDig, CmdTeleport
 from commands.areas import AreaCmdSet
+from commands.room_flags import RoomFlagCmdSet
 
 
 class CharacterCmdSet(default_cmds.CharacterCmdSet):
@@ -66,6 +67,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(GuildCmdSet)
         self.add(CmdDig)
         self.add(CmdTeleport)
+        self.add(RoomFlagCmdSet)
         self.add(AreaCmdSet)
 
 

--- a/commands/room_flags.py
+++ b/commands/room_flags.py
@@ -1,0 +1,84 @@
+from evennia import CmdSet
+from .command import Command
+
+VALID_ROOM_FLAGS = (
+    "dark",
+    "nopvp",
+    "sanctuary",
+    "indoors",
+    "safe",
+    "no_recall",
+    "no_mount",
+    "no_flee",
+    "rest_area",
+)
+
+
+class CmdRFlags(Command):
+    """List flags set on the current room."""
+
+    key = "rflags"
+    help_category = "Building"
+
+    def func(self):
+        room = self.caller.location
+        if not room:
+            self.msg("You have no location.")
+            return
+        flags = room.tags.get(category="room_flag", return_list=True) or []
+        if not flags:
+            self.msg("This room has no flags.")
+        else:
+            self.msg("Room flags: " + ", ".join(sorted(flags)))
+
+
+class CmdRFlag(Command):
+    """Add or remove room flags."""
+
+    key = "rflag"
+    locks = "cmd:perm(Builder)"
+    help_category = "Building"
+
+    def func(self):
+        if not self.args:
+            self.msg("Usage: rflag <add/remove/list> [flag]")
+            return
+        room = self.caller.location
+        if not room:
+            self.msg("You have no location.")
+            return
+        parts = self.args.split(None, 1)
+        action = parts[0].lower()
+        if action == "list":
+            self.msg("Valid flags: " + ", ".join(VALID_ROOM_FLAGS))
+            return
+        if len(parts) < 2:
+            self.msg("Usage: rflag <add/remove/list> <flag>")
+            return
+        flag = parts[1].lower()
+        if flag not in VALID_ROOM_FLAGS:
+            self.msg("Unknown flag.")
+            return
+        if action == "add":
+            if room.tags.has(flag, category="room_flag"):
+                self.msg("Flag already set.")
+            else:
+                room.tags.add(flag, category="room_flag")
+                self.msg(f"Added {flag} flag.")
+        elif action == "remove":
+            if room.tags.has(flag, category="room_flag"):
+                room.tags.remove(flag, category="room_flag")
+                self.msg(f"Removed {flag} flag.")
+            else:
+                self.msg("Flag not set.")
+        else:
+            self.msg("Usage: rflag <add/remove/list> <flag>")
+
+
+class RoomFlagCmdSet(CmdSet):
+    key = "Room Flag CmdSet"
+
+    def at_cmdset_creation(self):
+        super().at_cmdset_creation()
+        self.add(CmdRFlags)
+        self.add(CmdRFlag)

--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -319,3 +319,22 @@ class TestExtendedDigTeleport(EvenniaTest):
         self.char1.location = start
         self.char1.execute_cmd("@teleport test:6")
         self.assertEqual(self.char1.location, start)
+
+
+class TestRoomFlagCommands(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.char1.msg = MagicMock()
+
+    def test_rflags_empty(self):
+        self.char1.execute_cmd("rflags")
+        self.char1.msg.assert_called_with("This room has no flags.")
+
+    def test_rflag_add_and_remove(self):
+        self.char1.execute_cmd("rflag add dark")
+        self.assertTrue(self.char1.location.tags.has("dark", category="room_flag"))
+        self.char1.execute_cmd("rflags")
+        out = self.char1.msg.call_args[0][0]
+        self.assertIn("dark", out)
+        self.char1.execute_cmd("rflag remove dark")
+        self.assertFalse(self.char1.location.tags.has("dark", category="room_flag"))

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -98,4 +98,26 @@ HELP_ENTRY_DICTS = [
             Displays any active effects along with their remaining duration in ticks.
         """,
     },
+    {
+        "key": "room flags",
+        "aliases": ["rflags", "rflag"],
+        "category": "building",
+        "text": """
+            Rooms can be marked with special flags.
+
+            Use |wrflags|n to view flags on the current room.
+            Builders may add or remove them with |wrflag add <flag>|n
+            or |wrflag remove <flag>|n. Available flags:
+
+            dark - room is dark, requiring light to see.
+            nopvp - player versus player combat is blocked.
+            sanctuary - hostile actions are prevented.
+            indoors - counts as being indoors.
+            safe - NPCs won't start fights here.
+            no_recall - recall and teleport effects fail.
+            no_mount - mounts cannot be used.
+            no_flee - prevents fleeing from combat.
+            rest_area - resting recovers resources faster.
+        """,
+    },
 ]


### PR DESCRIPTION
## Summary
- add commands to manage room flags
- list room flags via command set
- document flags in help
- tests for room flag commands

## Testing
- `evennia migrate`
- `pytest typeclasses/tests/test_commands.py::TestRoomFlagCommands::test_rflags_empty -q` *(fails: settings.DEFAULT_HOME does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6841748e5ab4832cb17e98751aa3a742