### PR TITLE
Add rset command

### DIFF
--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -353,3 +353,23 @@ class TestRoomRenameCommand(EvenniaTest):
     def test_rname_usage(self):
         self.char1.execute_cmd("rname")
         self.char1.msg.assert_called_with("Usage: rname <new name>")
+
+
+class TestRoomSetCommand(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.char1.msg = MagicMock()
+
+    def test_rset_area(self):
+        self.char1.execute_cmd("rset area test")
+        self.assertEqual(self.char1.location.db.area, "test")
+
+    def test_rset_id_validation(self):
+        self.char1.execute_cmd("amake test 1-5")
+        self.char1.msg.reset_mock()
+        self.char1.execute_cmd("dig north test 2")
+        self.char1.execute_cmd("rset id 2")
+        self.char1.msg.assert_called_with("Room already exists.")
+        self.char1.msg.reset_mock()
+        self.char1.execute_cmd("rset id 6")
+        self.char1.msg.assert_called_with("Number outside area range.")

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -132,4 +132,17 @@ HELP_ENTRY_DICTS = [
             Changes the name of the current room.
         """,
     },
+    {
+        "key": "rset",
+        "category": "building",
+        "text": """
+            Set properties on the current room.
+
+            Usage:
+                rset area <area name>
+                rset id <number>
+
+            The id must be unique within the area's range.
+        """,
+    },
 ]


### PR DESCRIPTION
## Summary
- add `CmdRSet` for assigning room areas and IDs
- document rset in help entries
- expose rset via builder cmdset
- test room set behavior

## Testing
- `pytest -q` *(fails: OperationalError no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684177e1bf98832cb66fe828d1ed9fea