### PR TITLE
Add get/drop all, hide equipped items from inventory

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -352,8 +352,10 @@ class Character(ObjectParent, ClothedCharacter):
             hands = [hand]
             wielded[hand] = weapon
 
-        # update the character with the new wielded info
+        # update the character with the new wielded info and move the item out of inventory
         self.db._wielded = wielded
+        weapon.location = None
+        self.update_carry_weight()
         from world.system import stat_manager
         stat_manager.refresh_stats(self)
         # return the list of hands that are now holding the weapon
@@ -382,8 +384,10 @@ class Character(ObjectParent, ClothedCharacter):
                 # append the hand to the list of freed hands
                 freed.append(hand)
 
-        # update the character with the new wielded info
+        # update the character with the new wielded info and return weapon to inventory
         self.db._wielded = wielded
+        weapon.location = self
+        self.update_carry_weight()
         from world.system import stat_manager
         stat_manager.refresh_stats(self)
         # return the list of hands that are no longer holding the weapon

--- a/typeclasses/objects.py
+++ b/typeclasses/objects.py
@@ -229,7 +229,19 @@ class ClothingObject(ObjectParent, ContribClothing):
                     wearer.msg("You cannot use a shield while wielding a two-handed weapon.")
                     return
 
-        return super().wear(wearer, wearstyle, quiet=quiet)
+        result = super().wear(wearer, wearstyle, quiet=quiet)
+        if result:
+            self.location = None
+            wearer.update_carry_weight()
+        return result
+
+    def remove(self, wearer, quiet=False):
+        """Return to inventory when removed."""
+        result = super().remove(wearer, quiet=quiet)
+        if result:
+            self.location = wearer
+            wearer.update_carry_weight()
+        return result
 
 
 class GatherNode(Object):


### PR DESCRIPTION
## Summary
- add `drop all` and `get all` commands for convenience
- hide equipped weapons/clothes from inventory by moving them out of the character
- display two–handed weapons under a `Twohands` slot
- update equipment UI and command set

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6842659ed728832cb629be1e6ab17391