### PR TITLE
Fix unwield search to check wielded items

### DIFF
--- a/commands/combat.py
+++ b/commands/combat.py
@@ -190,7 +190,7 @@ class CmdUnwield(Command):
     def func(self):
         caller = self.caller
 
-        weapon = caller.search(self.args, location=caller)
+        weapon = caller.search(self.args, candidates=caller.wielding)
         if not weapon:
             # no valid object found
             return


### PR DESCRIPTION
## Summary
- fix `CmdUnwield.func` to search among wielded items

## Testing
- `pytest -q` *(fails: `django.db.utils.OperationalError: no such table: accounts_accountdb`)*

------
https://chatgpt.com/codex/tasks/task_e_684275312288832cb0b2a2fe9a03fc96