### PR TITLE
Update gear modifier handling

### DIFF
--- a/commands/info.py
+++ b/commands/info.py
@@ -365,7 +365,11 @@ class CmdInspect(Command):
         desc = obj.db.desc or "You see nothing special."
         lines.append(desc)
 
-        mods = getattr(obj.db, "bonuses", None) or getattr(obj.db, "stat_mods", None)
+        mods = (
+            getattr(obj.db, "bonuses", None)
+            or getattr(obj.db, "stat_mods", None)
+            or getattr(obj.db, "modifiers", None)
+        )
         if mods:
             lines.append("Bonuses:")
             for stat, amt in mods.items():

--- a/world/system/stat_manager.py
+++ b/world/system/stat_manager.py
@@ -122,6 +122,8 @@ def _gear_mods(obj) -> Dict[str, int]:  # pragma: no cover - placeholder
             mods = item.attributes.get("stat_mods", default=None)
             if not mods:
                 mods = item.attributes.get("bonuses", default=None)
+            if not mods:
+                mods = item.attributes.get("modifiers", default=None)
             if mods:
                 for stat, val in mods.items():
                     bonus[stat] = bonus.get(stat, 0) + int(val)
@@ -142,6 +144,11 @@ def _gear_mods(obj) -> Dict[str, int]:  # pragma: no cover - placeholder
                 if not mods:
                     try:
                         mods = getter("bonuses", None)
+                    except Exception:
+                        mods = None
+                if not mods:
+                    try:
+                        mods = getter("modifiers", None)
                     except Exception:
                         mods = None
                 if mods:


### PR DESCRIPTION
## Summary
- look up item `modifiers` attr in the stat manager's gear bonus parser
- show `.db.modifiers` info when inspecting items

## Testing
- `pytest -q` *(fails: django.db.utils.OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6842a44fbbd0832cadebaac6128f87ce