### PR TITLE
Add shield flag to cshield command

### DIFF
--- a/commands/admin.py
+++ b/commands/admin.py
@@ -531,7 +531,7 @@ class CmdCShield(Command):
             except ValueError:
                 self.msg("Weight must be a number.")
                 return
-        _create_gear(
+        obj = _create_gear(
             self.caller,
             "typeclasses.objects.ClothingObject",
             name,
@@ -541,6 +541,8 @@ class CmdCShield(Command):
             desc=None,
             weight=weight,
         )
+
+        obj.tags.add("shield", category="flag")
 
 
 class CmdCArmor(Command):

--- a/typeclasses/tests/test_admin_commands.py
+++ b/typeclasses/tests/test_admin_commands.py
@@ -184,3 +184,21 @@ class TestAdminCommands(EvenniaTest):
         self.assertTrue(armor.tags.has("head", category="slot"))
         armor.wear(self.char1, True)
         self.assertTrue(armor.db.worn)
+
+    def test_cshield_flags_and_blocks_twohanded(self):
+        """Shield created with cshield should get shield flag and block two-handed weapons."""
+
+        self.char1.execute_cmd("cshield buckler offhand 1")
+        shield = next((o for o in self.char1.contents if "buckler" in list(o.aliases.all())), None)
+        self.assertIsNotNone(shield)
+        self.assertTrue(shield.tags.has("shield", category="flag"))
+        shield.wear(self.char1, True)
+        self.assertTrue(shield.db.worn)
+
+        self.char1.attributes.add("_wielded", {"left": None, "right": None})
+        weapon = create_object("typeclasses.gear.MeleeWeapon", key="great", location=self.char1)
+        weapon.tags.add("equipment", category="flag")
+        weapon.tags.add("identified", category="flag")
+        weapon.tags.add("twohanded", category="flag")
+        self.assertIsNone(self.char1.at_wield(weapon))
+        self.assertNotIn(weapon, self.char1.wielding)


### PR DESCRIPTION
## Summary
- tag shields with `shield` flag when created via cshield
- test for shield flag and two‑handed wield block

## Testing
- `pytest -q` *(fails: OperationalError no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68428fb0ae50832c853016621d33c937