### PR TITLE
Implement Admin command set

### DIFF
--- a/commands/admin.py
+++ b/commands/admin.py
@@ -1,0 +1,180 @@
+from evennia import CmdSet
+from .command import Command
+from world.stats import CORE_STAT_KEYS
+from world.system import stat_manager
+
+
+class CmdSetStat(Command):
+    """
+    Set a base or derived stat on a target.
+
+    Usage:
+        setstat <target> <stat> <value>
+    """
+
+    key = "setstat"
+    aliases = ("statset",)
+    locks = "cmd:perm(Admin)"
+    help_category = "admin"
+
+    def func(self):
+        if not self.args:
+            self.msg("Usage: setstat <target> <stat> <value>")
+            return
+        parts = self.args.split(None, 2)
+        if len(parts) != 3 or not parts[2].lstrip("-+").isdigit():
+            self.msg("Usage: setstat <target> <stat> <value>")
+            return
+        target_name, stat_key, value_str = parts
+        target = self.caller.search(target_name, global_search=True)
+        if not target:
+            return
+        value = int(value_str)
+        stat_key_up = stat_key.upper()
+        if stat_key_up in CORE_STAT_KEYS:
+            trait = target.traits.get(stat_key_up)
+            if trait:
+                trait.base = value
+            else:
+                target.traits.add(stat_key_up, stat_key_up, base=value)
+            base = target.db.base_primary_stats or {}
+            base[stat_key_up] = value
+            target.db.base_primary_stats = base
+            stat_manager.refresh_stats(target)
+            self.msg(f"{stat_key_up} set to {value} on {target.key}.")
+            return
+        stat_key_low = stat_key.lower()
+        trait = target.traits.get(stat_key_low)
+        if trait:
+            trait.base = value
+        else:
+            target.traits.add(stat_key_low, stat_key_low, base=value)
+        data = target.db.derived_stats or {}
+        data[stat_key_low] = value
+        target.db.derived_stats = data
+        self.msg(f"{stat_key_low} set to {value} on {target.key}.")
+
+
+class CmdSetAttr(Command):
+    """
+    Set an arbitrary attribute on a target.
+
+    Usage:
+        setattr <target> <attr> <value>
+    """
+
+    key = "setattr"
+    aliases = ("setattribute",)
+    locks = "cmd:perm(Admin)"
+    help_category = "admin"
+
+    def func(self):
+        if not self.args:
+            self.msg("Usage: setattr <target> <attr> <value>")
+            return
+        parts = self.args.split(None, 2)
+        if len(parts) < 3:
+            self.msg("Usage: setattr <target> <attr> <value>")
+            return
+        target_name, attr, value = parts
+        target = self.caller.search(target_name, global_search=True)
+        if not target:
+            return
+        target.attributes.add(attr, value)
+        self.msg(f"{attr} set on {target.key}.")
+
+
+class CmdSetBounty(Command):
+    """
+    Set the bounty value on a target.
+
+    Usage:
+        setbounty <target> <amount>
+    """
+
+    key = "setbounty"
+    locks = "cmd:perm(Admin)"
+    help_category = "admin"
+
+    def func(self):
+        if not self.args:
+            self.msg("Usage: setbounty <target> <amount>")
+            return
+        parts = self.args.split(None, 1)
+        if len(parts) != 2 or not parts[1].isdigit():
+            self.msg("Usage: setbounty <target> <amount>")
+            return
+        target_name, amt_str = parts
+        target = self.caller.search(target_name, global_search=True)
+        if not target:
+            return
+        target.db.bounty = int(amt_str)
+        self.msg(f"Bounty for {target.key} set to {amt_str}.")
+
+
+class CmdSlay(Command):
+    """
+    Instantly defeat a target.
+
+    Usage:
+        slay <target>
+    """
+
+    key = "slay"
+    locks = "cmd:perm(Admin)"
+    help_category = "admin"
+
+    def func(self):
+        if not self.args:
+            self.msg("Usage: slay <target>")
+            return
+        target = self.caller.search(self.args.strip(), global_search=True)
+        if not target:
+            return
+        if not target.traits.get("health"):
+            self.msg("Target has no health stat.")
+            return
+        target.traits.health.current = 0
+        target.at_damage(self.caller, 0)
+        self.msg(f"You slay {target.key}.")
+
+
+class CmdSmite(Command):
+    """
+    Reduce a target to a single hit point.
+
+    Usage:
+        smite <target>
+    """
+
+    key = "smite"
+    locks = "cmd:perm(Admin)"
+    help_category = "admin"
+
+    def func(self):
+        if not self.args:
+            self.msg("Usage: smite <target>")
+            return
+        target = self.caller.search(self.args.strip(), global_search=True)
+        if not target:
+            return
+        if not target.traits.get("health"):
+            self.msg("Target has no health stat.")
+            return
+        target.traits.health.current = 1
+        self.msg(f"You smite {target.key}, leaving them on the brink of death.")
+
+
+class AdminCmdSet(CmdSet):
+    """Command set with admin utilities."""
+
+    key = "Admin CmdSet"
+
+    def at_cmdset_creation(self):
+        super().at_cmdset_creation()
+        self.add(CmdSetStat)
+        self.add(CmdSetAttr)
+        self.add(CmdSetBounty)
+        self.add(CmdSlay)
+        self.add(CmdSmite)
+

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -35,6 +35,7 @@ from commands.who import CmdWho
 from commands.building import CmdDig, CmdTeleport
 from commands.areas import AreaCmdSet
 from commands.room_flags import RoomFlagCmdSet
+from commands.admin import AdminCmdSet
 
 
 class CharacterCmdSet(default_cmds.CharacterCmdSet):
@@ -69,6 +70,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(CmdTeleport)
         self.add(RoomFlagCmdSet)
         self.add(AreaCmdSet)
+        self.add(AdminCmdSet)
 
 
 class AccountCmdSet(default_cmds.AccountCmdSet):

--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -373,3 +373,28 @@ class TestRoomSetCommand(EvenniaTest):
         self.char1.msg.reset_mock()
         self.char1.execute_cmd("rset id 6")
         self.char1.msg.assert_called_with("Number outside area range.")
+
+
+class TestAdminCommands(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.char1.msg = MagicMock()
+        self.char2.msg = MagicMock()
+
+    def test_setstat_core(self):
+        self.char1.execute_cmd(f"setstat {self.char2.key} STR 12")
+        self.assertEqual(self.char2.traits.STR.base, 12)
+
+    def test_setattr_and_bounty(self):
+        self.char1.execute_cmd(f"setattr {self.char2.key} testattr foo")
+        self.assertEqual(self.char2.db.testattr, "foo")
+        self.char1.execute_cmd(f"setbounty {self.char2.key} 5")
+        self.assertEqual(self.char2.db.bounty, 5)
+
+    def test_smite_and_slay(self):
+        self.char2.traits.health.current = 50
+        self.char1.execute_cmd(f"smite {self.char2.key}")
+        self.assertEqual(self.char2.traits.health.current, 1)
+        self.char1.execute_cmd(f"slay {self.char2.key}")
+        self.assertEqual(self.char2.traits.health.current, 0)
+        self.assertTrue(self.char2.tags.has("unconscious", category="status"))


### PR DESCRIPTION
## Summary
- add `commands/admin.py` with admin commands and cmdset
- integrate AdminCmdSet into `commands/default_cmdsets.py`
- test coverage for admin commands

## Testing
- `evennia migrate`
- `pytest -q` *(fails: evennia database not fully initialized)*

------
https://chatgpt.com/codex/tasks/task_e_68417c554180832caa043f149c0562c7