### PR TITLE
Track equipment bonuses

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -158,6 +158,7 @@ class Character(ObjectParent, ClothedCharacter):
         self.db.guild_points = {}
         self.db.guild_rank = ""
         self.db.stat_overrides = {}
+        self.db.equip_bonuses = {}
         self.db.sated = 5
 
     def at_post_puppet(self, **kwargs):
@@ -385,6 +386,7 @@ class Character(ObjectParent, ClothedCharacter):
         weapon.location = None
         self.update_carry_weight()
         from world.system import stat_manager
+        stat_manager.add_equip_bonus(self, weapon)
         stat_manager.refresh_stats(self)
         # return the list of hands that are now holding the weapon
         return hands
@@ -417,6 +419,7 @@ class Character(ObjectParent, ClothedCharacter):
         weapon.location = self
         self.update_carry_weight()
         from world.system import stat_manager
+        stat_manager.remove_equip_bonus(self, weapon)
         stat_manager.refresh_stats(self)
         # return the list of hands that are no longer holding the weapon
         return freed

--- a/typeclasses/objects.py
+++ b/typeclasses/objects.py
@@ -232,6 +232,7 @@ class ClothingObject(ObjectParent, ContribClothing):
         if result:
             self.location = None
             wearer.update_carry_weight()
+            stat_manager.add_equip_bonus(wearer, self)
             stat_manager.refresh_stats(wearer)
         return result
 
@@ -241,6 +242,7 @@ class ClothingObject(ObjectParent, ContribClothing):
         if result:
             self.location = wearer
             wearer.update_carry_weight()
+            stat_manager.remove_equip_bonus(wearer, self)
             stat_manager.refresh_stats(wearer)
         return result
 

--- a/typeclasses/tests/test_stat_manager.py
+++ b/typeclasses/tests/test_stat_manager.py
@@ -103,4 +103,23 @@ class TestStatManager(EvenniaTest):
         item.db.buffs = {"HP": 100}
         item.wear(char, True)
         stat_manager.refresh_stats(char)
+        self.assertEqual(char.db.equip_bonuses.get("HP"), 100)
         self.assertEqual(char.db.derived_stats.get("HP"), base_hp + 100)
+
+    def test_equip_bonus_removed(self):
+        char = self.char1
+        stat_manager.refresh_stats(char)
+        item = create.create_object(
+            "typeclasses.objects.ClothingObject",
+            key="ring",
+            location=char,
+        )
+        item.tags.add("equipment", category="flag")
+        item.tags.add("identified", category="flag")
+        item.db.modifiers = {"STR": 2}
+        item.wear(char, True)
+        stat_manager.refresh_stats(char)
+        self.assertEqual(char.db.equip_bonuses.get("STR"), 2)
+        item.remove(char, True)
+        stat_manager.refresh_stats(char)
+        self.assertFalse(char.db.equip_bonuses)


### PR DESCRIPTION
## Summary
- add a `db.equip_bonuses` store for equipped bonuses
- update wear and wield hooks to modify equipment bonuses
- expose helper functions in `stat_manager`
- include equip bonus totals in refresh
- test equip bonus tracking

## Testing
- `evennia migrate`
- `pytest -q` *(fails: settings.DEFAULT_HOME (#2) does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6842af8c40f4832c8bf25495f84a7a98