### PR TITLE
Add basic guild system

### DIFF
--- a/commands/guilds.py
+++ b/commands/guilds.py
@@ -1,8 +1,16 @@
 from evennia import CmdSet, search_object
 from evennia.utils.evtable import EvTable
+from evennia.utils.utils import make_iter
 
 from .command import Command
-from world.guilds import GUILDS, get_rank_title
+from world.guilds import (
+    Guild,
+    get_guilds,
+    save_guild,
+    update_guild,
+    find_guild,
+    get_rank_title,
+)
 
 
 class CmdGuild(Command):
@@ -27,15 +35,14 @@ class CmdGuild(Command):
         if not guild:
             self.msg("You are not a member of any guild.")
             return
-        info = GUILDS.get(guild, {})
-        crest = info.get("crest", "")
-        motd = info.get("motd", "")
+        _, gobj = find_guild(guild)
+        desc = gobj.desc if gobj else ""
         rank = get_rank_title(guild, honor)
-        self.msg(f"|w{guild}|n {crest}")
+        self.msg(f"|w{guild}|n")
         self.msg(f"Rank: {rank}")
         self.msg(f"Honor: {honor}")
-        if motd:
-            self.msg(motd)
+        if desc:
+            self.msg(desc)
 
 
 class CmdGuildWho(Command):
@@ -49,7 +56,8 @@ class CmdGuildWho(Command):
         guildwho
     """
 
-    key = "guildwho"
+    key = "gwho"
+    aliases = ("guildwho",)
     help_category = "general"
 
     def func(self):
@@ -75,6 +83,272 @@ class CmdGuildWho(Command):
         self.msg(str(table))
 
 
+class CmdGCreate(Command):
+    """Create a new guild and register it."""
+
+    key = "gcreate"
+    locks = "cmd:perm(Builder)"
+    help_category = "Building"
+
+    def func(self):
+        if not self.args:
+            self.msg("Usage: gcreate <name>")
+            return
+        name = self.args.strip()
+        _, existing = find_guild(name)
+        if existing:
+            self.msg("Guild already exists.")
+            return
+        guild = Guild(name=name)
+        save_guild(guild)
+        self.msg(f"Guild '{name}' created.")
+
+
+class CmdGRank(Command):
+    """Manage guild rank titles."""
+
+    key = "grank"
+    locks = "cmd:perm(Builder)"
+    help_category = "Building"
+
+    def func(self):
+        if not self.args:
+            self.msg("Usage: grank add/remove/list <guild> [level title]")
+            return
+        parts = self.args.split(None, 2)
+        if len(parts) < 2:
+            self.msg("Usage: grank add/remove/list <guild> [level title]")
+            return
+        action, guild_name = parts[0], parts[1]
+        idx, guild = find_guild(guild_name)
+        if guild is None:
+            self.msg("Unknown guild.")
+            return
+        action = action.lower()
+        if action == "list":
+            if not guild.ranks:
+                self.msg("No ranks defined.")
+                return
+            table = EvTable("Level", "Title", border="none")
+            for lvl, title in guild.ranks:
+                table.add_row(str(lvl), title)
+            self.msg(str(table))
+            return
+        if len(parts) < 3:
+            self.msg("Usage: grank add/remove <guild> <level> [title]")
+            return
+        rest = parts[2]
+        if action == "add":
+            lvl_title = rest.split(None, 1)
+            if len(lvl_title) < 2 or not lvl_title[0].isdigit():
+                self.msg("Usage: grank add <guild> <level> <title>")
+                return
+            level = int(lvl_title[0])
+            title = lvl_title[1]
+            guild.ranks.append((level, title))
+            guild.ranks.sort(key=lambda r: r[0])
+            update_guild(idx, guild)
+            self.msg("Rank added.")
+        elif action == "remove":
+            if not rest.isdigit():
+                self.msg("Usage: grank remove <guild> <level>")
+                return
+            level = int(rest)
+            guild.ranks = [r for r in guild.ranks if r[0] != level]
+            update_guild(idx, guild)
+            self.msg("Rank removed.")
+        else:
+            self.msg("Usage: grank add/remove/list <guild> ...")
+
+
+class CmdGSetHome(Command):
+    """Set the home location for a guild."""
+
+    key = "gsethome"
+    locks = "cmd:perm(Builder)"
+    help_category = "Building"
+
+    def func(self):
+        if not self.args:
+            self.msg("Usage: gsethome <guild>")
+            return
+        guild_name = self.args.strip()
+        idx, guild = find_guild(guild_name)
+        if guild is None:
+            self.msg("Unknown guild.")
+            return
+        if not self.caller.location:
+            self.msg("No location to set as home.")
+            return
+        guild.home = self.caller.location.id
+        update_guild(idx, guild)
+        self.msg(f"Home for {guild.name} set to {self.caller.location.key}.")
+
+
+class CmdGDesc(Command):
+    """Set the description of a guild."""
+
+    key = "gdesc"
+    locks = "cmd:perm(Builder)"
+    help_category = "Building"
+
+    def func(self):
+        if not self.args:
+            self.msg("Usage: gdesc <guild> <description>")
+            return
+        parts = self.args.split(None, 1)
+        if len(parts) < 2:
+            self.msg("Usage: gdesc <guild> <description>")
+            return
+        guild_name, desc = parts
+        idx, guild = find_guild(guild_name)
+        if guild is None:
+            self.msg("Unknown guild.")
+            return
+        guild.desc = desc
+        update_guild(idx, guild)
+        self.msg(f"Description for {guild.name} updated.")
+
+
+class CmdGJoin(Command):
+    """Request to join a guild."""
+
+    key = "gjoin"
+    help_category = "general"
+
+    def func(self):
+        if not self.args:
+            self.msg("Usage: gjoin <guild>")
+            return
+        if self.caller.db.guild:
+            self.msg("You are already in a guild.")
+            return
+        guild_name = self.args.strip()
+        _, guild = find_guild(guild_name)
+        if guild is None:
+            self.msg("Unknown guild.")
+            return
+        self.caller.db.guild_request = guild.name
+        self.msg(f"You request to join {guild.name}.")
+
+
+class CmdGAccept(Command):
+    """Accept a player's join request."""
+
+    key = "gaccept"
+    help_category = "general"
+
+    def func(self):
+        if not self.args:
+            self.msg("Usage: gaccept <player>")
+            return
+        guild = self.caller.db.guild
+        if not guild:
+            self.msg("You are not in a guild.")
+            return
+        target = self.caller.search(self.args.strip(), global_search=True)
+        if not target:
+            return
+        if target.db.guild:
+            self.msg("That player is already in a guild.")
+            return
+        if target.db.guild_request != guild:
+            self.msg(f"{target.key} has not requested to join {guild}.")
+            return
+        idx, gobj = find_guild(guild)
+        if gobj is None:
+            self.msg("Unknown guild.")
+            return
+        gobj.members[str(target.id)] = 0
+        update_guild(idx, gobj)
+        target.db.guild = guild
+        target.db.guild_honor = 0
+        target.db.guild_request = None
+        self.msg(f"{target.key} is now a member of {guild}.")
+
+
+class _BaseAdjustHonor(Command):
+    locks = "cmd:all()"
+    help_category = "general"
+
+    def adjust(self, amount: int):
+        if not self.args:
+            self.msg(f"Usage: {self.key} <player> [amount]")
+            return
+        guild = self.caller.db.guild
+        if not guild:
+            self.msg("You are not in a guild.")
+            return
+        parts = self.args.split(None, 1)
+        target = self.caller.search(parts[0], global_search=True)
+        if not target:
+            return
+        if target.db.guild != guild:
+            self.msg("They are not in your guild.")
+            return
+        amt = 1
+        if len(parts) > 1 and parts[1].lstrip("-+").isdigit():
+            amt = int(parts[1])
+        honor = target.db.guild_honor or 0
+        honor += amount * amt
+        if honor < 0:
+            honor = 0
+        target.db.guild_honor = honor
+        idx, gobj = find_guild(guild)
+        if gobj:
+            gobj.members[str(target.id)] = honor
+            update_guild(idx, gobj)
+        self.msg(f"{target.key} now has honor {honor}.")
+
+
+class CmdGPromote(_BaseAdjustHonor):
+    """Increase a member's guild honor."""
+
+    key = "gpromote"
+
+    def func(self):
+        self.adjust(1)
+
+
+class CmdGDemote(_BaseAdjustHonor):
+    """Decrease a member's guild honor."""
+
+    key = "gdemote"
+
+    def func(self):
+        self.adjust(-1)
+
+
+class CmdGKick(Command):
+    """Remove a member from your guild."""
+
+    key = "gkick"
+    help_category = "general"
+
+    def func(self):
+        if not self.args:
+            self.msg("Usage: gkick <player>")
+            return
+        guild = self.caller.db.guild
+        if not guild:
+            self.msg("You are not in a guild.")
+            return
+        target = self.caller.search(self.args.strip(), global_search=True)
+        if not target:
+            return
+        if target.db.guild != guild:
+            self.msg("They are not in your guild.")
+            return
+        idx, gobj = find_guild(guild)
+        if gobj and str(target.id) in gobj.members:
+            del gobj.members[str(target.id)]
+            update_guild(idx, gobj)
+        target.db.guild = ""
+        target.db.guild_honor = 0
+        target.db.guild_request = None
+        self.msg(f"{target.key} has been kicked from {guild}.")
+
+
 class GuildCmdSet(CmdSet):
     key = "Guild CmdSet"
 
@@ -82,4 +356,13 @@ class GuildCmdSet(CmdSet):
         super().at_cmdset_creation()
         self.add(CmdGuild)
         self.add(CmdGuildWho)
+        self.add(CmdGCreate)
+        self.add(CmdGRank)
+        self.add(CmdGSetHome)
+        self.add(CmdGDesc)
+        self.add(CmdGJoin)
+        self.add(CmdGAccept)
+        self.add(CmdGPromote)
+        self.add(CmdGDemote)
+        self.add(CmdGKick)
 

--- a/typeclasses/tests/test_guild_commands.py
+++ b/typeclasses/tests/test_guild_commands.py
@@ -1,0 +1,45 @@
+from unittest.mock import MagicMock
+from evennia.utils.test_resources import EvenniaTest
+from django.test import override_settings
+
+from commands.guilds import GuildCmdSet
+from world.guilds import find_guild
+
+
+@override_settings(DEFAULT_HOME=None)
+class TestGuildCommands(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.char1.msg = MagicMock()
+        self.char2.msg = MagicMock()
+        self.char1.cmdset.add_default(GuildCmdSet)
+        self.char2.cmdset.add_default(GuildCmdSet)
+        # give char1 builder perms for management commands
+        self.char1.permissions.add("Builder")
+
+    def test_create_and_membership(self):
+        # create a guild
+        self.char1.execute_cmd("gcreate testguild")
+        idx, guild = find_guild("testguild")
+        self.assertNotEqual(idx, -1)
+        # add char1 as initial member
+        guild.members[str(self.char1.id)] = 0
+        from world.guilds import update_guild
+        update_guild(idx, guild)
+        self.char1.db.guild = "testguild"
+        self.char1.db.guild_honor = 0
+
+        # char2 requests to join
+        self.char2.execute_cmd("gjoin testguild")
+        self.assertEqual(self.char2.db.guild_request, "testguild")
+
+        # char1 accepts
+        self.char1.execute_cmd(f"gaccept {self.char2.key}")
+        self.assertEqual(self.char2.db.guild, "testguild")
+        self.assertIsNone(self.char2.db.guild_request)
+
+        # promote and then kick
+        self.char1.execute_cmd(f"gpromote {self.char2.key} 5")
+        self.assertEqual(self.char2.db.guild_honor, 5)
+        self.char1.execute_cmd(f"gkick {self.char2.key}")
+        self.assertEqual(self.char2.db.guild, "")

--- a/world/guilds.py
+++ b/world/guilds.py
@@ -1,5 +1,10 @@
 """Guild definitions and utilities."""
 
+from dataclasses import dataclass, asdict, field
+from typing import Dict, List, Optional, Tuple
+
+from evennia.server.models import ServerConfig
+
 ADVENTURERS_GUILD_RANKS = [
     (0, "Private"),
     (10, "Corporal"),
@@ -13,6 +18,81 @@ ADVENTURERS_GUILD_RANKS = [
     (150, "Grand Marshal"),
 ]
 
+
+@dataclass
+class Guild:
+    """Simple data container for a guild."""
+
+    name: str
+    desc: str = ""
+    home: Optional[int] = None
+    ranks: List[Tuple[int, str]] = field(default_factory=list)
+    members: Dict[str, int] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: Dict) -> "Guild":
+        return cls(
+            name=data.get("name", ""),
+            desc=data.get("desc", ""),
+            home=data.get("home"),
+            ranks=data.get("ranks", []),
+            members=data.get("members", {}),
+        )
+
+    def to_dict(self) -> Dict:
+        return asdict(self)
+
+
+_REGISTRY_KEY = "guild_registry"
+
+
+def _load_registry() -> List[Dict]:
+    return ServerConfig.objects.conf(_REGISTRY_KEY, default=list)
+
+
+def _save_registry(registry: List[Dict]):
+    ServerConfig.objects.conf(_REGISTRY_KEY, value=registry)
+
+
+def get_guilds() -> List[Guild]:
+    """Return all stored guilds."""
+    data = _load_registry()
+    guilds = [Guild.from_dict(d) for d in data]
+    if not guilds:
+        # seed with default Adventurers Guild if none exist
+        default = Guild(
+            name="Adventurers Guild",
+            desc="The guild of brave adventurers.",
+            ranks=ADVENTURERS_GUILD_RANKS,
+        )
+        guilds.append(default)
+        _save_registry([g.to_dict() for g in guilds])
+    return guilds
+
+
+def save_guild(guild: Guild):
+    """Add a new guild to the registry."""
+    registry = _load_registry()
+    registry.append(guild.to_dict())
+    _save_registry(registry)
+
+
+def update_guild(index: int, guild: Guild):
+    """Update guild at index."""
+    registry = _load_registry()
+    registry[index] = guild.to_dict()
+    _save_registry(registry)
+
+
+def find_guild(name: str) -> Tuple[int, Optional[Guild]]:
+    """Return index and guild matching name (case-insensitive)."""
+    registry = _load_registry()
+    for i, data in enumerate(registry):
+        guild = Guild.from_dict(data)
+        if guild.name.lower() == name.lower():
+            return i, guild
+    return -1, None
+
 GUILDS = {
     "Adventurers Guild": {
         "crest": "|b[|gAdventurers Guild|b]|n",
@@ -25,11 +105,20 @@ GUILDS = {
 
 def get_rank_title(guild_name: str, honor: int) -> str:
     """Return the rank title for a guild member."""
-    guild = GUILDS.get(guild_name)
-    if not guild:
+    guild_map = {g.name: g for g in get_guilds()}
+    guild = guild_map.get(guild_name)
+    ranks = []
+    if guild:
+        ranks = guild.ranks
+    else:
+        # fallback to legacy dictionary
+        info = GUILDS.get(guild_name)
+        if info:
+            ranks = info.get("ranks", [])
+    if not ranks:
         return ""
-    title = guild["ranks"][0][1]
-    for threshold, rank in guild["ranks"]:
+    title = ranks[0][1]
+    for threshold, rank in ranks:
         if honor >= threshold:
             title = rank
         else:

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -404,4 +404,107 @@ HELP_ENTRY_DICTS = [
             Using |wall|n revives every unconscious character in the game.
         """,
     },
+    {
+        "key": "gcreate",
+        "category": "building",
+        "text": """
+            Create a new guild.
+
+            Usage:
+                gcreate <name>
+        """,
+    },
+    {
+        "key": "grank",
+        "category": "building",
+        "text": """
+            Manage guild rank titles.
+
+            Usage:
+                grank add <guild> <level> <title>
+                grank remove <guild> <level>
+                grank list <guild>
+        """,
+    },
+    {
+        "key": "gsethome",
+        "category": "building",
+        "text": """
+            Set a guild's home location to your current room.
+
+            Usage:
+                gsethome <guild>
+        """,
+    },
+    {
+        "key": "gdesc",
+        "category": "building",
+        "text": """
+            Set a guild's description.
+
+            Usage:
+                gdesc <guild> <description>
+        """,
+    },
+    {
+        "key": "gjoin",
+        "category": "general",
+        "text": """
+            Request to join a guild.
+
+            Usage:
+                gjoin <guild>
+        """,
+    },
+    {
+        "key": "gaccept",
+        "category": "general",
+        "text": """
+            Accept a player's guild request.
+
+            Usage:
+                gaccept <player>
+        """,
+    },
+    {
+        "key": "gpromote",
+        "category": "general",
+        "text": """
+            Increase a member's guild honor.
+
+            Usage:
+                gpromote <player> [amount]
+        """,
+    },
+    {
+        "key": "gdemote",
+        "category": "general",
+        "text": """
+            Decrease a member's guild honor.
+
+            Usage:
+                gdemote <player> [amount]
+        """,
+    },
+    {
+        "key": "gkick",
+        "category": "general",
+        "text": """
+            Remove a member from your guild.
+
+            Usage:
+                gkick <player>
+        """,
+    },
+    {
+        "key": "gwho",
+        "aliases": ["guildwho"],
+        "category": "general",
+        "text": """
+            List members of your guild.
+
+            Usage:
+                gwho
+        """,
+    },
 ]


### PR DESCRIPTION
## Summary
- create dataclass-backed guild registry
- add builder and player guild commands
- register guild commands in cmdset
- document new guild commands
- test guild creation and membership

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684244850474832c91969052db9c024d