### PR TITLE
Add optional weight handling for gear

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -99,7 +99,8 @@ class Character(ObjectParent, ClothedCharacter):
         for obj in self.contents:
             if obj.db.worn:
                 continue
-            weight += getattr(obj.db, "weight", 1)
+            w = getattr(obj.db, "weight", 0)
+            weight += w if isinstance(w, (int, float)) else 0
         self.db.carry_weight = weight
 
     def encumbrance_level(self):

--- a/typeclasses/objects.py
+++ b/typeclasses/objects.py
@@ -181,8 +181,8 @@ class Object(ObjectParent, DefaultObject):
     def at_object_creation(self):
         """Set default attributes when object is first created."""
         super().at_object_creation()
-        if self.db.weight is None:
-            self.db.weight = 1
+        if getattr(self.db, "weight", None) is None:
+            self.db.weight = 0
 
     def at_drop(self, dropper, **kwargs):
         """

--- a/typeclasses/tests/test_objects_basic.py
+++ b/typeclasses/tests/test_objects_basic.py
@@ -7,7 +7,7 @@ from evennia.utils.test_resources import EvenniaTest
 class TestObjectCreation(EvenniaTest):
     def test_default_weight_on_creation(self):
         obj = create_object("typeclasses.objects.Object", key="widget")
-        self.assertEqual(obj.db.weight, 1)
+        self.assertEqual(obj.db.weight, 0)
 
     def test_weight_not_overwritten(self):
         obj = create_object("typeclasses.objects.Object", key="stone")


### PR DESCRIPTION
## Summary
- allow `_create_gear` to set `weight` and parse optional weight in builder commands
- support setting weight in `ocreate` and `ctool`
- default item weight to 0 in `Object.at_object_creation`
- handle invalid weights gracefully when computing carry weight
- adjust tests for new default weight

## Testing
- `pytest -q` *(fails: no such table `accounts_accountdb`)*

------
https://chatgpt.com/codex/tasks/task_e_684242c57a7c832ca4139c982af52ac8