### PR TITLE
Add builder attribute commands

### DIFF
--- a/commands/README.md
+++ b/commands/README.md
@@ -35,3 +35,13 @@ Builders can tweak the current room with a few simple commands:
   argument it will show the current description.
 * `rset area <area>` or `rset id <number>` - assign the room to an
   area or change its id within that area.
+
+## Object Editing Commands
+
+Builders and admins can adjust object attributes with these commands:
+
+* `setdesc <target> <description>` - change an object's description.
+* `setweight <target> <value>` - assign a numeric carry weight.
+* `setslot <target> <slot>` - set the slot or clothing type.
+* `setdamage <target> <amount>` - set the object's damage value.
+* `setbuff <target> <buff>` - label the object with a buff identifier.

--- a/commands/admin.py
+++ b/commands/admin.py
@@ -1,6 +1,13 @@
 from evennia import CmdSet, create_object
 from .command import Command
 from .info import CmdScan
+from .building import (
+    CmdSetDesc,
+    CmdSetWeight,
+    CmdSetSlot,
+    CmdSetDamage,
+    CmdSetBuff,
+)
 from world.stats import CORE_STAT_KEYS
 from world.system import stat_manager
 
@@ -416,4 +423,9 @@ class BuilderCmdSet(CmdSet):
         self.add(CmdCArmor)
         self.add(CmdCTool)
         self.add(CmdCGear)
+        self.add(CmdSetDesc)
+        self.add(CmdSetWeight)
+        self.add(CmdSetSlot)
+        self.add(CmdSetDamage)
+        self.add(CmdSetBuff)
 

--- a/commands/building.py
+++ b/commands/building.py
@@ -184,3 +184,114 @@ class CmdTeleport(Command):
             return
         self.caller.move_to(room, quiet=True, move_type="teleport")
         self.msg(f"Teleported to {room.get_display_name(self.caller)}.")
+
+
+class CmdSetDesc(Command):
+    """Set an object's description."""
+
+    key = "setdesc"
+    locks = "cmd:perm(Admin) or perm(Builder)"
+    help_category = "Building"
+
+    def func(self):
+        if not self.args:
+            self.msg("Usage: setdesc <target> <description>")
+            return
+        target_name, *desc_parts = self.args.split(None, 1)
+        if not desc_parts:
+            self.msg("Usage: setdesc <target> <description>")
+            return
+        target = self.caller.search(target_name, global_search=True)
+        if not target:
+            return
+        target.db.desc = desc_parts[0].strip()
+        self.msg(f"Description set on {target.key}.")
+
+
+class CmdSetWeight(Command):
+    """Set an object's weight."""
+
+    key = "setweight"
+    locks = "cmd:perm(Admin) or perm(Builder)"
+    help_category = "Building"
+
+    def func(self):
+        if not self.args:
+            self.msg("Usage: setweight <target> <value>")
+            return
+        parts = self.args.split(None, 1)
+        if len(parts) != 2 or not parts[1].isdigit():
+            self.msg("Usage: setweight <target> <value>")
+            return
+        target = self.caller.search(parts[0], global_search=True)
+        if not target:
+            return
+        target.db.weight = int(parts[1])
+        self.msg(f"Weight on {target.key} set to {parts[1]}.")
+
+
+class CmdSetSlot(Command):
+    """Set an object's slot attribute."""
+
+    key = "setslot"
+    locks = "cmd:perm(Admin) or perm(Builder)"
+    help_category = "Building"
+
+    def func(self):
+        if not self.args:
+            self.msg("Usage: setslot <target> <slot>")
+            return
+        parts = self.args.split(None, 1)
+        if len(parts) != 2:
+            self.msg("Usage: setslot <target> <slot>")
+            return
+        target = self.caller.search(parts[0], global_search=True)
+        if not target:
+            return
+        target.db.slot = parts[1].strip()
+        self.msg(f"Slot on {target.key} set to {parts[1].strip()}.")
+
+
+class CmdSetDamage(Command):
+    """Set an object's damage value."""
+
+    key = "setdamage"
+    locks = "cmd:perm(Admin) or perm(Builder)"
+    help_category = "Building"
+
+    def func(self):
+        if not self.args:
+            self.msg("Usage: setdamage <target> <amount>")
+            return
+        parts = self.args.split(None, 1)
+        if len(parts) != 2 or not parts[1].lstrip("-+").isdigit():
+            self.msg("Usage: setdamage <target> <amount>")
+            return
+        target = self.caller.search(parts[0], global_search=True)
+        if not target:
+            return
+        target.db.dmg = int(parts[1])
+        self.msg(f"Damage on {target.key} set to {parts[1]}.")
+
+
+class CmdSetBuff(Command):
+    """Set a buff identifier on a target."""
+
+    key = "setbuff"
+    locks = "cmd:perm(Admin) or perm(Builder)"
+    help_category = "Building"
+
+    def func(self):
+        if not self.args:
+            self.msg("Usage: setbuff <target> <buff>")
+            return
+        parts = self.args.split(None, 1)
+        if len(parts) != 2:
+            self.msg("Usage: setbuff <target> <buff>")
+            return
+        target = self.caller.search(parts[0], global_search=True)
+        if not target:
+            return
+        target.db.buff = parts[1].strip()
+        self.msg(f"Buff on {target.key} set to {parts[1].strip()}.")
+


### PR DESCRIPTION
## Summary
- allow editing object attributes with new commands
- document builder editing commands
- include new commands in Builder cmdset

## Testing
- `python -m py_compile commands/building.py commands/admin.py`
- `pytest -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6841a42e62a0832ca36ffa0aee6002e4