### PR TITLE
Add room rename and description commands

### DIFF
--- a/commands/README.md
+++ b/commands/README.md
@@ -24,3 +24,14 @@ dig <direction>
 
 For example, `dig north` will make a new room north of the current one
 and also create a south exit back.
+
+## Room Editing Commands
+
+Builders can tweak the current room with a few simple commands:
+
+* `rrename <new name>` - change the room's name. Aliases: `roomrename`,
+  `renameroom`, `rname`.
+* `rdesc <new description>` - set the room's description. With no
+  argument it will show the current description.
+* `rset area <area>` or `rset id <number>` - assign the room to an
+  area or change its id within that area.

--- a/commands/areas.py
+++ b/commands/areas.py
@@ -150,13 +150,14 @@ class CmdRooms(Command):
 class CmdRName(Command):
     """Rename the current room."""
 
-    key = "rname"
+    key = "rrename"
+    aliases = ("roomrename", "renameroom", "rname")
     locks = "cmd:perm(Builder)"
     help_category = "Building"
 
     def func(self):
         if not self.args:
-            self.msg("Usage: rname <new name>")
+            self.msg("Usage: rrename <new name>")
             return
         room = self.caller.location
         if not room:
@@ -165,6 +166,27 @@ class CmdRName(Command):
         new_name = self.args.strip()
         room.key = new_name
         self.msg(f"Room renamed to {new_name}.")
+
+
+class CmdRDesc(Command):
+    """View or set the room description."""
+
+    key = "rdesc"
+    aliases = ("roomdesc",)
+    locks = "cmd:perm(Builder)"
+    help_category = "Building"
+
+    def func(self):
+        room = self.caller.location
+        if not room:
+            self.msg("You have no location.")
+            return
+        if not self.args:
+            desc = room.db.desc or "This room has no description."
+            self.msg(desc)
+        else:
+            room.db.desc = self.args.strip()
+            self.msg("Room description updated.")
 
 
 class CmdRSet(Command):
@@ -231,4 +253,5 @@ class AreaCmdSet(CmdSet):
         self.add(CmdASet)
         self.add(CmdRooms)
         self.add(CmdRName)
+        self.add(CmdRDesc)
         self.add(CmdRSet)

--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -345,14 +345,29 @@ class TestRoomRenameCommand(EvenniaTest):
         super().setUp()
         self.char1.msg = MagicMock()
 
-    def test_rname_changes_room_name(self):
+    def test_rrename_changes_room_name(self):
         start = self.char1.location
-        self.char1.execute_cmd("rname New Room")
+        self.char1.execute_cmd("rrename New Room")
         self.assertEqual(start.key, "New Room")
 
-    def test_rname_usage(self):
-        self.char1.execute_cmd("rname")
-        self.char1.msg.assert_called_with("Usage: rname <new name>")
+    def test_rrename_usage(self):
+        self.char1.execute_cmd("rrename")
+        self.char1.msg.assert_called_with("Usage: rrename <new name>")
+
+
+class TestRoomDescCommand(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.char1.msg = MagicMock()
+
+    def test_rdesc_sets_room_description(self):
+        self.char1.execute_cmd("rdesc A dark cavern")
+        self.assertEqual(self.char1.location.db.desc, "A dark cavern")
+
+    def test_rdesc_shows_description(self):
+        self.char1.location.db.desc = "Some desc"
+        self.char1.execute_cmd("rdesc")
+        self.char1.msg.assert_called_with("Some desc")
 
 
 class TestRoomSetCommand(EvenniaTest):

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -121,15 +121,29 @@ HELP_ENTRY_DICTS = [
         """,
     },
     {
-        "key": "rname",
+        "key": "rrename",
+        "aliases": ["roomrename", "renameroom", "rname"],
         "category": "building",
         "text": """
             Rename the room you are currently in.
 
             Usage:
-                rname <new name>
+                rrename <new name>
 
             Changes the name of the current room.
+        """,
+    },
+    {
+        "key": "rdesc",
+        "aliases": ["roomdesc"],
+        "category": "building",
+        "text": """
+            View or change the current room's description.
+
+            Usage:
+                rdesc <new description>
+
+            With no description given, shows the current one.
         """,
     },
     {


### PR DESCRIPTION
## Summary
- add rrename/roomdesc commands for builders
- document new builder commands
- update help entries
- test new builder functionality

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684189e84c10832cb908638e3f9689e6