### PR TITLE
Add multi-currency quest rewards

### DIFF
--- a/commands/quests.py
+++ b/commands/quests.py
@@ -348,7 +348,9 @@ class CmdCompleteQuest(Command):
 
         if quest.currency_reward:
             wallet = caller.db.coins or {}
-            total = to_copper(wallet) + to_copper(quest.currency_reward)
+            total = to_copper(wallet)
+            for coin, amount in quest.currency_reward.items():
+                total += to_copper({coin: amount})
             caller.db.coins = from_copper(total)
             rewards.append(format_wallet(quest.currency_reward))
 

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -507,4 +507,15 @@ HELP_ENTRY_DICTS = [
                 gwho
         """,
     },
+    {
+        "key": "quest rewards",
+        "category": "general",
+        "text": """
+            Some quests give coins of multiple types when completed.
+
+            Builders set the |wcurrency_reward|n field on the quest to a
+            mapping like ``{"platinum": 1, "gold": 5}``. Each coin type is
+            added to your wallet when you turn in the quest.
+        """,
+    },
 ]

--- a/world/quests.py
+++ b/world/quests.py
@@ -26,6 +26,7 @@ class Quest:
     complete_dialogue: str = ""
     failure_dialogue: str = ""
     unique_tag: str = ""
+    # mapping of coin type to amount, e.g. {"platinum": 1, "gold": 5}
     currency_reward: Dict[str, int] = field(default_factory=dict)
     guild_points: Dict[str, int] = field(default_factory=dict)
 


### PR DESCRIPTION
## Summary
- extend `Quest` dataclass with a note on coin mapping
- grant multi-currency rewards when completing quests
- document new functionality in help entries

## Testing
- `pytest -q` *(fails: 111 failed)*

------
https://chatgpt.com/codex/tasks/task_e_684255f9567c832c8b5b45966e41e755