### PR TITLE
Handle buffs on gear

### DIFF
--- a/typeclasses/tests/test_stat_manager.py
+++ b/typeclasses/tests/test_stat_manager.py
@@ -1,4 +1,5 @@
 from evennia.utils.test_resources import EvenniaTest
+from evennia.utils import create
 from world.system import stat_manager, state_manager
 from world import stats
 
@@ -87,3 +88,19 @@ class TestStatManager(EvenniaTest):
         self.assertEqual(char.traits.DEX.base, base - 5)
         state_manager.tick_character(char)
         self.assertEqual(char.traits.DEX.base, base)
+
+    def test_gear_buffs_apply(self):
+        char = self.char1
+        stat_manager.refresh_stats(char)
+        base_hp = char.db.derived_stats.get("HP")
+        item = create.create_object(
+            "typeclasses.objects.ClothingObject",
+            key="amulet",
+            location=char,
+        )
+        item.tags.add("equipment", category="flag")
+        item.tags.add("identified", category="flag")
+        item.db.buffs = {"HP": 100}
+        item.wear(char, True)
+        stat_manager.refresh_stats(char)
+        self.assertEqual(char.db.derived_stats.get("HP"), base_hp + 100)

--- a/world/system/stat_manager.py
+++ b/world/system/stat_manager.py
@@ -124,6 +124,8 @@ def _gear_mods(obj) -> Dict[str, int]:  # pragma: no cover - placeholder
                 mods = item.attributes.get("bonuses", default=None)
             if not mods:
                 mods = item.attributes.get("modifiers", default=None)
+            if not mods:
+                mods = item.attributes.get("buffs", default=None)
             if mods:
                 for stat, val in mods.items():
                     bonus[stat] = bonus.get(stat, 0) + int(val)
@@ -149,6 +151,11 @@ def _gear_mods(obj) -> Dict[str, int]:  # pragma: no cover - placeholder
                 if not mods:
                     try:
                         mods = getter("modifiers", None)
+                    except Exception:
+                        mods = None
+                if not mods:
+                    try:
+                        mods = getter("buffs", None)
                     except Exception:
                         mods = None
                 if mods:


### PR DESCRIPTION
## Summary
- support `buffs` on gear when aggregating equipment stat modifiers
- verify that gear buffs increase derived stats

## Testing
- `pytest -q` *(fails: OperationalError no such table: accounts_accountdb)*
- `pytest typeclasses/tests/test_stat_manager.py::TestStatManager::test_gear_buffs_apply -q` *(fails: OperationalError no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6842add2ca34832c93de538df4083da1