### PR TITLE
Update display scroll coin handling

### DIFF
--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -70,12 +70,10 @@ class TestInfoCommands(EvenniaTest):
 
     def test_score(self):
         self.char1.db.title = "Tester"
-        self.char1.db.coins = {
-            "copper": 10,
-            "silver": 2,
-            "gold": 1,
-            "platinum": 0,
-        }
+        self.char1.db.copper = 10
+        self.char1.db.silver = 2
+        self.char1.db.gold = 1
+        self.char1.db.platinum = 0
         self.char1.execute_cmd("score")
         self.assertTrue(self.char1.msg.called)
         args = self.char1.msg.call_args[0][0]

--- a/utils/stats_utils.py
+++ b/utils/stats_utils.py
@@ -12,7 +12,6 @@ from world.stats import (
     apply_stats,
 )
 from world.system import stat_manager
-from utils.currency import from_copper
 import math
 import re
 
@@ -137,9 +136,12 @@ def get_display_scroll(chara):
     )
     lines.append(f"|ySated|n {sated_disp}")
 
-    coins = _db_get(chara, "coins", 0)
-    if isinstance(coins, int):
-        coins = from_copper(coins)
+    coins = {
+        "copper": _db_get(chara, "copper", 0),
+        "silver": _db_get(chara, "silver", 0),
+        "gold": _db_get(chara, "gold", 0),
+        "platinum": _db_get(chara, "platinum", 0),
+    }
     copper = int(coins.get("copper", 0))
     silver = int(coins.get("silver", 0))
     gold = int(coins.get("gold", 0))

--- a/utils/tests/__init__.py
+++ b/utils/tests/__init__.py
@@ -1,0 +1,14 @@
+"""Test package setup for Evennia."""
+
+import os
+import django
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "server.conf.settings")
+django.setup()
+
+# Ensure Evennia fully initializes so SESSION_HANDLER and other globals exist
+import evennia
+
+if getattr(evennia, "SESSION_HANDLER", None) is None:
+    evennia._init()
+


### PR DESCRIPTION
## Summary
- show copper/silver/gold/platinum coins individually in `get_display_scroll`
- adjust `test_score` for new attributes
- configure utils tests to initialize Evennia

## Testing
- `evennia migrate` *(fails: OperationalError - no such table)*

------
https://chatgpt.com/codex/tasks/task_e_68423fa6f740832c8388bfd8240132f0