### PR TITLE
Align command docstrings with help entries

### DIFF
--- a/commands/admin.py
+++ b/commands/admin.py
@@ -19,10 +19,12 @@ from utils.stats_utils import get_display_scroll
 
 class CmdSetStat(Command):
     """
-    Set a base or derived stat on a target.
+    Change a character's stat directly.
 
     Usage:
         setstat <target> <stat> <value>
+
+    See |whelp setstat|n for details.
     """
 
     key = "setstat"
@@ -102,10 +104,12 @@ class CmdSetStat(Command):
 
 class CmdSetAttr(Command):
     """
-    Set an arbitrary attribute on a target.
+    Set an arbitrary attribute on an object or character.
 
     Usage:
         setattr <target> <attr> <value>
+
+    See |whelp setattr|n for details.
     """
 
     key = "setattr"
@@ -131,10 +135,12 @@ class CmdSetAttr(Command):
 
 class CmdSetBounty(Command):
     """
-    Set the bounty value on a target.
+    Assign a bounty to a character.
 
     Usage:
         setbounty <target> <amount>
+
+    See |whelp setbounty|n for details.
     """
 
     key = "setbounty"
@@ -159,10 +165,12 @@ class CmdSetBounty(Command):
 
 class CmdSlay(Command):
     """
-    Instantly defeat a target.
+    Instantly reduce a target's health to zero.
 
     Usage:
         slay <target>
+
+    See |whelp slay|n for details.
     """
 
     key = "slay"
@@ -190,6 +198,8 @@ class CmdSmite(Command):
 
     Usage:
         smite <target>
+
+    See |whelp smite|n for details.
     """
 
     key = "smite"
@@ -211,7 +221,14 @@ class CmdSmite(Command):
 
 
 class CmdRestoreAll(Command):
-    """Fully restore all player characters."""
+    """
+    Fully heal every player and remove all buffs and status effects.
+
+    Usage:
+        restoreall
+
+    See |whelp restoreall|n for details.
+    """
 
     key = "restoreall"
     locks = "cmd:perm(Admin)"
@@ -236,16 +253,14 @@ class CmdRestoreAll(Command):
 
 
 class CmdPurge(Command):
-    """Remove unwanted objects.
+    """
+    Delete unwanted objects.
 
     Usage:
         purge
         purge <target>
 
-    Without arguments this deletes all objects in the caller's
-    current room except for the caller themselves. With an argument
-    it deletes the specified target. Players, exits and rooms are
-    protected from deletion.
+    See |whelp purge|n for details.
     """
 
     key = "purge"
@@ -322,7 +337,14 @@ def _create_gear(
 
 
 class CmdCGear(Command):
-    """Create a generic gear item."""
+    """
+    Generic helper for gear creation.
+
+    Usage:
+        cgear <typeclass> <name> [slot] [value]
+
+    See |whelp cgear|n for details.
+    """
 
     key = "cgear"
     locks = "cmd:perm(Builder)"
@@ -357,7 +379,14 @@ class CmdCGear(Command):
 
 
 class CmdOCreate(Command):
-    """Create a generic object."""
+    """
+    Create a generic object and put it in your inventory.
+
+    Usage:
+        ocreate <name>
+
+    See |whelp ocreate|n for details.
+    """
 
     key = "ocreate"
     locks = "cmd:perm(Builder)"
@@ -388,7 +417,14 @@ class CmdOCreate(Command):
 
 
 class CmdCWeapon(Command):
-    """Create a simple weapon."""
+    """
+    Create a simple melee weapon.
+
+    Usage:
+        cweapon <name> <slot> <damage> [description]
+
+    See |whelp cweapon|n for details.
+    """
 
     key = "cweapon"
     locks = "cmd:perm(Builder)"
@@ -461,7 +497,14 @@ class CmdCWeapon(Command):
 
 
 class CmdCShield(Command):
-    """Create a shield."""
+    """
+    Create a shield piece of armor.
+
+    Usage:
+        cshield <name> [slot] [armor]
+
+    See |whelp cshield|n for details.
+    """
 
     key = "cshield"
     locks = "cmd:perm(Builder)"
@@ -501,7 +544,14 @@ class CmdCShield(Command):
 
 
 class CmdCArmor(Command):
-    """Create an armor piece."""
+    """
+    Create a wearable armor item.
+
+    Usage:
+        carmor <name> [slot] [armor]
+
+    See |whelp carmor|n for details.
+    """
 
     key = "carmor"
     locks = "cmd:perm(Builder)"
@@ -541,7 +591,14 @@ class CmdCArmor(Command):
 
 
 class CmdCTool(Command):
-    """Create a crafting tool."""
+    """
+    Create a crafting tool.
+
+    Usage:
+        ctool <name> [tag]
+
+    See |whelp ctool|n for details.
+    """
 
     key = "ctool"
     locks = "cmd:perm(Builder)"

--- a/commands/areas.py
+++ b/commands/areas.py
@@ -7,7 +7,14 @@ from world.areas import Area, get_areas, save_area, update_area, find_area
 
 
 class CmdAreas(Command):
-    """List all registered areas."""
+    """
+    List all registered areas and their number ranges.
+
+    Usage:
+        alist
+
+    See |whelp alist|n for details.
+    """
 
     key = "alist"
     aliases = ("areas",)
@@ -26,7 +33,14 @@ class CmdAreas(Command):
 
 
 class CmdAMake(Command):
-    """Register a new area."""
+    """
+    Register a new area. Usage: amake <name> <start>-<end>
+
+    Usage:
+        amake
+
+    See |whelp amake|n for details.
+    """
 
     key = "amake"
     locks = "cmd:perm(Builder)"
@@ -62,7 +76,14 @@ class CmdAMake(Command):
 
 
 class CmdASet(Command):
-    """Update an existing area's info."""
+    """
+    Update an area's properties. Usage: aset <area> <name|range|desc> <value>
+
+    Usage:
+        aset
+
+    See |whelp aset|n for details.
+    """
 
     key = "aset"
     locks = "cmd:perm(Builder)"
@@ -113,7 +134,14 @@ class CmdASet(Command):
 
 
 class CmdRooms(Command):
-    """List rooms in the current area."""
+    """
+    Show rooms belonging to your current area.
+
+    Usage:
+        rooms
+
+    See |whelp rooms|n for details.
+    """
 
     key = "rooms"
     aliases = ("roomsall",)
@@ -148,7 +176,14 @@ class CmdRooms(Command):
 
 
 class CmdRName(Command):
-    """Rename the current room."""
+    """
+    Rename the room you are currently in.
+
+    Usage:
+        rrename <new name>
+
+    See |whelp rrename|n for details.
+    """
 
     key = "rrename"
     aliases = ("roomrename", "renameroom", "rname")
@@ -169,7 +204,14 @@ class CmdRName(Command):
 
 
 class CmdRDesc(Command):
-    """View or set the room description."""
+    """
+    View or change the current room's description.
+
+    Usage:
+        rdesc <new description>
+
+    See |whelp rdesc|n for details.
+    """
 
     key = "rdesc"
     aliases = ("roomdesc",)
@@ -190,7 +232,15 @@ class CmdRDesc(Command):
 
 
 class CmdRSet(Command):
-    """Set properties on the current room."""
+    """
+    Set properties on the current room.
+
+    Usage:
+        rset area <area name>
+        rset id <number>
+
+    See |whelp rset|n for details.
+    """
 
     key = "rset"
     locks = "cmd:perm(Builder)"

--- a/commands/building.py
+++ b/commands/building.py
@@ -65,7 +65,14 @@ SHORT = {
 
 
 class CmdDig(Command):
-    """Dig a new room in a direction."""
+    """
+    Create a new room in a direction. Usage: dig <direction> [<area>:<number>]
+
+    Usage:
+        dig
+
+    See |whelp dig|n for details.
+    """
 
     key = "dig"
     locks = "cmd:perm(Builder)"
@@ -149,7 +156,14 @@ class CmdDig(Command):
 
 
 class CmdTeleport(Command):
-    """Teleport to a room using ``<area>:<number>``."""
+    """
+    Teleport directly to a room. Usage: @teleport <area>:<number>
+
+    Usage:
+        @teleport
+
+    See |whelp @teleport|n for details.
+    """
 
     key = "@teleport"
     locks = "cmd:perm(Builder)"
@@ -187,7 +201,14 @@ class CmdTeleport(Command):
 
 
 class CmdSetDesc(Command):
-    """Set an object's description."""
+    """
+    Set an object's description. Usage: setdesc <target> <description>
+
+    Usage:
+        setdesc
+
+    See |whelp setdesc|n for details.
+    """
 
     key = "setdesc"
     locks = "cmd:perm(Admin) or perm(Builder)"
@@ -209,7 +230,14 @@ class CmdSetDesc(Command):
 
 
 class CmdSetWeight(Command):
-    """Set an object's weight."""
+    """
+    Set an object's weight. Usage: setweight <target> <value>
+
+    Usage:
+        setweight
+
+    See |whelp setweight|n for details.
+    """
 
     key = "setweight"
     locks = "cmd:perm(Admin) or perm(Builder)"
@@ -231,7 +259,14 @@ class CmdSetWeight(Command):
 
 
 class CmdSetSlot(Command):
-    """Set an object's slot attribute."""
+    """
+    Define the slot or clothing type on an item. Usage: setslot <target> <slot>
+
+    Usage:
+        setslot
+
+    See |whelp setslot|n for details.
+    """
 
     key = "setslot"
     locks = "cmd:perm(Admin) or perm(Builder)"
@@ -253,7 +288,14 @@ class CmdSetSlot(Command):
 
 
 class CmdSetDamage(Command):
-    """Set an object's damage value."""
+    """
+    Assign a damage value to a weapon. Usage: setdamage <target> <amount>
+
+    Usage:
+        setdamage
+
+    See |whelp setdamage|n for details.
+    """
 
     key = "setdamage"
     locks = "cmd:perm(Admin) or perm(Builder)"
@@ -275,7 +317,14 @@ class CmdSetDamage(Command):
 
 
 class CmdSetBuff(Command):
-    """Set a buff identifier on a target."""
+    """
+    Add a buff identifier to an object. Usage: setbuff <target> <buff>
+
+    Usage:
+        setbuff
+
+    See |whelp setbuff|n for details.
+    """
 
     key = "setbuff"
     locks = "cmd:perm(Admin) or perm(Builder)"

--- a/commands/combat.py
+++ b/commands/combat.py
@@ -10,16 +10,12 @@ from typeclasses.scripts import get_or_create_combat_script
 
 class CmdAttack(Command):
     """
-    Attack an enemy with your equipped weapon.
+    Attack an enemy. Usage: attack <target> [with <weapon>]
 
     Usage:
-        attack <enemy> [with <weapon>]
+        attack
 
-    Example:
-        attack wolf
-        attack bear with sword
-        attack bear w sword
-        attack bear w/sword
+    See |whelp attack|n for details.
     """
 
     key = "attack"
@@ -113,14 +109,12 @@ class CmdAttack(Command):
 
 class CmdWield(Command):
     """
-    Wield a weapon
+    Wield a weapon. Usage: wield <weapon> [in <hand>]
 
     Usage:
-        wield <weapon> [in <hand>]
+        wield
 
-    Example:
-        wield sword
-        wield dagger in right
+    See |whelp wield|n for details.
     """
 
     key = "wield"
@@ -181,13 +175,12 @@ class CmdWield(Command):
 
 class CmdUnwield(Command):
     """
-    Stop wielding a weapon
+    Stop wielding a weapon. Usage: unwield <weapon>
 
     Usage:
-        unwield <weapon>
+        unwield
 
-    Example:
-        unwield dagger
+    See |whelp unwield|n for details.
     """
 
     key = "unwield"
@@ -214,10 +207,12 @@ class CmdUnwield(Command):
 
 class CmdFlee(Command):
     """
-    Attempt to escape from combat.
+    Attempt to escape from combat. Usage: flee
 
     Usage:
         flee
+
+    See |whelp flee|n for details.
     """
 
     key = "flee"
@@ -262,10 +257,12 @@ class CmdFlee(Command):
 
 class CmdRespawn(Command):
     """
-    Return to the center of town when defeated, with full health.
+    Return to town after being defeated. Usage: respawn
 
     Usage:
         respawn
+
+    See |whelp respawn|n for details.
     """
 
     key = "respawn"
@@ -282,11 +279,13 @@ class CmdRespawn(Command):
 
 class CmdRevive(Command):
     """
-    Revive another player who has been defeated. They will recover partial health.
+    Revive a defeated player at partial health.
 
     Usage:
         revive <player>
         revive all
+
+    See |whelp revive|n for details.
     """
 
     key = "revive"

--- a/commands/guilds.py
+++ b/commands/guilds.py
@@ -16,13 +16,12 @@ from world.guilds import (
 
 class CmdGuild(Command):
     """
-    Show information about your current guild.
+    Display information about your guild membership. Usage: guild
 
     Usage:
         guild
 
-    Example:
-        guild
+    See |whelp guild|n for details.
     """
 
     key = "guild"
@@ -49,13 +48,12 @@ class CmdGuild(Command):
 
 class CmdGuildWho(Command):
     """
-    List members of your guild and their status.
+    List members of your guild.
 
     Usage:
-        guildwho
+        gwho
 
-    Example:
-        guildwho
+    See |whelp gwho|n for details.
     """
 
     key = "gwho"
@@ -88,7 +86,14 @@ class CmdGuildWho(Command):
 
 
 class CmdGCreate(Command):
-    """Create a new guild and register it."""
+    """
+    Create a new guild.
+
+    Usage:
+        gcreate <name>
+
+    See |whelp gcreate|n for details.
+    """
 
     key = "gcreate"
     locks = "cmd:all()"
@@ -112,7 +117,16 @@ class CmdGCreate(Command):
 
 
 class CmdGRank(Command):
-    """Manage guild rank titles."""
+    """
+    Manage guild rank titles.
+
+    Usage:
+        grank add <guild> <level> <title>
+        grank remove <guild> <level>
+        grank list <guild>
+
+    See |whelp grank|n for details.
+    """
 
     key = "grank"
     locks = "cmd:all()"
@@ -172,7 +186,14 @@ class CmdGRank(Command):
 
 
 class CmdGSetHome(Command):
-    """Set the home location for a guild."""
+    """
+    Set a guild's home location to your current room.
+
+    Usage:
+        gsethome <guild>
+
+    See |whelp gsethome|n for details.
+    """
 
     key = "gsethome"
     locks = "cmd:all()"
@@ -199,7 +220,14 @@ class CmdGSetHome(Command):
 
 
 class CmdGDesc(Command):
-    """Set the description of a guild."""
+    """
+    Set a guild's description.
+
+    Usage:
+        gdesc <guild> <description>
+
+    See |whelp gdesc|n for details.
+    """
 
     key = "gdesc"
     locks = "cmd:all()"
@@ -227,7 +255,14 @@ class CmdGDesc(Command):
 
 
 class CmdGJoin(Command):
-    """Request to join a guild."""
+    """
+    Request to join a guild.
+
+    Usage:
+        gjoin <guild>
+
+    See |whelp gjoin|n for details.
+    """
 
     key = "gjoin"
     help_category = "General"
@@ -249,7 +284,14 @@ class CmdGJoin(Command):
 
 
 class CmdGAccept(Command):
-    """Accept a player's join request."""
+    """
+    Accept a player's guild request.
+
+    Usage:
+        gaccept <player>
+
+    See |whelp gaccept|n for details.
+    """
 
     key = "gaccept"
     help_category = "General"
@@ -330,7 +372,14 @@ class _BaseAdjustHonor(Command):
 
 
 class CmdGPromote(_BaseAdjustHonor):
-    """Increase a member's guild points."""
+    """
+    Increase a member's guild points.
+
+    Usage:
+        gpromote <player> [amount]
+
+    See |whelp gpromote|n for details.
+    """
 
     key = "gpromote"
 
@@ -339,7 +388,14 @@ class CmdGPromote(_BaseAdjustHonor):
 
 
 class CmdGDemote(_BaseAdjustHonor):
-    """Decrease a member's guild points."""
+    """
+    Decrease a member's guild points.
+
+    Usage:
+        gdemote <player> [amount]
+
+    See |whelp gdemote|n for details.
+    """
 
     key = "gdemote"
 
@@ -348,7 +404,14 @@ class CmdGDemote(_BaseAdjustHonor):
 
 
 class CmdGKick(Command):
-    """Remove a member from your guild."""
+    """
+    Remove a member from your guild.
+
+    Usage:
+        gkick <player>
+
+    See |whelp gkick|n for details.
+    """
 
     key = "gkick"
     help_category = "General"

--- a/commands/info.py
+++ b/commands/info.py
@@ -11,13 +11,12 @@ from .command import Command
 
 class CmdScore(Command):
     """
-    View your character sheet.
+    View your character sheet. Usage: score
 
     Usage:
         score
 
-    Example:
-        score
+    See |whelp score|n for details.
     """
 
     key = "score"
@@ -30,15 +29,12 @@ class CmdScore(Command):
 
 class CmdDesc(Command):
     """
-    View your character description or set a new one.
+    View or set your description. Usage: desc [text]
 
     Usage:
         desc
-        desc <text>
 
-    Example:
-        desc
-        desc A scarred veteran
+    See |whelp desc|n for details.
     """
 
     key = "desc"
@@ -55,13 +51,12 @@ class CmdDesc(Command):
 
 class CmdFinger(Command):
     """
-    Show information about yourself or another player.
+    Show information about a player. Usage: finger <player>
 
     Usage:
-        finger <player>
+        finger
 
-    Example:
-        finger Bob
+    See |whelp finger|n for details.
     """
 
     key = "finger"
@@ -115,13 +110,12 @@ class CmdFinger(Command):
 
 class CmdBounty(Command):
     """
-    Place a bounty on another character.
+    Place a bounty on another character. Usage: bounty <target> <amount>
 
     Usage:
-        bounty <target> <amount>
+        bounty
 
-    Example:
-        bounty orc 50
+    See |whelp bounty|n for details.
     """
 
     key = "bounty"
@@ -160,15 +154,12 @@ class CmdBounty(Command):
 
 class CmdInventory(Command):
     """
-    List the items you are carrying.
+    List items you are carrying. Usage: inventory [filter]
 
     Usage:
         inventory
-        inventory <filter>
 
-    Example:
-        inventory
-        inventory sword
+    See |whelp inventory|n for details.
     """
 
     key = "inventory"
@@ -200,13 +191,12 @@ class CmdInventory(Command):
 
 class CmdEquipment(Command):
     """
-    Show what you are wearing or wielding.
+    Show what you are wearing and wielding. Usage: equipment
 
     Usage:
         equipment
 
-    Example:
-        equipment
+    See |whelp equipment|n for details.
     """
 
     key = "equipment"
@@ -249,13 +239,12 @@ class CmdEquipment(Command):
 
 class CmdInspect(Command):
     """
-    Inspect an item for detailed information.
+    Examine an item for more information.
 
     Usage:
         inspect <item>
 
-    Example:
-        inspect longsword
+    See |whelp inspect|n for details.
     """
 
     key = "inspect"
@@ -359,13 +348,12 @@ class CmdInspect(Command):
 
 class CmdBuffs(Command):
     """
-    List active buff effects on you.
+    Display active buff effects. Usage: buffs
 
     Usage:
         buffs
 
-    Example:
-        buffs
+    See |whelp buffs|n for details.
     """
 
     key = "buffs"
@@ -411,13 +399,12 @@ class CmdBuffs(Command):
 
 class CmdAffects(Command):
     """
-    List all status and buff effects.
+    View your active buffs and status effects.
 
     Usage:
         affects
 
-    Example:
-        affects
+    See |whelp affects|n for details.
     """
 
     key = "affects"
@@ -471,15 +458,12 @@ class CmdAffects(Command):
 
 class CmdTitle(Command):
     """
-    View or set your character's title.
+    View or change your title. Usage: title [new title]
 
     Usage:
         title
-        title <new title>
 
-    Example:
-        title
-        title The Brave
+    See |whelp title|n for details.
     """
 
     key = "title"
@@ -496,15 +480,12 @@ class CmdTitle(Command):
 
 class CmdPrompt(Command):
     """
-    View or set your command prompt.
+    Customize the information shown in your command prompt.
 
     Usage:
         prompt
-        prompt <format>
 
-    Example:
-        prompt
-        prompt HP:{hp}/{hp_max}> 
+    See |whelp prompt|n for details.
     """
 
     key = "prompt"
@@ -524,13 +505,12 @@ class CmdPrompt(Command):
 
 class CmdScan(Command):
     """
-    Scan adjacent rooms for visible activity.
+    Look around and into adjacent rooms.
 
     Usage:
         scan
 
-    Example:
-        scan
+    See |whelp scan|n for details.
     """
 
     key = "scan"

--- a/commands/interact.py
+++ b/commands/interact.py
@@ -5,13 +5,12 @@ from evennia.utils import make_iter
 
 class CmdGather(Command):
     """
-    Collect resources from a gathering node.
+    Collect resources from a gathering node. Usage: gather
 
     Usage:
         gather
 
-    Example:
-        gather
+    See |whelp gather|n for details.
     """
 
     key = "gather"

--- a/commands/quests.py
+++ b/commands/quests.py
@@ -6,7 +6,14 @@ from world.quests import Quest, QuestManager
 
 
 class CmdQCreate(Command):
-    """Create and register a quest."""
+    """
+    Create and register a new quest. Usage: qcreate <quest_key> "<title>"
+
+    Usage:
+        qcreate
+
+    See |whelp qcreate|n for details.
+    """
 
     key = "qcreate"
     locks = "cmd:perm(Builder)"
@@ -29,7 +36,14 @@ class CmdQCreate(Command):
 
 
 class CmdQSet(Command):
-    """Set quest attributes."""
+    """
+    Change quest attributes. Usage: qset <quest_key> <attr> <value>
+
+    Usage:
+        qset
+
+    See |whelp qset|n for details.
+    """
 
     key = "qset"
     locks = "cmd:perm(Builder)"
@@ -81,7 +95,14 @@ class CmdQSet(Command):
 
 
 class CmdQItem(Command):
-    """Create a quest item linked to a quest."""
+    """
+    Spawn a quest item. Usage: qitem <quest_key> <item_key>
+
+    Usage:
+        qitem
+
+    See |whelp qitem|n for details.
+    """
 
     key = "qitem"
     locks = "cmd:perm(Builder)"
@@ -107,7 +128,14 @@ class CmdQItem(Command):
 
 
 class CmdQAssign(Command):
-    """Assign a quest to an NPC."""
+    """
+    Assign a quest to an NPC. Usage: qassign <npc> <quest_key>
+
+    Usage:
+        qassign
+
+    See |whelp qassign|n for details.
+    """
 
     key = "qassign"
     locks = "cmd:perm(Builder)"
@@ -139,7 +167,14 @@ class CmdQAssign(Command):
 
 
 class CmdQTag(Command):
-    """Tag quests with guild point rewards."""
+    """
+    Set guild point rewards on a quest. Usage: qtag <quest_key> guild <guild> <amount>
+
+    Usage:
+        qtag
+
+    See |whelp qtag|n for details.
+    """
 
     key = "qtag"
     locks = "cmd:perm(Builder)"
@@ -171,7 +206,14 @@ class CmdQTag(Command):
 
 
 class CmdQuestList(Command):
-    """List quests offered by NPCs in the current room."""
+    """
+    List quests offered by NPCs here. Usage: questlist
+
+    Usage:
+        questlist
+
+    See |whelp questlist|n for details.
+    """
 
     key = "questlist"
     aliases = ("quests",)
@@ -215,7 +257,14 @@ class CmdQuestList(Command):
 
 
 class CmdAcceptQuest(Command):
-    """Accept a quest offered by an NPC."""
+    """
+    Accept a quest. Usage: accept <quest>
+
+    Usage:
+        accept
+
+    See |whelp accept|n for details.
+    """
 
     key = "accept"
     help_category = "General"
@@ -262,7 +311,14 @@ class CmdAcceptQuest(Command):
 
 
 class CmdQuestProgress(Command):
-    """Show progress on your active quests."""
+    """
+    Show your progress on active quests. Usage: progress
+
+    Usage:
+        progress
+
+    See |whelp progress|n for details.
+    """
 
     key = "progress"
     help_category = "General"
@@ -291,7 +347,14 @@ class CmdQuestProgress(Command):
 
 
 class CmdCompleteQuest(Command):
-    """Turn in a completed quest."""
+    """
+    Turn in a completed quest. Usage: complete <quest>
+
+    Usage:
+        complete
+
+    See |whelp complete|n for details.
+    """
 
     key = "complete"
     help_category = "General"

--- a/commands/rest.py
+++ b/commands/rest.py
@@ -6,13 +6,12 @@ from .command import Command
 
 class CmdRest(Command):
     """
-    Sit down and rest to regain stamina.
+    Sit down to recover stamina. Usage: rest
 
     Usage:
         rest
 
-    Example:
-        rest
+    See |whelp rest|n for details.
     """
 
     key = "rest"
@@ -32,13 +31,12 @@ class CmdRest(Command):
 
 class CmdSleep(Command):
     """
-    Lie down and go to sleep.
+    Lie down and go to sleep. Usage: sleep
 
     Usage:
         sleep
 
-    Example:
-        sleep
+    See |whelp sleep|n for details.
     """
 
     key = "sleep"
@@ -57,13 +55,12 @@ class CmdSleep(Command):
 
 class CmdWake(Command):
     """
-    Stand up from rest or sleep.
+    Stand up from rest or sleep. Usage: wake
 
     Usage:
         wake
 
-    Example:
-        wake
+    See |whelp wake|n for details.
     """
 
     key = "wake"

--- a/commands/shops.py
+++ b/commands/shops.py
@@ -9,7 +9,12 @@ from .command import Command
 
 class CmdList(Command):
     """
-    View a list of items available for sale.
+    View items a shop has for sale. Usage: list
+
+    Usage:
+        list
+
+    See |whelp list|n for details.
     """
 
     key = "list"
@@ -46,15 +51,12 @@ class CmdList(Command):
 
 class CmdBuy(Command):
     """
-    Attempt to buy an item from this shop.
+    Purchase an item from a shop. Usage: buy <item>
 
     Usage:
-        buy <obj>
-        buy <num> <obj>
+        buy
 
-    Example:
-        buy iron sword
-        buy 12 arrow
+    See |whelp buy|n for details.
     """
 
     key = "buy"
@@ -140,15 +142,12 @@ class CmdBuy(Command):
 
 class CmdSell(Command):
     """
-    Offer something for sale to a shop.
+    Offer an item for sale to a shop. Usage: sell <item>
 
     Usage:
-        sell <obj>
-        sell <num> <obj>
+        sell
 
-    Example:
-        sell sword
-        sell 8 apple
+    See |whelp sell|n for details.
     """
 
     key = "sell"


### PR DESCRIPTION
## Summary
- refresh docstrings for all command classes
- docstrings now briefly describe the command, show usage and point to help

## Testing
- `pytest -q` *(fails: OperationalError no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684261dd640c832ca92e61e9bdbedd16