### PR TITLE
Add room scan command

### DIFF
--- a/commands/admin.py
+++ b/commands/admin.py
@@ -1,5 +1,6 @@
 from evennia import CmdSet
 from .command import Command
+from .info import CmdScan
 from world.stats import CORE_STAT_KEYS
 from world.system import stat_manager
 
@@ -177,4 +178,5 @@ class AdminCmdSet(CmdSet):
         self.add(CmdSetBounty)
         self.add(CmdSlay)
         self.add(CmdSmite)
+        self.add(CmdScan)
 


### PR DESCRIPTION
## Summary
- add `CmdScan` for peeking into adjacent rooms
- include command in Info and Admin command sets
- register for admin cmdset

## Testing
- `evennia migrate`
- `pytest -q` *(fails: no such table / DEFAULT_HOME errors)*

------
https://chatgpt.com/codex/tasks/task_e_68417e8a7868832ca297a1fe1d743ed9