### PR TITLE
Fix remove command and inventory updates

### DIFF
--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -27,6 +27,7 @@ from evennia.contrib.game_systems.crafting.crafting import CmdCraft
 from commands.combat import CombatCmdSet
 from commands.skills import SkillCmdSet
 from commands.interact import InteractCmdSet
+from commands.equipment import EquipmentCmdSet
 from commands.account import AccountOptsCmdSet
 from commands.shops import CmdMoney
 from commands.info import InfoCmdSet
@@ -69,6 +70,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(InfoCmdSet)
         self.add(RestCmdSet)
         self.add(GuildCmdSet)
+        self.add(EquipmentCmdSet)
         self.add(CmdDig)
         self.add(CmdTeleport)
         self.add(RoomFlagCmdSet)

--- a/commands/equipment.py
+++ b/commands/equipment.py
@@ -1,0 +1,33 @@
+from evennia import CmdSet
+from evennia.contrib.game_systems.clothing.clothing import get_worn_clothes
+from .command import Command
+
+
+class CmdRemove(Command):
+    """Remove a worn item and return it to inventory."""
+
+    key = "remove"
+    aliases = ("takeoff",)
+    help_category = "General"
+
+    def func(self):
+        caller = self.caller
+        if not self.args:
+            caller.msg("Remove what?")
+            return
+
+        candidates = list(get_worn_clothes(caller))
+        # include worn items still in inventory
+        candidates.extend(o for o in caller.contents if getattr(o.db, "worn", False))
+        obj = caller.search(self.args.strip(), candidates=candidates)
+        if not obj:
+            return
+        obj.remove(caller)
+
+
+class EquipmentCmdSet(CmdSet):
+    key = "Equipment CmdSet"
+
+    def at_cmdset_creation(self):
+        super().at_cmdset_creation()
+        self.add(CmdRemove)

--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -409,6 +409,27 @@ class TestRestCommands(EvenniaTest):
         self.char1.msg.assert_any_call("You can't see anything with your eyes closed.")
 
 
+class TestRemoveCommand(EvenniaTest):
+    def test_remove_returns_to_inventory(self):
+        from evennia.utils import create
+
+        item = create.create_object(
+            "typeclasses.objects.ClothingObject",
+            key="cap",
+            location=self.char1,
+        )
+        item.tags.add("equipment", category="flag")
+        item.tags.add("identified", category="flag")
+        item.tags.add("hat", category="slot")
+        item.wear(self.char1, True)
+        self.assertTrue(item.db.worn)
+        self.assertIsNone(item.location)
+
+        self.char1.execute_cmd(f"remove {item.key}")
+        self.assertFalse(item.db.worn)
+        self.assertEqual(item.location, self.char1)
+
+
 class TestDigCommand(EvenniaTest):
     def test_dig_creates_room_and_exits(self):
         start = self.char1.location

--- a/typeclasses/tests/test_objects_basic.py
+++ b/typeclasses/tests/test_objects_basic.py
@@ -76,6 +76,7 @@ class TestObjectFlags(EvenniaTest):
         second.wear(self.char1, "wear")
         self.assertTrue(second.db.worn)
         self.assertFalse(first.db.worn)
+        self.assertEqual(first.location, self.char1)
 
 
 class TestInspectFlags(EvenniaTest):


### PR DESCRIPTION
## Summary
- add new `CmdRemove` command handling worn items not in inventory
- include `EquipmentCmdSet` in default commands
- test that duplicate wear moves prior item back to inventory
- test remove command returns equipment to inventory

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684280a70d5c832c984c0430faf6b0ea