### PR TITLE
Fix Optional import in areas

### DIFF
--- a/world/areas.py
+++ b/world/areas.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, asdict
-from typing import List, Dict
+from typing import List, Dict, Optional
 
 from evennia.server.models import ServerConfig
 


### PR DESCRIPTION
## Summary
- fix Optional import in areas module

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684184a21220832c88969375a4b7b2a2