### PR TITLE
Fix twohanded equipment detection

### DIFF
--- a/commands/info.py
+++ b/commands/info.py
@@ -18,15 +18,7 @@ def render_equipment(caller):
     display = ["+=========================+", "| [ EQUIPMENT ]"]
 
     twohanded_weapon = None
-    if (
-        "mainhand" in eq
-        and eq["mainhand"]
-        and (
-            getattr(eq["mainhand"].db, "twohanded", False)
-            or eq["mainhand"].tags.has("twohanded", category="flag")
-            or eq["mainhand"].tags.has("two_handed", category="wielded")
-        )
-    ):
+    if eq.get("mainhand") and eq.get("mainhand") == eq.get("offhand"):
         twohanded_weapon = eq["mainhand"]
 
     if twohanded_weapon:

--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -121,7 +121,6 @@ class TestInfoCommands(EvenniaTest):
         )
         weapon.tags.add("equipment", category="flag")
         weapon.tags.add("identified", category="flag")
-        weapon.db.twohanded = True
 
         self.char1.attributes.add("_wielded", {"left": weapon, "right": weapon})
         self.char1.execute_cmd("equipment")


### PR DESCRIPTION
## Summary
- detect twohanded weapons when both hands hold the same item
- update command tests

## Testing
- `evennia test` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684277d8fb7c832cbfce4cebd8f99050