### PR TITLE
Normalize stat keys across gear systems

### DIFF
--- a/commands/admin.py
+++ b/commands/admin.py
@@ -13,52 +13,15 @@ from .building import (
     CmdSetFlag,
     CmdRemoveFlag,
 )
-from world.stats import CORE_STAT_KEYS
+from world.stats import CORE_STAT_KEYS, ALL_STATS
 from world.system import stat_manager
-from utils.stats_utils import get_display_scroll
+from utils.stats_utils import get_display_scroll, normalize_stat_key
 from utils import VALID_SLOTS
 
 
 # Valid stats that can be modified by gear bonuses
-VALID_STATS = [
-    "str",
-    "con",
-    "dex",
-    "int",
-    "wis",
-    "luck",
-    "per",
-    "evasion",
-    "armor",
-    "magic_resist",
-    "dodge",
-    "block_rate",
-    "parry_rate",
-    "status_resist",
-    "critical_resist",
-    "attack_power",
-    "spell_power",
-    "critical_chance",
-    "critical_damage_bonus",
-    "accuracy",
-    "armor_penetration",
-    "spell_penetration",
-    "health_regen",
-    "mana_regen",
-    "stamina_regen",
-    "lifesteal",
-    "leech",
-    "cooldown_reduction",
-    "initiative",
-    "stealth",
-    "detection",
-    "threat",
-    "movement_speed",
-    "crafting_bonus",
-    "pvp_power",
-    "pvp_resilience",
-    "guild_honor_rank_modifiers",
-]
+VALID_STATS = {normalize_stat_key(stat.key) for stat in ALL_STATS}
+VALID_STATS.update({"HP", "MP", "SP"})
 
 
 def parse_stat_mods(text):
@@ -86,7 +49,7 @@ def parse_stat_mods(text):
         if match:
             stat_name = match.group(1).strip()
             amount = int(match.group(2))
-            key = stat_name.lower().replace(" ", "_")
+            key = normalize_stat_key(stat_name)
             if key not in VALID_STATS:
                 raise ValueError(stat_name)
             bonuses[key] = amount

--- a/typeclasses/tests/test_stat_manager.py
+++ b/typeclasses/tests/test_stat_manager.py
@@ -123,3 +123,25 @@ class TestStatManager(EvenniaTest):
         item.remove(char, True)
         stat_manager.refresh_stats(char)
         self.assertFalse(char.db.equip_bonuses)
+
+    def test_lowercase_item_modifiers(self):
+        char = self.char1
+        stat_manager.refresh_stats(char)
+        base_str = char.traits.STR.base
+        base_per = char.db.derived_stats.get("perception")
+
+        item = create.create_object(
+            "typeclasses.objects.ClothingObject",
+            key="bauble",
+            location=char,
+        )
+        item.tags.add("equipment", category="flag")
+        item.tags.add("identified", category="flag")
+        item.db.stat_mods = {"str": 2, "per": 100}
+        item.wear(char, True)
+        stat_manager.refresh_stats(char)
+
+        self.assertEqual(char.db.equip_bonuses.get("STR"), 2)
+        self.assertEqual(char.db.equip_bonuses.get("perception"), 100)
+        self.assertEqual(char.traits.STR.base, base_str + 2)
+        self.assertEqual(char.db.derived_stats.get("perception"), base_per + 100)

--- a/utils/stats_utils.py
+++ b/utils/stats_utils.py
@@ -15,6 +15,33 @@ from world.system import stat_manager
 import math
 import re
 
+ALIAS_MAP = {
+    "str": "STR",
+    "con": "CON",
+    "dex": "DEX",
+    "int": "INT",
+    "wis": "WIS",
+    "luck": "LUCK",
+    "per": "perception",
+    "critical_chance": "crit_chance",
+    "critical_damage_bonus": "crit_bonus",
+    "critical_resist": "crit_resist",
+    "armor_penetration": "piercing",
+    "crafting_bonus": "craft_bonus",
+    "guild_honor_rank_modifiers": "guild_honor_mod",
+}
+
+
+def normalize_stat_key(key: str) -> str:
+    """Return canonical stat key for ``key``."""
+    name = str(key).strip().replace(" ", "_")
+    lower = name.lower()
+    if lower in ALIAS_MAP:
+        return ALIAS_MAP[lower]
+    if lower in {"str", "con", "dex", "int", "wis", "luck"}:
+        return lower.upper()
+    return lower
+
 PRIMARY_EXTRA = "perception"
 
 # Build list of secondary stats from world.stats excluding core attributes,


### PR DESCRIPTION
## Summary
- normalize stat key aliases with `normalize_stat_key`
- validate admin stat modifiers using normalized keys
- normalize keys when collecting item bonuses
- store normalized stat bonuses from equipment
- test lowercase stat modifiers

## Testing
- `pytest typeclasses/tests/test_stat_manager.py::TestStatManager::test_lowercase_item_modifiers -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6842c5bdb0e0832c965446d8348696e0