### PR TITLE
Add admin restoreall command

### DIFF
--- a/commands/admin.py
+++ b/commands/admin.py
@@ -164,6 +164,31 @@ class CmdSmite(Command):
         self.msg(f"You smite {target.key}, leaving them on the brink of death.")
 
 
+class CmdRestoreAll(Command):
+    """Fully restore all player characters."""
+
+    key = "restoreall"
+    locks = "cmd:perm(Admin)"
+    help_category = "admin"
+
+    def func(self):
+        from typeclasses.characters import PlayerCharacter
+
+        for pc in PlayerCharacter.objects.all():
+            if pc.traits.get("health"):
+                pc.traits.health.reset()
+            if pc.traits.get("mana"):
+                pc.traits.mana.reset()
+            if pc.traits.get("stamina"):
+                pc.traits.stamina.reset()
+            pc.tags.clear(category="buff")
+            pc.tags.clear(category="status")
+            pc.db.status_effects = {}
+            pc.db.temp_bonuses = {}
+            pc.db.active_effects = {}
+        self.msg("All player characters fully restored.")
+
+
 class AdminCmdSet(CmdSet):
     """Command set with admin utilities."""
 
@@ -176,6 +201,7 @@ class AdminCmdSet(CmdSet):
         self.add(CmdSetBounty)
         self.add(CmdSlay)
         self.add(CmdSmite)
+        self.add(CmdRestoreAll)
         self.add(CmdScan)
 
 

--- a/typeclasses/tests/test_admin_commands.py
+++ b/typeclasses/tests/test_admin_commands.py
@@ -56,8 +56,22 @@ class TestAdminCommands(EvenniaTest):
         self.assertIn("HP", admin_out)
 
     def test_help_entries_exist(self):
-        for cmd in ("slay", "smite", "setstat", "setattr", "scan"):
+        for cmd in ("slay", "smite", "setstat", "setattr", "scan", "restoreall"):
             self.char1.msg.reset_mock()
             self.char1.execute_cmd(f"help {cmd}")
             self.assertTrue(self.char1.msg.called)
+
+    def test_restoreall(self):
+        self.char1.traits.health.current = 10
+        self.char2.traits.mana.current = 5
+        self.char1.tags.add("speed", category="buff")
+        self.char2.tags.add("sleeping", category="status")
+        self.char_other.traits.stamina.current = 1
+        self.char1.execute_cmd("restoreall")
+        for pc in (self.char1, self.char2, self.char_other):
+            self.assertEqual(pc.traits.health.current, pc.traits.health.max)
+            self.assertEqual(pc.traits.mana.current, pc.traits.mana.max)
+            self.assertEqual(pc.traits.stamina.current, pc.traits.stamina.max)
+            self.assertFalse(pc.tags.get(category="buff", return_list=True))
+            self.assertFalse(pc.tags.get(category="status", return_list=True))
 

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -260,4 +260,14 @@ HELP_ENTRY_DICTS = [
             responsibly and avoid revealing secret data to regular players.
         """,
     },
+    {
+        "key": "restoreall",
+        "category": "admin",
+        "text": """
+            Fully heal every player and remove all buffs and status effects.
+
+            Usage:
+                restoreall
+        """,
+    },
 ]


### PR DESCRIPTION
## Summary
- implement `CmdRestoreAll` to heal players and remove all active effects
- include command in `AdminCmdSet`
- document in admin help
- test command

## Testing
- `evennia migrate` *(sets up database)*
- `pytest -q` *(fails: OperationalError due to missing default home)*

------
https://chatgpt.com/codex/tasks/task_e_68419301b438832c926e983175faca21