### PR TITLE
Add tags and slot processing for created gear

### DIFF
--- a/commands/admin.py
+++ b/commands/admin.py
@@ -309,6 +309,12 @@ def _create_gear(
             obj.db.clothing_type = slot
         else:
             obj.db.slot = slot
+        # mark the object as equipment and identified
+        obj.tags.add("equipment", category="flag")
+        obj.tags.add("identified", category="flag")
+        obj.db.identified = True
+        for part in slot.split("/"):
+            obj.tags.add(part, category="slot")
     if value is not None:
         obj.attributes.add(attr, value)
     caller.msg(f"Created {obj.get_display_name(caller)}.")
@@ -434,12 +440,10 @@ class CmdCWeapon(Command):
             self.caller,
             "typeclasses.gear.MeleeWeapon",
             name.capitalize(),
+            slot,
             desc=desc,
             weight=weight,
         )
-
-        if slot:
-            obj.db.slot = slot
 
         if slot:
             if slot == "mainhand/offhand":

--- a/typeclasses/tests/test_admin_commands.py
+++ b/typeclasses/tests/test_admin_commands.py
@@ -151,3 +151,36 @@ class TestAdminCommands(EvenniaTest):
 
         self.assertEqual(w1.db.damage_dice, "1d4")
         self.assertEqual(w2.db.damage_dice, "2d6")
+
+    def test_cweapon_tags_and_wield(self):
+        """Weapon created with cweapon should get tags and be wieldable."""
+
+        self.char1.execute_cmd("cweapon axe mainhand 5")
+        weapon = next(
+            (o for o in self.char1.contents if "axe" in list(o.aliases.all())),
+            None,
+        )
+        self.assertIsNotNone(weapon)
+        self.assertTrue(weapon.tags.has("equipment", category="flag"))
+        self.assertTrue(weapon.tags.has("identified", category="flag"))
+        self.assertTrue(weapon.tags.has("mainhand", category="flag"))
+        self.assertTrue(weapon.tags.has("mainhand", category="slot"))
+        self.char1.attributes.add("_wielded", {"left": None, "right": None})
+        hands = self.char1.at_wield(weapon)
+        self.assertTrue(hands)
+        self.assertIn(weapon, self.char1.wielding)
+
+    def test_carmor_tags_and_wear(self):
+        """Armor created with carmor gets tags and can be worn."""
+
+        self.char1.execute_cmd("carmor helm head 1")
+        armor = next(
+            (o for o in self.char1.contents if "helm" in list(o.aliases.all())),
+            None,
+        )
+        self.assertIsNotNone(armor)
+        self.assertTrue(armor.tags.has("equipment", category="flag"))
+        self.assertTrue(armor.tags.has("identified", category="flag"))
+        self.assertTrue(armor.tags.has("head", category="slot"))
+        armor.wear(self.char1, True)
+        self.assertTrue(armor.db.worn)


### PR DESCRIPTION
## Summary
- auto-tag equipment with slot information when creating gear
- ensure cweapon passes slot to helper and keep flag logic
- test new tag behavior for cweapon and carmor

## Testing
- `pytest -q` *(fails: various test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68424cd4a394832cb3f4aba4e00a6e26