### PR TITLE
Switch exits to dictionary-based navigation

### DIFF
--- a/commands/building.py
+++ b/commands/building.py
@@ -2,7 +2,6 @@ from evennia import create_object
 from evennia.objects.models import ObjectDB
 from .command import Command
 from typeclasses.rooms import Room
-from typeclasses.exits import Exit
 from world.areas import find_area
 
 
@@ -138,20 +137,13 @@ class CmdDig(Command):
         new_room = create_object(Room, key="Room")
         if area:
             new_room.set_area(area, room_id)
-        exit_to = create_object(
-            Exit,
-            key=direction,
-            aliases=[SHORT[direction]],
-            location=caller.location,
-            destination=new_room,
-        )
-        exit_back = create_object(
-            Exit,
-            key=opposite,
-            aliases=[SHORT[opposite]],
-            location=new_room,
-            destination=caller.location,
-        )
+
+        # add exits in both directions
+        caller.location.db.exits = caller.location.db.exits or {}
+        new_room.db.exits = new_room.db.exits or {}
+        caller.location.db.exits[direction] = new_room
+        new_room.db.exits[opposite] = caller.location
+
         caller.msg(f"You dig {direction} and create a new room.")
 
 

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -19,6 +19,7 @@ from evennia.contrib.game_systems.clothing import ClothedCharacterCmdSet
 
 from evennia.contrib.game_systems.containers.containers import ContainerCmdSet
 from evennia.contrib.grid.xyzgrid.commands import XYZGridCmdSet
+from commands.movement import MovementCmdSet
 from evennia.contrib.rpg.character_creator.character_creator import ContribCmdCharCreate
 from evennia.contrib.game_systems.crafting.crafting import CmdCraft
 
@@ -59,6 +60,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(ClothedCharacterCmdSet)
         self.add(CmdMoney)
         self.add(ContainerCmdSet)
+        self.add(MovementCmdSet)
         self.add(XYZGridCmdSet)
         self.add(CmdCraft)
         self.add(CombatCmdSet)

--- a/commands/info.py
+++ b/commands/info.py
@@ -5,16 +5,11 @@ from utils.currency import to_copper, from_copper
 from evennia.contrib.game_systems.clothing.clothing import get_worn_clothes
 from world.stats import CORE_STAT_KEYS
 from utils.stats_utils import get_display_scroll, _strip_colors, _pad
-from evennia.objects.objects import DefaultExit
 
 
 def is_gettable(obj, caller):
     """Return True if caller can pick up obj."""
-    return (
-        obj.access(caller, "get")
-        and not isinstance(obj, DefaultExit)
-        and obj.db.gettable is not False
-    )
+    return obj.access(caller, "get") and obj.db.gettable is not False
 
 
 def render_equipment(caller):

--- a/commands/movement.py
+++ b/commands/movement.py
@@ -1,0 +1,95 @@
+from evennia import CmdSet
+from .command import Command
+
+DIR_MAP = {
+    "n": "north",
+    "north": "north",
+    "s": "south",
+    "south": "south",
+    "e": "east",
+    "east": "east",
+    "w": "west",
+    "west": "west",
+    "ne": "northeast",
+    "northeast": "northeast",
+    "nw": "northwest",
+    "northwest": "northwest",
+    "se": "southeast",
+    "southeast": "southeast",
+    "sw": "southwest",
+    "southwest": "southwest",
+    "u": "up",
+    "up": "up",
+    "d": "down",
+    "down": "down",
+    "i": "in",
+    "in": "in",
+    "o": "out",
+    "out": "out",
+}
+
+
+class MoveCommand(Command):
+    direction = ""
+    key = ""
+    aliases = []
+    locks = "cmd:all()"
+
+    def func(self):
+        dest_info = (self.caller.location.db.exits or {}).get(self.direction)
+        if not dest_info:
+            self.caller.msg("You cannot go that way.")
+            return
+
+        if isinstance(dest_info, dict):
+            map_name = dest_info.get("wilderness_name")
+            coords = dest_info.get("wilderness_coords")
+            if map_name and coords:
+                from evennia.contrib.grid.wilderness import wilderness
+                if wilderness.enter_wilderness(self.caller, coordinates=coords, name=map_name):
+                    return
+                self.caller.msg("You cannot go that way.")
+                return
+            dest = dest_info.get("room")
+        else:
+            dest = dest_info
+
+        if not dest:
+            self.caller.msg("You cannot go that way.")
+            return
+        self.caller.move_to(dest, move_type="exit")
+
+
+def create_move_command(name, aliases):
+    return type(
+        f"Cmd{name.capitalize()}",
+        (MoveCommand,),
+        {"direction": name, "key": name, "aliases": aliases},
+    )
+
+
+# generate commands for all directions
+_move_cmds = [
+    create_move_command("north", ["n"]),
+    create_move_command("south", ["s"]),
+    create_move_command("east", ["e"]),
+    create_move_command("west", ["w"]),
+    create_move_command("northeast", ["ne"]),
+    create_move_command("northwest", ["nw"]),
+    create_move_command("southeast", ["se"]),
+    create_move_command("southwest", ["sw"]),
+    create_move_command("up", ["u"]),
+    create_move_command("down", ["d"]),
+    create_move_command("in", ["i"]),
+    create_move_command("out", ["o"]),
+]
+
+
+class MovementCmdSet(CmdSet):
+    key = "MovementCmdSet"
+
+    def at_cmdset_creation(self):
+        super().at_cmdset_creation()
+        for cmd in _move_cmds:
+            self.add(cmd())
+

--- a/server/conf/settings.py
+++ b/server/conf/settings.py
@@ -46,7 +46,7 @@ COMMAND_DEFAULT_CLASS = "commands.command.MuxCommand"
 EXTRA_LAUNCHER_COMMANDS["xyzgrid"] = "evennia.contrib.grid.xyzgrid.launchcmd.xyzcommand"
 PROTOTYPE_MODULES += ["evennia.contrib.grid.xyzgrid.prototypes"]
 XYZROOM_PROTOTYPE_OVERRIDE = {"typeclass": "typeclasses.rooms.XYGridRoom"}
-XYZEXIT_PROTOTYPE_OVERRIDE = {"typeclass": "typeclasses.exits.XYGridExit"}
+# exits are stored as room.db.exits mappings
 
 
 # Clothing - https://www.evennia.com/docs/latest/Contribs/Contrib-Clothing.html#configuration

--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -25,6 +25,10 @@ class RoomParent(ObjectParent):
         "{name}\n{desc}\n\n{exits}\n\n{characters}\n{things}\n{footer}"
     )
 
+    def at_object_creation(self):
+        super().at_object_creation()
+        self.db.exits = self.db.exits or {}
+
     def at_object_receive(self, mover, source_location, move_type=None, **kwargs):
         """
         Apply extra hooks when an object enters this room, so things (e.g. NPCs) can react.
@@ -99,13 +103,9 @@ class RoomParent(ObjectParent):
     def get_display_exits(self, looker, **kwargs):
         """Return a list of exits visible to ``looker``."""
 
-        exits = [
-            ex.key.capitalize()
-            for ex in self.exits
-            if ex.access(looker, "view")
-        ]
-        if exits:
-            return "|wExits:|n " + ", ".join(exits)
+        exit_names = [key.capitalize() for key in (self.db.exits or {})]
+        if exit_names:
+            return "|wExits:|n " + ", ".join(exit_names)
         else:
             return "|wExits:|n None"
 

--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -414,13 +414,10 @@ class TestDigCommand(EvenniaTest):
     def test_dig_creates_room_and_exits(self):
         start = self.char1.location
         self.char1.execute_cmd("dig north")
-        new_exit = start.exits.get(key="north")
-        self.assertIsNotNone(new_exit)
-        self.assertIn("n", list(new_exit.aliases.all()))
-        new_room = new_exit.destination
-        back_exit = new_room.exits.get(key="south")
-        self.assertIsNotNone(back_exit)
-        self.assertIn("s", list(back_exit.aliases.all()))
+        new_room = start.db.exits.get("north")
+        self.assertIsNotNone(new_room)
+        back = new_room.db.exits.get("south")
+        self.assertEqual(back, start)
         self.char1.execute_cmd("north")
         self.assertEqual(self.char1.location, new_room)
         self.char1.execute_cmd("south")
@@ -430,7 +427,7 @@ class TestDigCommand(EvenniaTest):
         start = self.char1.location
         start.set_area("test", 1)
         self.char1.execute_cmd("dig east test 2")
-        new_room = start.exits.get(key="east").destination
+        new_room = start.db.exits.get("east")
         self.assertEqual(new_room.db.area, "test")
         self.assertEqual(new_room.db.room_id, 2)
 
@@ -450,14 +447,14 @@ class TestExtendedDigTeleport(EvenniaTest):
     def test_dig_eq_syntax(self):
         start = self.char1.location
         self.char1.execute_cmd("dig north=test:2")
-        new_room = start.exits.get(key="north").destination
+        new_room = start.db.exits.get("north")
         self.assertEqual(new_room.db.area, "test")
         self.assertEqual(new_room.db.room_id, 2)
 
     def test_teleport_to_area_room(self):
         start = self.char1.location
         self.char1.execute_cmd("dig east=test:3")
-        target = start.exits.get(key="east").destination
+        target = start.db.exits.get("east")
         self.char1.execute_cmd("@teleport test:3")
         self.assertEqual(self.char1.location, target)
         # out of range should not move

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,1 +1,2 @@
 from .roles import has_role, is_guildmaster, is_receptionist
+

--- a/utils/exit_conversion.py
+++ b/utils/exit_conversion.py
@@ -1,0 +1,22 @@
+from evennia.objects.models import ObjectDB
+
+
+def convert_exits():
+    """Convert all exit objects into room.db.exits mappings."""
+    exits = ObjectDB.objects.filter(db_destination__isnull=False)
+    for ex in exits:
+        src = ex.location
+        dst = ex.db_destination
+        if not src or not dst:
+            continue
+        mapping = src.attributes.get("exits", default={})
+        if ex.db.wilderness_name and ex.db.wilderness_coords:
+            mapping[ex.key] = {
+                "wilderness_name": ex.db.wilderness_name,
+                "wilderness_coords": ex.db.wilderness_coords,
+            }
+        else:
+            mapping[ex.key] = dst
+        src.db.exits = mapping
+        ex.delete()
+


### PR DESCRIPTION
## Summary
- represent room exits with `db.exits` instead of Exit objects
- create movement commands referencing the new mapping
- update builder `dig` command to populate exits dict
- tweak display logic for exits
- add migration helper
- adjust tests for new exit storage

## Testing
- `pytest typeclasses/tests/test_commands.py::TestDigCommand::test_dig_creates_room_and_exits -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68426f4ea190832cadc047be905c3c01