### PR TITLE
Allow builders to modify stats and attributes

### DIFF
--- a/commands/admin.py
+++ b/commands/admin.py
@@ -15,7 +15,7 @@ class CmdSetStat(Command):
 
     key = "setstat"
     aliases = ("statset",)
-    locks = "cmd:perm(Admin)"
+    locks = "cmd:perm(Admin) or perm(Builder)"
     help_category = "admin"
 
     def func(self):
@@ -66,7 +66,7 @@ class CmdSetAttr(Command):
 
     key = "setattr"
     aliases = ("setattribute",)
-    locks = "cmd:perm(Admin)"
+    locks = "cmd:perm(Admin) or perm(Builder)"
     help_category = "admin"
 
     def func(self):
@@ -179,4 +179,15 @@ class AdminCmdSet(CmdSet):
         self.add(CmdSlay)
         self.add(CmdSmite)
         self.add(CmdScan)
+
+
+class BuilderCmdSet(CmdSet):
+    """Command set with builder utilities."""
+
+    key = "Builder CmdSet"
+
+    def at_cmdset_creation(self):
+        super().at_cmdset_creation()
+        self.add(CmdSetStat)
+        self.add(CmdSetAttr)
 

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -35,7 +35,7 @@ from commands.who import CmdWho
 from commands.building import CmdDig, CmdTeleport
 from commands.areas import AreaCmdSet
 from commands.room_flags import RoomFlagCmdSet
-from commands.admin import AdminCmdSet
+from commands.admin import AdminCmdSet, BuilderCmdSet
 
 
 class CharacterCmdSet(default_cmds.CharacterCmdSet):
@@ -71,6 +71,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(RoomFlagCmdSet)
         self.add(AreaCmdSet)
         self.add(AdminCmdSet)
+        self.add(BuilderCmdSet)
 
 
 class AccountCmdSet(default_cmds.AccountCmdSet):


### PR DESCRIPTION
## Summary
- permit builders to use `setstat` and `setattr`
- add optional `BuilderCmdSet` for builder-only commands
- update default cmdsets to include `BuilderCmdSet`

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68418d46e60c832c94b1bcfa2ea6514b