### PR TITLE
Implement hunger system

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -136,6 +136,7 @@ class Character(ObjectParent, ClothedCharacter):
         self.db.guild = ""
         self.db.guild_honor = 0
         self.db.stat_overrides = {}
+        self.db.sated = 5
 
     def at_post_puppet(self, **kwargs):
         """Ensure stats refresh when a character is controlled."""
@@ -184,6 +185,8 @@ class Character(ObjectParent, ClothedCharacter):
         if carry_weight > carry_capacity and carry_capacity > 0:
             excess = carry_weight - carry_capacity
             cost += excess // 10
+        if self.tags.has("hungry_thirsty", category="status"):
+            cost += 1
         if self.traits.stamina:
             self.traits.stamina.current = max(
                 self.traits.stamina.current - cost, 0

--- a/typeclasses/scripts.py
+++ b/typeclasses/scripts.py
@@ -250,8 +250,7 @@ class GlobalTick(Script):
         for obj in search_tag(key="tickable"):
             if hasattr(obj, "at_tick"):
                 obj.at_tick()
+            state_manager.tick_character(obj)
 
         for pc in PlayerCharacter.objects.all():
             pc.refresh_prompt()
-
-        state_manager.tick_all()

--- a/typeclasses/tests/test_characters.py
+++ b/typeclasses/tests/test_characters.py
@@ -91,13 +91,13 @@ class TestGlobalTick(EvenniaTest):
         self.char1.at_tick = MagicMock()
         self.char1.refresh_prompt = MagicMock()
         from world.system import state_manager
-        state_manager.tick_all = MagicMock()
+        state_manager.tick_character = MagicMock()
 
         script.at_repeat()
 
         self.char1.at_tick.assert_called_once()
         self.char1.refresh_prompt.assert_called()
-        state_manager.tick_all.assert_called_once()
+        state_manager.tick_character.assert_called_once_with(self.char1)
 
 
 class TestRegeneration(EvenniaTest):

--- a/typeclasses/tests/test_state_manager.py
+++ b/typeclasses/tests/test_state_manager.py
@@ -41,3 +41,12 @@ class TestStateManager(EvenniaTest):
         state_manager.tick_character(char)
         entry_after = char.db.temp_bonuses["STR"][0]
         self.assertEqual(entry_after["key"], "speed")
+
+    def test_sated_and_hungry_effect(self):
+        char = self.char1
+        char.db.sated = 1
+        hp = char.traits.health.current
+        state_manager.tick_character(char)
+        self.assertEqual(char.db.sated, 0)
+        self.assertTrue(char.tags.has("hungry_thirsty", category="status"))
+        self.assertEqual(char.traits.health.current, hp - 1)

--- a/utils/stats_utils.py
+++ b/utils/stats_utils.py
@@ -120,8 +120,16 @@ def get_display_scroll(chara):
     else:
         hp_disp = mp_disp = sp_disp = "--/--"
 
+    sated_val = int(_db_get(chara, "sated", 0) or 0)
+    if sated_val <= 0:
+        sated_disp = "|r0 (URGENT)|n"
+    elif sated_val < 5:
+        sated_disp = f"|y{sated_val}|n"
+    else:
+        sated_disp = f"|g{sated_val}|n"
+
     lines.append(
-        f"|YLvl {level}|n  |CXP|n {xp}  |rHP|n {hp_disp}  |cMP|n {mp_disp}  |gSP|n {sp_disp}"
+        f"|YLvl {level}|n  |CXP|n {xp}  |rHP|n {hp_disp}  |cMP|n {mp_disp}  |gSP|n {sp_disp}  |ySated|n {sated_disp}"
     )
 
     coins = _db_get(chara, "coins", 0)

--- a/utils/tests/test_stats_utils.py
+++ b/utils/tests/test_stats_utils.py
@@ -1,0 +1,11 @@
+from evennia.utils.test_resources import EvenniaTest
+from utils.stats_utils import get_display_scroll
+
+
+class TestDisplayScroll(EvenniaTest):
+    def test_sated_display(self):
+        char = self.char1
+        char.db.sated = 0
+        sheet = get_display_scroll(char)
+        self.assertIn("Sated", sheet)
+        self.assertIn("URGENT", sheet)

--- a/world/effects.py
+++ b/world/effects.py
@@ -59,4 +59,10 @@ EFFECTS: Dict[str, Effect] = {
         desc="You are sprawled on the ground.",
         type="status",
     ),
+    "hungry_thirsty": Effect(
+        key="hungry_thirsty",
+        name="Hungry & Thirsty",
+        desc="You are weakened from hunger and thirst.",
+        type="status",
+    ),
 }

--- a/world/system/state_manager.py
+++ b/world/system/state_manager.py
@@ -205,6 +205,17 @@ def tick_character(chara):
         _save_status_dict(chara, statuses)
         stat_manager.refresh_stats(chara)
 
+    # Hunger and thirst
+    if hasattr(chara.db, "sated"):
+        sated = chara.db.sated or 0
+        if sated > 0:
+            chara.db.sated = sated - 1
+        if chara.db.sated <= 0:
+            chara.db.sated = 0
+            add_effect(chara, "hungry_thirsty", 1)
+            if (hp := chara.traits.get("health")):
+                hp.current = max(hp.current - 1, 0)
+
 
 def tick_all():
     """Tick timers for all characters."""


### PR DESCRIPTION
## Summary
- add hunger-tracking attribute `sated`
- create new Hungry & Thirsty effect
- drain sated and health each tick
- show Sated value on the score sheet
- adjust movement cost when hungry
- update global tick and tests

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68419a569f5c832c8a10ac729b221057