### PR TITLE
Add mass revive command

### DIFF
--- a/commands/combat.py
+++ b/commands/combat.py
@@ -286,9 +286,11 @@ class CmdRevive(Command):
 
     Usage:
         revive <player>
+        revive all
     """
 
     key = "revive"
+    aliases = ("resurrect",)
     help_category = "combat"
 
     def func(self):
@@ -298,7 +300,24 @@ class CmdRevive(Command):
             self.msg("Revive who?")
             return
 
-        target = caller.search(self.args.strip())
+        arg = self.args.strip()
+
+        if arg.lower() == "all":
+            from evennia.utils.search import search_tag
+
+            targets = [
+                obj
+                for obj in search_tag(key="unconscious", category="status")
+                if hasattr(obj, "revive")
+            ]
+            if not targets:
+                self.msg("No one is unconscious.")
+                return
+            for target in targets:
+                target.revive(caller)
+            return
+
+        target = caller.search(arg)
         if not target:
             return
 

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -270,4 +270,18 @@ HELP_ENTRY_DICTS = [
                 restoreall
         """,
     },
+    {
+        "key": "revive",
+        "aliases": ["resurrect"],
+        "category": "combat",
+        "text": """
+            Revive a defeated player at partial health.
+
+            Usage:
+                revive <player>
+                revive all
+
+            Using |wall|n revives every unconscious character in the game.
+        """,
+    },
 ]


### PR DESCRIPTION
## Summary
- allow `revive all` to revive every unconscious character
- add command alias `resurrect`
- document the new behaviour in help entries

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684195ef06cc832cbbff98347546d078