### PR TITLE
Update cshield help entry

### DIFF
--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -380,7 +380,7 @@ Help for cshield
 Create a shield piece of armor.
 
 Usage:
-    cshield <name> <armor_rating> <block_rate> <weight> [stat_mods] <description>
+    cshield <name> <armor> <block_rate> <weight> [modifiers] <description>
 
 Switches:
     None
@@ -393,8 +393,9 @@ Examples:
 
 Notes:
     - The armor and block rate values are stored on the item.
-    - Optional stat modifiers can be provided as comma separated entries like
-    |wSTR+2, Attack Power+5|n. Valid stats include all core and derived values.
+    - Optional comma separated modifiers may be given, such as
+    |wBlock Rate+3|n or |wSTR+2, Attack Power+5|n. Valid stats include
+    all core and derived values.
 
 Related:
     help ansi


### PR DESCRIPTION
## Summary
- clarify usage line for cshield command
- explain optional modifiers in help notes

## Testing
- `pytest -q` *(fails: sqlite3.OperationalError - no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6842a5934a10832ca1dea5fb076ff3fa