### PR TITLE
Display equip bonuses on sheet

### DIFF
--- a/utils/tests/test_stats_utils.py
+++ b/utils/tests/test_stats_utils.py
@@ -9,3 +9,9 @@ class TestDisplayScroll(EvenniaTest):
         sheet = get_display_scroll(char)
         self.assertIn("Sated", sheet)
         self.assertIn("URGENT", sheet)
+
+    def test_bonus_display(self):
+        char = self.char1
+        char.db.equip_bonuses = {"STR": 2}
+        sheet = get_display_scroll(char)
+        self.assertIn("(+2)", sheet)


### PR DESCRIPTION
## Summary
- show base and bonus stats separately
- include equipment bonuses when displaying primary and secondary stats
- test bonus display formatting

## Testing
- `pytest -q utils/tests/test_stats_utils.py::TestDisplayScroll::test_bonus_display -s` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6842b2b46a88832c8209209c1bfa7c38