### PR TITLE
Add item inspection command

### DIFF
--- a/commands/info.py
+++ b/commands/info.py
@@ -181,6 +181,43 @@ class CmdEquipment(Command):
                 self.msg(line)
 
 
+class CmdInspect(Command):
+    """Inspect an item for detailed information."""
+
+    key = "inspect"
+    help_category = "general"
+
+    def func(self):
+        caller = self.caller
+        if not self.args:
+            caller.msg("Usage: inspect <item>")
+            return
+
+        obj = caller.search(self.args.strip())
+        if not obj:
+            return
+
+        lines = [f"|w{obj.get_display_name(caller)}|n"]
+        desc = obj.db.desc or "You see nothing special."
+        lines.append(desc)
+
+        if obj.db.identified:
+            if (weight := obj.db.weight) is not None:
+                lines.append(f"Weight: {weight}")
+            if (dmg := obj.db.dmg) is not None:
+                lines.append(f"Damage: {dmg}")
+            slot = obj.db.slot or obj.db.clothing_type
+            if slot:
+                lines.append(f"Slot: {slot}")
+            if (buff := obj.db.buff):
+                lines.append(f"Buff: {buff}")
+            flags = obj.tags.get(category="flag", return_list=True) or []
+            if flags:
+                lines.append("Flags: " + ", ".join(sorted(flags)))
+
+        caller.msg("\n".join(lines))
+
+
 class CmdBuffs(Command):
     """List active buff effects."""
 
@@ -395,6 +432,7 @@ class InfoCmdSet(CmdSet):
         self.add(CmdFinger)
         self.add(CmdBounty)
         self.add(CmdInventory)
+        self.add(CmdInspect)
         self.add(CmdEquipment)
         self.add(CmdAffects)
         self.add(CmdBuffs)

--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -108,6 +108,31 @@ class TestInfoCommands(EvenniaTest):
         self.char1.execute_cmd("equipment")
         self.assertTrue(self.char1.msg.called)
 
+    def test_inspect_identified(self):
+        self.obj1.db.desc = "A sharp blade."
+        self.obj1.db.weight = 2
+        self.obj1.db.dmg = 5
+        self.obj1.db.slot = "hand"
+        self.obj1.db.buff = "speed"
+        self.obj1.db.identified = True
+        self.obj1.tags.add("equipment", category="flag")
+        self.char1.execute_cmd(f"inspect {self.obj1.key}")
+        out = self.char1.msg.call_args[0][0]
+        self.assertIn("A sharp blade.", out)
+        self.assertIn("Weight: 2", out)
+        self.assertIn("Damage: 5", out)
+        self.assertIn("Slot: hand", out)
+        self.assertIn("Buff: speed", out)
+        self.assertIn("equipment", out)
+
+    def test_inspect_unidentified(self):
+        self.obj1.db.desc = "A mystery item."
+        self.obj1.db.identified = False
+        self.char1.execute_cmd(f"inspect {self.obj1.key}")
+        out = self.char1.msg.call_args[0][0]
+        self.assertIn("A mystery item.", out)
+        self.assertNotIn("Weight:", out)
+
     def test_buffs(self):
         self.char1.execute_cmd("buffs")
         self.assertTrue(self.char1.msg.called)

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -99,6 +99,20 @@ HELP_ENTRY_DICTS = [
         """,
     },
     {
+        "key": "inspect",
+        "category": "General",
+        "text": """
+            Examine an item for more information.
+
+            Usage:
+                inspect <item>
+
+            Identified items reveal their weight, damage, slots,
+            buffs and any flags. Unidentified items only show a brief
+            description.
+        """,
+    },
+    {
         "key": "room flags",
         "aliases": ["rflags", "rflag"],
         "category": "building",


### PR DESCRIPTION
## Summary
- add `inspect` command to reveal item information
- document command in help entries
- cover new behavior with tests

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6841a7fa80e8832cad2e043b1c6d1f4a