### PR TITLE
Add is_twohanded helper

### DIFF
--- a/commands/info.py
+++ b/commands/info.py
@@ -18,8 +18,15 @@ def render_equipment(caller):
     display = ["+=========================+", "| [ EQUIPMENT ]"]
 
     twohanded_weapon = None
-    if eq.get("mainhand") and eq.get("mainhand") == eq.get("offhand"):
-        twohanded_weapon = eq["mainhand"]
+    main = eq.get("mainhand")
+    off = eq.get("offhand")
+    if main and main == off:
+        twohanded_weapon = main
+    else:
+        for weap in (main, off):
+            if weap and getattr(weap, "is_twohanded", lambda: False)():
+                twohanded_weapon = weap
+                break
 
     if twohanded_weapon:
         display.append(

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -347,9 +347,7 @@ class Character(ObjectParent, ClothedCharacter):
             hand = required
 
         # handle two-handed weapons
-        twohanded = weapon.tags.has("two_handed", category="wielded") or weapon.tags.has(
-            "twohanded", category="flag"
-        )
+        twohanded = getattr(weapon, "is_twohanded", lambda: False)()
         if twohanded:
             if any(obj.tags.has("shield", category="flag") for obj in get_worn_clothes(self)):
                 self.msg(

--- a/typeclasses/gear.py
+++ b/typeclasses/gear.py
@@ -63,6 +63,12 @@ class MeleeWeapon(Object):
 
     speed = AttributeProperty(10)
 
+    def is_twohanded(self):
+        """Return True if this weapon requires two hands."""
+        return bool(self.db.twohanded) or self.tags.has(
+            "twohanded", category="flag"
+        ) or self.tags.has("two_handed", category="wielded")
+
     def at_pre_attack(self, wielder, **kwargs):
         """
         Validate that this is usable - has ammo, etc.

--- a/typeclasses/objects.py
+++ b/typeclasses/objects.py
@@ -223,9 +223,8 @@ class ClothingObject(ObjectParent, ContribClothing):
         # shields can't be worn with two-handed weapons
         if self.tags.has("shield", category="flag"):
             for weap in wearer.wielding:
-                if weap.tags.has("twohanded", category="flag") or weap.tags.has(
-                    "two_handed", category="wielded"
-                ):
+                is_twohanded = getattr(weap, "is_twohanded", lambda: False)()
+                if is_twohanded:
                     wearer.msg("You cannot use a shield while wielding a two-handed weapon.")
                     return
 

--- a/typeclasses/tests/test_objects_basic.py
+++ b/typeclasses/tests/test_objects_basic.py
@@ -64,3 +64,44 @@ class TestInspectFlags(EvenniaTest):
         out = self.char1.msg.call_args[0][0]
         self.assertIn("Flags: equipment, rare", out)
 
+
+class TestMeleeWeaponUtility(EvenniaTest):
+    def test_is_twohanded_attribute(self):
+        weapon = create_object(
+            "typeclasses.gear.MeleeWeapon",
+            key="great",
+            location=self.char1,
+            nohome=True,
+        )
+        weapon.db.twohanded = True
+        self.assertTrue(weapon.is_twohanded())
+
+    def test_is_twohanded_flag_tag(self):
+        weapon = create_object(
+            "typeclasses.gear.MeleeWeapon",
+            key="axe",
+            location=self.char1,
+            nohome=True,
+        )
+        weapon.tags.add("twohanded", category="flag")
+        self.assertTrue(weapon.is_twohanded())
+
+    def test_is_twohanded_wielded_tag(self):
+        weapon = create_object(
+            "typeclasses.gear.MeleeWeapon",
+            key="spear",
+            location=self.char1,
+            nohome=True,
+        )
+        weapon.tags.add("two_handed", category="wielded")
+        self.assertTrue(weapon.is_twohanded())
+
+    def test_is_twohanded_false(self):
+        weapon = create_object(
+            "typeclasses.gear.MeleeWeapon",
+            key="sword",
+            location=self.char1,
+            nohome=True,
+        )
+        self.assertFalse(weapon.is_twohanded())
+


### PR DESCRIPTION
## Summary
- implement `MeleeWeapon.is_twohanded`
- use new helper in character wielding, equipment display, and shield checks
- add unit tests for the new helper

## Testing
- `pytest typeclasses/tests/test_objects_basic.py::TestMeleeWeaponUtility::test_is_twohanded_attribute -q` *(fails: settings.DEFAULT_HOME does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_684279de9f68832c95cd7a609ca3ab2a