### PR TITLE
Refresh stats when gear changes

### DIFF
--- a/typeclasses/objects.py
+++ b/typeclasses/objects.py
@@ -18,6 +18,7 @@ from evennia.contrib.game_systems.clothing import ContribClothing
 from evennia.contrib.game_systems.clothing.clothing import get_worn_clothes
 
 from commands.interact import GatherCmdSet
+from world.system import stat_manager
 
 
 class ObjectParent:
@@ -231,6 +232,7 @@ class ClothingObject(ObjectParent, ContribClothing):
         if result:
             self.location = None
             wearer.update_carry_weight()
+            stat_manager.refresh_stats(wearer)
         return result
 
     def remove(self, wearer, quiet=False):
@@ -239,6 +241,7 @@ class ClothingObject(ObjectParent, ContribClothing):
         if result:
             self.location = wearer
             wearer.update_carry_weight()
+            stat_manager.refresh_stats(wearer)
         return result
 
 


### PR DESCRIPTION
## Summary
- ensure stat manager is available in `objects`
- refresh stats whenever gear is worn or removed

## Testing
- `pytest -q` *(fails: OperationalError - no such table)*

------
https://chatgpt.com/codex/tasks/task_e_6842aa831b48832c85b78a8614e49177