### PR TITLE
Update shield creation command

### DIFF
--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -380,7 +380,7 @@ Help for cshield
 Create a shield piece of armor.
 
 Usage:
-    cshield <name> <armor_rating> <weight> <description>
+    cshield <name> <armor_rating> <block_rate> <weight> [stat_mods] <description>
 
 Switches:
     None
@@ -392,7 +392,9 @@ Examples:
     None
 
 Notes:
-    - The armor value is stored on the item.
+    - The armor and block rate values are stored on the item.
+    - Optional stat modifiers can be provided as comma separated entries like
+    |wSTR+2, Attack Power+5|n. Valid stats include all core and derived values.
 
 Related:
     help ansi


### PR DESCRIPTION
## Summary
- enhance `cshield` command with block rate and stat modifiers
- document new shield syntax
- test shield creation with modifiers

## Testing
- `evennia migrate`
- `pytest typeclasses/tests/test_admin_commands.py::TestAdminCommands::test_cshield_flags_and_blocks_twohanded -q` *(fails: Account with the name 'TestAccount' already exists)*

------
https://chatgpt.com/codex/tasks/task_e_6842a1ef9d94832cb7201eb8c49c6a9c