### PR TITLE
Add stat overrides

### DIFF
--- a/commands/admin.py
+++ b/commands/admin.py
@@ -47,14 +47,10 @@ class CmdSetStat(Command):
             self.msg(f"{stat_key_up} set to {value} on {target.key}.")
             return
         stat_key_low = stat_key.lower()
-        trait = target.traits.get(stat_key_low)
-        if trait:
-            trait.base = value
-        else:
-            target.traits.add(stat_key_low, stat_key_low, base=value)
-        data = target.db.derived_stats or {}
-        data[stat_key_low] = value
-        target.db.derived_stats = data
+        overrides = target.db.stat_overrides or {}
+        overrides[stat_key_low] = value
+        target.db.stat_overrides = overrides
+        stat_manager.refresh_stats(target)
         self.msg(f"{stat_key_low} set to {value} on {target.key}.")
 
 

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -29,6 +29,7 @@ class Character(ObjectParent, ClothedCharacter):
     gender = AttributeProperty("plural")
     guild = AttributeProperty("")
     guild_honor = AttributeProperty(0)
+    stat_overrides = AttributeProperty({})
 
     @property
     def guild_rank(self):
@@ -134,6 +135,7 @@ class Character(ObjectParent, ClothedCharacter):
 
         self.db.guild = ""
         self.db.guild_honor = 0
+        self.db.stat_overrides = {}
 
     def at_post_puppet(self, **kwargs):
         """Ensure stats refresh when a character is controlled."""

--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -400,6 +400,11 @@ class TestAdminCommands(EvenniaTest):
         self.char1.execute_cmd(f"setstat {self.char2.key} STR 12")
         self.assertEqual(self.char2.traits.STR.base, 12)
 
+    def test_setstat_derived(self):
+        self.char1.execute_cmd(f"setstat {self.char2.key} attack_power 50")
+        self.assertEqual(self.char2.db.stat_overrides.get("attack_power"), 50)
+        self.assertEqual(self.char2.db.derived_stats.get("attack_power"), 50)
+
     def test_setattr_and_bounty(self):
         self.char1.execute_cmd(f"setattr {self.char2.key} testattr foo")
         self.assertEqual(self.char2.db.testattr, "foo")

--- a/typeclasses/tests/test_stat_manager.py
+++ b/typeclasses/tests/test_stat_manager.py
@@ -62,6 +62,12 @@ class TestStatManager(EvenniaTest):
         for key in stats.CORE_STAT_KEYS:
             self.assertIn(key, char.db.base_primary_stats)
 
+    def test_stat_overrides(self):
+        char = self.char1
+        char.db.stat_overrides = {"attack_power": 123}
+        stat_manager.refresh_stats(char)
+        self.assertEqual(char.db.derived_stats.get("attack_power"), 123)
+
     def test_active_effect_modifiers(self):
         char = self.char1
         stat_manager.refresh_stats(char)

--- a/world/system/stat_manager.py
+++ b/world/system/stat_manager.py
@@ -141,6 +141,10 @@ def refresh_stats(obj) -> None:
             value += primary_totals.get(pkey, 0) * weight
         derived[dkey] = int(round(value))
 
+    overrides = getattr(obj.db, "stat_overrides", {}) or {}
+    for key, val in overrides.items():
+        derived[key] = val
+
     obj.db.derived_stats = derived
     obj.db.primary_stats = primary_totals
 


### PR DESCRIPTION
## Summary
- allow storing stat overrides on characters
- honor stat overrides when computing derived stats
- update CmdSetStat to save derived stat values in overrides
- test for overrides

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68419033508c832c83777c5984564abe