### PR TITLE
Improve search for equipped item removal

### DIFF
--- a/commands/equipment.py
+++ b/commands/equipment.py
@@ -3,17 +3,17 @@ from evennia.utils.ansi import strip_ansi
 from .command import Command
 
 
-def match_name(obj, name):
-    """Return True if obj.key matches name ignoring ANSI."""
-    return strip_ansi(obj.key).lower() == name.lower()
-
-
 def get_equipped_item_by_name(caller, itemname):
     """Find equipped item by name."""
     eq = caller.equipment
+    candidates = [item for item in eq.values() if item]
+    searchstr = strip_ansi(itemname)
+    obj = caller.search(searchstr, candidates=candidates)
+    if not obj:
+        return None, None
     for slot, item in eq.items():
-        if item and match_name(item, itemname):
-            return slot, item
+        if item == obj:
+            return slot, obj
     return None, None
 
 

--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -443,6 +443,31 @@ class TestRemoveCommand(EvenniaTest):
         self.assertFalse(item.db.worn)
         self.assertEqual(item.location, self.char1)
 
+    def test_remove_partial_and_alias(self):
+        from evennia.utils import create
+
+        item = create.create_object(
+            "typeclasses.objects.ClothingObject",
+            key="|gbright cap|n",
+            location=self.char1,
+        )
+        item.aliases.add("capper")
+        item.tags.add("equipment", category="flag")
+        item.tags.add("identified", category="flag")
+        item.tags.add("helm", category="slot")
+        item.wear(self.char1, True)
+
+        # partial key
+        self.char1.execute_cmd("remove bright")
+        self.assertFalse(item.db.worn)
+        self.assertEqual(item.location, self.char1)
+
+        item.wear(self.char1, True)
+        # alias
+        self.char1.execute_cmd("remove capper")
+        self.assertFalse(item.db.worn)
+        self.assertEqual(item.location, self.char1)
+
 
 class TestRemoveAllCommand(EvenniaTest):
     def test_remove_all_removes_everything(self):


### PR DESCRIPTION
## Summary
- use `caller.search` with equipped items as candidates when removing gear
- support partial names and aliases when stripping ANSI
- test removing equipped items by partial name and alias

## Testing
- `python -m pytest typeclasses/tests/test_commands.py::TestRemoveCommand::test_remove_partial_and_alias -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6842ac4c7400832c93cead67977c9d3f