### PR TITLE
Normalize help categories

### DIFF
--- a/commands/admin.py
+++ b/commands/admin.py
@@ -28,7 +28,7 @@ class CmdSetStat(Command):
     key = "setstat"
     aliases = ("set",)
     locks = "cmd:perm(Admin) or perm(Builder)"
-    help_category = "admin"
+    help_category = "Admin"
 
     def func(self):
         if not self.args:
@@ -111,7 +111,7 @@ class CmdSetAttr(Command):
     key = "setattr"
     aliases = ("setattribute",)
     locks = "cmd:perm(Admin) or perm(Builder)"
-    help_category = "admin"
+    help_category = "Admin"
 
     def func(self):
         if not self.args:
@@ -139,7 +139,7 @@ class CmdSetBounty(Command):
 
     key = "setbounty"
     locks = "cmd:perm(Admin)"
-    help_category = "admin"
+    help_category = "Admin"
 
     def func(self):
         if not self.args:
@@ -167,7 +167,7 @@ class CmdSlay(Command):
 
     key = "slay"
     locks = "cmd:perm(Admin)"
-    help_category = "admin"
+    help_category = "Admin"
 
     def func(self):
         if not self.args:
@@ -194,7 +194,7 @@ class CmdSmite(Command):
 
     key = "smite"
     locks = "cmd:perm(Admin)"
-    help_category = "admin"
+    help_category = "Admin"
 
     def func(self):
         if not self.args:
@@ -215,7 +215,7 @@ class CmdRestoreAll(Command):
 
     key = "restoreall"
     locks = "cmd:perm(Admin)"
-    help_category = "admin"
+    help_category = "Admin"
 
     def func(self):
         from typeclasses.characters import PlayerCharacter
@@ -250,7 +250,7 @@ class CmdPurge(Command):
 
     key = "purge"
     locks = "cmd:perm(Admin)"
-    help_category = "admin"
+    help_category = "Admin"
 
     def func(self):
         caller = self.caller

--- a/commands/combat.py
+++ b/commands/combat.py
@@ -24,7 +24,7 @@ class CmdAttack(Command):
 
     key = "attack"
     aliases = ("att", "hit", "shoot")
-    help_category = "combat"
+    help_category = "Combat"
 
     def parse(self):
         """
@@ -125,7 +125,7 @@ class CmdWield(Command):
 
     key = "wield"
     aliases = ("hold",)
-    help_category = "combat"
+    help_category = "Combat"
 
     def parse(self):
         """
@@ -192,7 +192,7 @@ class CmdUnwield(Command):
 
     key = "unwield"
     aliases = ("unhold",)
-    help_category = "combat"
+    help_category = "Combat"
 
     def func(self):
         caller = self.caller
@@ -221,7 +221,7 @@ class CmdFlee(Command):
     """
 
     key = "flee"
-    help_category = "combat"
+    help_category = "Combat"
 
     def func(self):
         caller = self.caller
@@ -269,7 +269,7 @@ class CmdRespawn(Command):
     """
 
     key = "respawn"
-    help_category = "combat"
+    help_category = "Combat"
 
     def func(self):
         caller = self.caller
@@ -291,7 +291,7 @@ class CmdRevive(Command):
 
     key = "revive"
     aliases = ("resurrect",)
-    help_category = "combat"
+    help_category = "Combat"
 
     def func(self):
         caller = self.caller

--- a/commands/guilds.py
+++ b/commands/guilds.py
@@ -27,7 +27,7 @@ class CmdGuild(Command):
 
     key = "guild"
     aliases = ("/guild",)
-    help_category = "general"
+    help_category = "General"
 
     def func(self):
         caller = self.caller
@@ -60,7 +60,7 @@ class CmdGuildWho(Command):
 
     key = "gwho"
     aliases = ("guildwho",)
-    help_category = "general"
+    help_category = "General"
 
     def func(self):
         caller = self.caller
@@ -230,7 +230,7 @@ class CmdGJoin(Command):
     """Request to join a guild."""
 
     key = "gjoin"
-    help_category = "general"
+    help_category = "General"
 
     def func(self):
         if not self.args:
@@ -252,7 +252,7 @@ class CmdGAccept(Command):
     """Accept a player's join request."""
 
     key = "gaccept"
-    help_category = "general"
+    help_category = "General"
 
     def func(self):
         if not is_guildmaster(self.caller):
@@ -291,7 +291,7 @@ class CmdGAccept(Command):
 
 class _BaseAdjustHonor(Command):
     locks = "cmd:all()"
-    help_category = "general"
+    help_category = "General"
 
     def adjust(self, amount: int):
         if not (is_guildmaster(self.caller) or is_receptionist(self.caller)):
@@ -351,7 +351,7 @@ class CmdGKick(Command):
     """Remove a member from your guild."""
 
     key = "gkick"
-    help_category = "general"
+    help_category = "General"
 
     def func(self):
         if not is_guildmaster(self.caller):

--- a/commands/info.py
+++ b/commands/info.py
@@ -22,7 +22,7 @@ class CmdScore(Command):
 
     key = "score"
     aliases = ("sheet", "sc")
-    help_category = "general"
+    help_category = "General"
 
     def func(self):
         self.caller.msg(get_display_scroll(self.caller))
@@ -42,7 +42,7 @@ class CmdDesc(Command):
     """
 
     key = "desc"
-    help_category = "general"
+    help_category = "General"
 
     def func(self):
         if not self.args:
@@ -66,7 +66,7 @@ class CmdFinger(Command):
 
     key = "finger"
     aliases = ("whois",)
-    help_category = "general"
+    help_category = "General"
 
     def func(self):
         if not self.args or self.args.strip().lower() in {"self", "me"}:
@@ -125,7 +125,7 @@ class CmdBounty(Command):
     """
 
     key = "bounty"
-    help_category = "general"
+    help_category = "General"
 
     def func(self):
         if not self.args:
@@ -173,7 +173,7 @@ class CmdInventory(Command):
 
     key = "inventory"
     aliases = ("inv", "i")
-    help_category = "general"
+    help_category = "General"
 
     def func(self):
         caller = self.caller
@@ -211,7 +211,7 @@ class CmdEquipment(Command):
 
     key = "equipment"
     aliases = ("eq",)
-    help_category = "general"
+    help_category = "General"
 
     def func(self):
         caller = self.caller
@@ -259,7 +259,7 @@ class CmdInspect(Command):
     """
 
     key = "inspect"
-    help_category = "general"
+    help_category = "General"
 
     def func(self):
         caller = self.caller
@@ -369,7 +369,7 @@ class CmdBuffs(Command):
     """
 
     key = "buffs"
-    help_category = "general"
+    help_category = "General"
 
     def func(self):
         from world.effects import EFFECTS
@@ -422,7 +422,7 @@ class CmdAffects(Command):
 
     key = "affects"
     aliases = ("effects",)
-    help_category = "general"
+    help_category = "General"
 
     def func(self):
         from world.effects import EFFECTS
@@ -483,7 +483,7 @@ class CmdTitle(Command):
     """
 
     key = "title"
-    help_category = "general"
+    help_category = "General"
 
     def func(self):
         if not self.args:
@@ -508,7 +508,7 @@ class CmdPrompt(Command):
     """
 
     key = "prompt"
-    help_category = "general"
+    help_category = "General"
 
     def func(self):
         caller = self.caller
@@ -534,7 +534,7 @@ class CmdScan(Command):
     """
 
     key = "scan"
-    help_category = "movement"
+    help_category = "Movement"
 
     def func(self):
         caller = self.caller

--- a/commands/interact.py
+++ b/commands/interact.py
@@ -16,7 +16,7 @@ class CmdGather(Command):
 
     key = "gather"
     aliases = ("collect", "harvest")
-    help_category = "here"
+    help_category = "Here"
 
     def func(self):
         if not self.obj:

--- a/commands/quests.py
+++ b/commands/quests.py
@@ -175,7 +175,7 @@ class CmdQuestList(Command):
 
     key = "questlist"
     aliases = ("quests",)
-    help_category = "general"
+    help_category = "General"
 
     def func(self):
         caller = self.caller
@@ -218,7 +218,7 @@ class CmdAcceptQuest(Command):
     """Accept a quest offered by an NPC."""
 
     key = "accept"
-    help_category = "general"
+    help_category = "General"
 
     def func(self):
         caller = self.caller
@@ -265,7 +265,7 @@ class CmdQuestProgress(Command):
     """Show progress on your active quests."""
 
     key = "progress"
-    help_category = "general"
+    help_category = "General"
 
     def func(self):
         caller = self.caller
@@ -294,7 +294,7 @@ class CmdCompleteQuest(Command):
     """Turn in a completed quest."""
 
     key = "complete"
-    help_category = "general"
+    help_category = "General"
 
     def func(self):
         caller = self.caller

--- a/commands/rest.py
+++ b/commands/rest.py
@@ -17,7 +17,7 @@ class CmdRest(Command):
 
     key = "rest"
     aliases = ("relax",)
-    help_category = "general"
+    help_category = "General"
 
     def func(self):
         caller = self.caller
@@ -42,7 +42,7 @@ class CmdSleep(Command):
     """
 
     key = "sleep"
-    help_category = "general"
+    help_category = "General"
 
     def func(self):
         caller = self.caller
@@ -68,7 +68,7 @@ class CmdWake(Command):
 
     key = "wake"
     aliases = ("stand",)
-    help_category = "general"
+    help_category = "General"
 
     def func(self):
         caller = self.caller

--- a/commands/shops.py
+++ b/commands/shops.py
@@ -14,7 +14,7 @@ class CmdList(Command):
 
     key = "list"
     aliases = ("browse",)
-    help_category = "here"
+    help_category = "Here"
 
     def func(self):
         # verify that this shop has a storage box
@@ -59,7 +59,7 @@ class CmdBuy(Command):
 
     key = "buy"
     aliases = ("order", "purchase")
-    help_category = "here"
+    help_category = "Here"
 
     def parse(self):
         """
@@ -152,7 +152,7 @@ class CmdSell(Command):
     """
 
     key = "sell"
-    help_category = "here"
+    help_category = "Here"
 
     def parse(self):
         """

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -57,7 +57,7 @@ HELP_ENTRY_DICTS = [
     },
     {
         "key": "building",
-        "category": "building",
+        "category": "Building",
         "text": """
             Evennia comes with a bunch of default building commands. You can
             find a beginner tutorial in the Evennia documentation.
@@ -115,7 +115,7 @@ HELP_ENTRY_DICTS = [
     {
         "key": "room flags",
         "aliases": ["rflags", "rflag"],
-        "category": "building",
+        "category": "Building",
         "text": """
             Rooms can be marked with special flags.
 
@@ -137,7 +137,7 @@ HELP_ENTRY_DICTS = [
     {
         "key": "rrename",
         "aliases": ["roomrename", "renameroom", "rname"],
-        "category": "building",
+        "category": "Building",
         "text": """
             Rename the room you are currently in.
 
@@ -150,7 +150,7 @@ HELP_ENTRY_DICTS = [
     {
         "key": "rdesc",
         "aliases": ["roomdesc"],
-        "category": "building",
+        "category": "Building",
         "text": """
             View or change the current room's description.
 
@@ -162,7 +162,7 @@ HELP_ENTRY_DICTS = [
     },
     {
         "key": "rset",
-        "category": "building",
+        "category": "Building",
         "text": """
             Set properties on the current room.
 
@@ -175,7 +175,7 @@ HELP_ENTRY_DICTS = [
     },
     {
         "key": "ocreate",
-        "category": "building",
+        "category": "Building",
         "text": """
             Create a generic object and put it in your inventory.
 
@@ -185,7 +185,7 @@ HELP_ENTRY_DICTS = [
     },
     {
         "key": "cweapon",
-        "category": "building",
+        "category": "Building",
         "text": """
             Create a simple melee weapon.
 
@@ -201,7 +201,7 @@ HELP_ENTRY_DICTS = [
     },
     {
         "key": "cshield",
-        "category": "building",
+        "category": "Building",
         "text": """
             Create a shield piece of armor.
 
@@ -213,7 +213,7 @@ HELP_ENTRY_DICTS = [
     },
     {
         "key": "carmor",
-        "category": "building",
+        "category": "Building",
         "text": """
             Create a wearable armor item.
 
@@ -225,7 +225,7 @@ HELP_ENTRY_DICTS = [
     },
     {
         "key": "ctool",
-        "category": "building",
+        "category": "Building",
         "text": """
             Create a crafting tool.
 
@@ -237,7 +237,7 @@ HELP_ENTRY_DICTS = [
     },
     {
         "key": "cgear",
-        "category": "building",
+        "category": "Building",
         "text": """
             Generic helper for gear creation.
 
@@ -250,7 +250,7 @@ HELP_ENTRY_DICTS = [
     {
         "key": "item flags",
         "aliases": ["setflag", "removeflag"],
-        "category": "building",
+        "category": "Building",
         "text": """
             Items may have special flags stored on them.
 
@@ -266,7 +266,7 @@ HELP_ENTRY_DICTS = [
     },
     {
         "key": "admin",
-        "category": "admin",
+        "category": "Admin",
         "text": """
             Commands reserved for administrators. These bypass normal limits and
             should be used carefully. Most require `perm(Admin)` access.
@@ -275,7 +275,7 @@ HELP_ENTRY_DICTS = [
     {
         "key": "setstat",
         "aliases": ["set"],
-        "category": "admin",
+        "category": "Admin",
         "text": """
             Change a character's stat directly.
 
@@ -297,7 +297,7 @@ HELP_ENTRY_DICTS = [
     },
     {
         "key": "setattr",
-        "category": "admin",
+        "category": "Admin",
         "text": """
             Set an arbitrary attribute on an object or character.
 
@@ -311,7 +311,7 @@ HELP_ENTRY_DICTS = [
     },
     {
         "key": "setbounty",
-        "category": "admin",
+        "category": "Admin",
         "text": """
             Assign a bounty to a character.
 
@@ -325,7 +325,7 @@ HELP_ENTRY_DICTS = [
     },
     {
         "key": "slay",
-        "category": "admin",
+        "category": "Admin",
         "text": """
             Instantly reduce a target's health to zero.
 
@@ -339,7 +339,7 @@ HELP_ENTRY_DICTS = [
     },
     {
         "key": "smite",
-        "category": "admin",
+        "category": "Admin",
         "text": """
             Reduce a target to a single hit point.
 
@@ -353,7 +353,7 @@ HELP_ENTRY_DICTS = [
     },
     {
         "key": "scan",
-        "category": "admin",
+        "category": "Admin",
         "text": """
             Look around and into adjacent rooms.
 
@@ -367,7 +367,7 @@ HELP_ENTRY_DICTS = [
     },
     {
         "key": "restoreall",
-        "category": "admin",
+        "category": "Admin",
         "text": """
             Fully heal every player and remove all buffs and status effects.
 
@@ -377,7 +377,7 @@ HELP_ENTRY_DICTS = [
     },
     {
         "key": "purge",
-        "category": "admin",
+        "category": "Admin",
         "text": """
             Delete unwanted objects.
 
@@ -393,7 +393,7 @@ HELP_ENTRY_DICTS = [
     {
         "key": "revive",
         "aliases": ["resurrect"],
-        "category": "combat",
+        "category": "Combat",
         "text": """
             Revive a defeated player at partial health.
 
@@ -406,7 +406,7 @@ HELP_ENTRY_DICTS = [
     },
     {
         "key": "gcreate",
-        "category": "building",
+        "category": "Building",
         "text": """
             Create a new guild.
 
@@ -416,7 +416,7 @@ HELP_ENTRY_DICTS = [
     },
     {
         "key": "grank",
-        "category": "building",
+        "category": "Building",
         "text": """
             Manage guild rank titles.
 
@@ -428,7 +428,7 @@ HELP_ENTRY_DICTS = [
     },
     {
         "key": "gsethome",
-        "category": "building",
+        "category": "Building",
         "text": """
             Set a guild's home location to your current room.
 
@@ -438,7 +438,7 @@ HELP_ENTRY_DICTS = [
     },
     {
         "key": "gdesc",
-        "category": "building",
+        "category": "Building",
         "text": """
             Set a guild's description.
 
@@ -448,7 +448,7 @@ HELP_ENTRY_DICTS = [
     },
     {
         "key": "gjoin",
-        "category": "general",
+        "category": "General",
         "text": """
             Request to join a guild.
 
@@ -458,7 +458,7 @@ HELP_ENTRY_DICTS = [
     },
     {
         "key": "gaccept",
-        "category": "general",
+        "category": "General",
         "text": """
             Accept a player's guild request.
 
@@ -468,7 +468,7 @@ HELP_ENTRY_DICTS = [
     },
     {
         "key": "gpromote",
-        "category": "general",
+        "category": "General",
         "text": """
             Increase a member's guild points.
 
@@ -478,7 +478,7 @@ HELP_ENTRY_DICTS = [
     },
     {
         "key": "gdemote",
-        "category": "general",
+        "category": "General",
         "text": """
             Decrease a member's guild points.
 
@@ -488,7 +488,7 @@ HELP_ENTRY_DICTS = [
     },
     {
         "key": "gkick",
-        "category": "general",
+        "category": "General",
         "text": """
             Remove a member from your guild.
 
@@ -499,7 +499,7 @@ HELP_ENTRY_DICTS = [
     {
         "key": "gwho",
         "aliases": ["guildwho"],
-        "category": "general",
+        "category": "General",
         "text": """
             List members of your guild.
 
@@ -509,7 +509,7 @@ HELP_ENTRY_DICTS = [
     },
     {
         "key": "quest rewards",
-        "category": "general",
+        "category": "General",
         "text": """
             Some quests give coins of multiple types when completed.
 


### PR DESCRIPTION
## Summary
- capitalize all `help_category` attributes in commands
- capitalize all help entry `category` values

## Testing
- `pytest -q` *(fails: no such table accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68425bc35158832c92a1976122a44bd4