### PR TITLE
Fix wield message

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -295,7 +295,7 @@ class Character(ObjectParent, ClothedCharacter):
                 else:
                     # a weapon was found, provide this information
                     self.msg(
-                        f"You are already wielding {weap.get_display_name(self)} in your {key}."
+                        f"You are already wielding {weap.get_display_name(self)} in your {hand}."
                     )
                 return
         elif not free:


### PR DESCRIPTION
## Summary
- use `{hand}` instead of `{key}` so the wield message references the correct hand

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68420a5d28b4832c90bb3766407c71b3