### PR TITLE
Add purge admin command

### DIFF
--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -271,6 +271,21 @@ HELP_ENTRY_DICTS = [
         """,
     },
     {
+        "key": "purge",
+        "category": "admin",
+        "text": """
+            Delete unwanted objects.
+
+            Usage:
+                purge
+                purge <target>
+
+            Without arguments, removes everything in the current room
+            except for you. When given a target it deletes that object.
+            Players, rooms and exits are protected from being purged.
+        """,
+    },
+    {
         "key": "revive",
         "aliases": ["resurrect"],
         "category": "combat",


### PR DESCRIPTION
## Summary
- add `CmdPurge` to remove objects from a room or delete a target
- register command in `AdminCmdSet`
- document `purge` in help entries

## Testing
- `pytest -q` *(fails: OperationalError - no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68419760a334832cabc4de2c92162f80