### PR TITLE
Improve equipment display with twohanded support

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -84,6 +84,31 @@ class Character(ObjectParent, ClothedCharacter):
             key for key, val in self.attributes.get("_wielded", {}).items() if not val
         ]
 
+    @property
+    def equipment(self):
+        """Return mapping of equipment slots to worn or wielded items."""
+        eq = {}
+
+        wielded = self.attributes.get("_wielded", {})
+        if wielded:
+            wielded.deserialize()
+
+        main = self.db.handedness or "right"
+        off = "left" if main == "right" else "right"
+
+        eq["mainhand"] = wielded.get(main)
+        eq["offhand"] = wielded.get(off)
+
+        for item in get_worn_clothes(self):
+            slots = item.tags.get(category="slot", return_list=True) or []
+            if not slots and (ctype := item.db.clothing_type):
+                slots = [ctype]
+            for slot in slots:
+                if slot:
+                    eq[slot] = item
+
+        return eq
+
     # -------------------------------------------------------------
     # Carry weight helpers
     # -------------------------------------------------------------

--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -105,9 +105,30 @@ class TestInfoCommands(EvenniaTest):
         self.assertTrue(self.char1.msg.called)
 
     def test_equipment(self):
-        self.char1.attributes.add("_wielded", {"left": self.obj1})
+        self.char1.attributes.add("_wielded", {"left": None, "right": None})
         self.char1.execute_cmd("equipment")
-        self.assertTrue(self.char1.msg.called)
+        out = self.char1.msg.call_args[0][0]
+        self.assertIn("Mainhand", out)
+        self.assertIn("Offhand", out)
+        self.assertIn("Hat", out)
+        self.assertIn("Accessory", out)
+
+    def test_equipment_twohanded(self):
+        from evennia.utils import create
+
+        weapon = create.create_object(
+            "typeclasses.gear.MeleeWeapon", key="great", location=self.char1
+        )
+        weapon.tags.add("equipment", category="flag")
+        weapon.tags.add("identified", category="flag")
+        weapon.db.twohanded = True
+
+        self.char1.attributes.add("_wielded", {"left": weapon, "right": weapon})
+        self.char1.execute_cmd("equipment")
+        out = self.char1.msg.call_args[0][0]
+        self.assertIn("Twohands", out)
+        self.assertNotIn("Mainhand", out)
+        self.assertNotIn("Offhand", out)
 
     def test_inspect_identified(self):
         self.obj1.db.desc = "A sharp blade."


### PR DESCRIPTION
## Summary
- implement `equipment` property on characters for easier access to equipped items
- show all equipment slots and handle twohanded weapons via `render_equipment`
- simplify `CmdEquipment` command
- extend command tests for empty slots and twohanded weapons

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684267df8650832ca3dfeb1cc72d9d66