### PR TITLE
Add rname builder command

### DIFF
--- a/commands/areas.py
+++ b/commands/areas.py
@@ -147,6 +147,26 @@ class CmdRooms(Command):
         self.msg("\n".join([header] + lines))
 
 
+class CmdRName(Command):
+    """Rename the current room."""
+
+    key = "rname"
+    locks = "cmd:perm(Builder)"
+    help_category = "Building"
+
+    def func(self):
+        if not self.args:
+            self.msg("Usage: rname <new name>")
+            return
+        room = self.caller.location
+        if not room:
+            self.msg("You have no location.")
+            return
+        new_name = self.args.strip()
+        room.key = new_name
+        self.msg(f"Room renamed to {new_name}.")
+
+
 class AreaCmdSet(CmdSet):
     key = "Area CmdSet"
 
@@ -156,3 +176,4 @@ class AreaCmdSet(CmdSet):
         self.add(CmdAMake)
         self.add(CmdASet)
         self.add(CmdRooms)
+        self.add(CmdRName)

--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -338,3 +338,18 @@ class TestRoomFlagCommands(EvenniaTest):
         self.assertIn("dark", out)
         self.char1.execute_cmd("rflag remove dark")
         self.assertFalse(self.char1.location.tags.has("dark", category="room_flag"))
+
+
+class TestRoomRenameCommand(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.char1.msg = MagicMock()
+
+    def test_rname_changes_room_name(self):
+        start = self.char1.location
+        self.char1.execute_cmd("rname New Room")
+        self.assertEqual(start.key, "New Room")
+
+    def test_rname_usage(self):
+        self.char1.execute_cmd("rname")
+        self.char1.msg.assert_called_with("Usage: rname <new name>")

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -120,4 +120,16 @@ HELP_ENTRY_DICTS = [
             rest_area - resting recovers resources faster.
         """,
     },
+    {
+        "key": "rname",
+        "category": "building",
+        "text": """
+            Rename the room you are currently in.
+
+            Usage:
+                rname <new name>
+
+            Changes the name of the current room.
+        """,
+    },
 ]


### PR DESCRIPTION
## Summary
- add `rname` builder command in `commands/areas.py`
- register command in `AreaCmdSet`
- document `rname` in help entries
- add unit tests for the command

## Testing
- `pytest -q` *(fails: OperationalError no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68417668951c832c990b67dd6d7aec88