### PR TITLE
Add alias and shorthand mapping to setstat

### DIFF
--- a/commands/admin.py
+++ b/commands/admin.py
@@ -14,7 +14,7 @@ class CmdSetStat(Command):
     """
 
     key = "setstat"
-    aliases = ("statset",)
+    aliases = ("set",)
     locks = "cmd:perm(Admin) or perm(Builder)"
     help_category = "admin"
 
@@ -31,6 +31,8 @@ class CmdSetStat(Command):
         if not target:
             return
         value = int(value_str)
+        alias_map = {"hp": "health", "mp": "mana", "sp": "stamina"}
+        stat_key = alias_map.get(stat_key.lower(), stat_key)
         stat_key_up = stat_key.upper()
         if stat_key_up in CORE_STAT_KEYS:
             trait = target.traits.get(stat_key_up)

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -169,12 +169,21 @@ HELP_ENTRY_DICTS = [
     },
     {
         "key": "setstat",
+        "aliases": ["set"],
         "category": "admin",
         "text": """
             Change a character's stat directly.
 
             Usage:
                 setstat <target> <stat> <value>
+
+            Aliases:
+                set
+
+            The stat name accepts shorthands:
+                hp -> health
+                mp -> mana
+                sp -> stamina
 
             This modifies the target's stat permanently. Creating or adjusting
             stats incorrectly may break the character, so double-check your


### PR DESCRIPTION
## Summary
- make `CmdSetStat` respond to the alias `set`
- support hp/mp/sp shorthand in `setstat`
- document alias and shorthand usage in help

## Testing
- `evennia migrate`
- `pytest typeclasses/tests/test_admin_commands.py::TestAdminCommands::test_setstat_and_setattr_offline -q`
- `pytest -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68418e6418fc832c802214feaa9660ca