### PR TITLE
Add spacing between desc and exits in room look output

### DIFF
--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -18,9 +18,12 @@ from commands.skills import TrainCmdSet
 
 
 class RoomParent(ObjectParent):
-    """
-    A mixin for logic that should be applied to all rooms.
-    """
+    """Mixin with logic shared by all rooms."""
+
+    # add a blank line after the room description and exits
+    appearance_template = (
+        "{name}\n{desc}\n\n{exits}\n\n{characters}\n{things}\n{footer}"
+    )
 
     def at_object_receive(self, mover, source_location, move_type=None, **kwargs):
         """


### PR DESCRIPTION
## Summary
- adjust `RoomParent.appearance_template` so room descriptions show blank lines
  between description, exits, and characters

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6841890165ec832ca055b86b5f13f26e