### PR TITLE
Handle quoted names for gear commands

### DIFF
--- a/commands/admin.py
+++ b/commands/admin.py
@@ -478,7 +478,7 @@ class CmdCGear(Command):
             )
             return
         tclass = parts[0]
-        name = parts[1]
+        name = parts[1].strip("'\"")
         idx = 2
         slot = None
         if idx < len(parts) and not parts[idx].lstrip("-+").isdigit():
@@ -539,12 +539,16 @@ class CmdOCreate(Command):
             name = "object"
             weight = 0
         else:
-            parts = self.args.split(None, 1)
-            name = parts[0]
+            parts = shlex.split(self.args)
+            if not parts:
+                self.msg("Usage: ocreate <name>")
+                return
+            name = parts[0].strip("'\"")
             weight = 0
-            if len(parts) > 1:
-                if parts[1].isdigit():
-                    weight = int(parts[1])
+            weight_str = " ".join(parts[1:])
+            if weight_str:
+                if weight_str.isdigit():
+                    weight = int(weight_str)
                 else:
                     self.msg("Weight must be a number.")
                     return
@@ -587,18 +591,18 @@ class CmdCWeapon(Command):
             )
             return
 
-        parts = argstr.split(None, 4)
+        parts = shlex.split(argstr)
         if len(parts) < 5:
             self.msg(
                 "Usage: cweapon [/unidentified] <name> <slot> <damage> <weight> [stat_mods] <description>"
             )
             return
-        name = parts[0]
+        name = parts[0].strip("'\"")
         slot = parts[1].lower()
 
         dmg_arg = parts[2]
         weight_str = parts[3]
-        rest = parts[4]
+        rest = " ".join(parts[4:])
 
         if slot not in VALID_SLOTS:
             self.msg("Invalid slot name.")
@@ -725,17 +729,17 @@ class CmdCShield(Command):
                 "Usage: cshield [/unidentified] <name> <armor_rating> <block_rate> <weight> [stat_mods] <description>"
             )
             return
-        parts = argstr.split(None, 4)
+        parts = shlex.split(argstr)
         if len(parts) < 5:
             self.msg(
                 "Usage: cshield [/unidentified] <name> <armor_rating> <block_rate> <weight> [stat_mods] <description>"
             )
             return
-        name = parts[0]
+        name = parts[0].strip("'\"")
         armor_str = parts[1]
         block_rate_str = parts[2]
         weight_str = parts[3]
-        rest = parts[4]
+        rest = " ".join(parts[4:])
 
         try:
             armor = int(armor_str)
@@ -856,6 +860,7 @@ class CmdCArmor(Command):
             )
             return
         name, slot, armor_str, weight_str = parts[:4]
+        name = name.strip("'\"")
         rest = " ".join(parts[4:])
         try:
             bonuses, desc = parse_stat_mods(rest)
@@ -918,7 +923,7 @@ class CmdCTool(Command):
         if not parts:
             self.msg("Usage: ctool <name> [tag] [weight] [stat_mods] <description>")
             return
-        name = parts[0]
+        name = parts[0].strip("'\"")
         tag = None
         weight = 0
         idx = 1
@@ -989,7 +994,7 @@ class CmdCRing(Command):
                 "Usage: cring [/unidentified] <name> [slot] [weight] [stat_mods] <description>"
             )
             return
-        name = parts[0]
+        name = parts[0].strip("'\"")
         slot = "ring1"
         weight = 0
         idx = 1
@@ -1060,7 +1065,7 @@ class CmdCTrinket(Command):
                 "Usage: ctrinket [/unidentified] <name> [slot] [weight] [stat_mods] <description>"
             )
             return
-        name = parts[0]
+        name = parts[0].strip("'\"")
         slot = "accessory"
         weight = 0
         idx = 1

--- a/typeclasses/tests/test_admin_commands.py
+++ b/typeclasses/tests/test_admin_commands.py
@@ -397,3 +397,37 @@ class TestAdminCommands(EvenniaTest):
         self.assertIsNotNone(gear)
         self.assertEqual(gear.db.stat_mods, {"str": 1, "con": 2})
         self.assertEqual(gear.db.desc, "A special token.")
+
+    def test_creation_commands_strip_quotes(self):
+        self.char1.execute_cmd('cweapon "long sword" mainhand 3 1 sharp blade')
+        weapon = next((o for o in self.char1.contents if o.key == "Long sword"), None)
+        self.assertIsNotNone(weapon)
+
+        self.char1.execute_cmd('cshield "kite shield" 2 5 1 sturdy')
+        shield = next((o for o in self.char1.contents if o.key == "kite shield"), None)
+        self.assertIsNotNone(shield)
+
+        self.char1.execute_cmd('carmor "iron helm" helm 1 1 basic')
+        armor = next((o for o in self.char1.contents if o.key == "iron helm"), None)
+        self.assertIsNotNone(armor)
+
+        self.char1.execute_cmd('ctool "rock hammer" smith 2 heavy')
+        tool = next((o for o in self.char1.contents if o.key == "rock hammer"), None)
+        self.assertIsNotNone(tool)
+
+        self.char1.execute_cmd('cring "ruby ring" ring2 1 shiny')
+        ring = next((o for o in self.char1.contents if o.key == "ruby ring"), None)
+        self.assertIsNotNone(ring)
+
+        self.char1.execute_cmd('ctrinket "lucky charm" accessory 1 shiny')
+        trinket = next((o for o in self.char1.contents if o.key == "lucky charm"), None)
+        self.assertIsNotNone(trinket)
+
+        self.char1.execute_cmd('cgear typeclasses.objects.Object "mysterious orb" accessory 1 1 odd')
+        gear = next((o for o in self.char1.contents if o.key == "mysterious orb"), None)
+        self.assertIsNotNone(gear)
+
+        self.char1.execute_cmd('ocreate "strange box" 1')
+        obj = next((o for o in self.char1.contents if o.key == "strange box"), None)
+        self.assertIsNotNone(obj)
+


### PR DESCRIPTION
## Summary
- replace string splitting with `shlex.split()`
- strip surrounding quotes from item names
- regression test for creating items with quotes

## Testing
- `pytest -q` *(fails: OperationalError no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6842bce7ace8832c98ab1d649ee5d91b