### PR TITLE
Add consumable builder commands

### DIFF
--- a/commands/admin.py
+++ b/commands/admin.py
@@ -1064,6 +1064,101 @@ class CmdCTrinket(Command):
             obj.db.stat_mods = bonuses
 
 
+class CmdCFood(Command):
+    """Create a food item."""
+
+    key = "cfood"
+    locks = "cmd:perm(Builder)"
+    help_category = "Building"
+
+    def func(self):
+        parts = shlex.split(self.args)
+        if len(parts) < 3:
+            self.msg("Usage: cfood <name> <sated_boost> <description>")
+            return
+        name = parts[0].strip("'\"")
+        boost_str = parts[1]
+        rest = " ".join(parts[2:])
+        if not boost_str.lstrip("-+").isdigit():
+            self.msg("Sated boost must be a number.")
+            return
+        boost = int(boost_str)
+
+        obj = _create_gear(
+            self.caller,
+            "typeclasses.objects.Object",
+            name,
+            desc=rest,
+        )
+        obj.tags.add("edible")
+        obj.db.item_type = "food"
+        obj.db.sated = boost
+
+
+class CmdCDrink(Command):
+    """Create a drink item."""
+
+    key = "cdrink"
+    locks = "cmd:perm(Builder)"
+    help_category = "Building"
+
+    def func(self):
+        parts = shlex.split(self.args)
+        if len(parts) < 3:
+            self.msg("Usage: cdrink <name> <sated_boost> <description>")
+            return
+        name = parts[0].strip("'\"")
+        boost_str = parts[1]
+        rest = " ".join(parts[2:])
+        if not boost_str.lstrip("-+").isdigit():
+            self.msg("Sated boost must be a number.")
+            return
+        boost = int(boost_str)
+
+        obj = _create_gear(
+            self.caller,
+            "typeclasses.objects.Object",
+            name,
+            desc=rest,
+        )
+        obj.tags.add("edible")
+        obj.db.item_type = "drink"
+        obj.db.sated = boost
+
+
+class CmdCPotion(Command):
+    """Create a potion item."""
+
+    key = "cpotion"
+    locks = "cmd:perm(Builder)"
+    help_category = "Building"
+
+    def func(self):
+        parts = shlex.split(self.args)
+        if len(parts) < 2:
+            self.msg("Usage: cpotion <name> <bonuses> <description>")
+            return
+        name = parts[0].strip("'\"")
+        rest = " ".join(parts[1:])
+        try:
+            bonuses, desc = parse_stat_mods(rest)
+        except ValueError as err:
+            self.msg(f"Invalid stat modifier: {err}")
+            return
+
+        obj = _create_gear(
+            self.caller,
+            "typeclasses.objects.Object",
+            name,
+            desc=desc,
+        )
+        obj.tags.add("edible")
+        obj.db.item_type = "drink"
+        obj.db.is_potion = True
+        if bonuses:
+            obj.db.buffs = bonuses
+
+
 class AdminCmdSet(CmdSet):
     """Command set with admin utilities."""
 
@@ -1095,6 +1190,9 @@ class BuilderCmdSet(CmdSet):
         self.add(CmdCShield)
         self.add(CmdCArmor)
         self.add(CmdCTool)
+        self.add(CmdCFood)
+        self.add(CmdCDrink)
+        self.add(CmdCPotion)
         self.add(CmdCRing)
         self.add(CmdCTrinket)
         self.add(CmdCGear)

--- a/typeclasses/tests/test_consumable_commands.py
+++ b/typeclasses/tests/test_consumable_commands.py
@@ -1,0 +1,65 @@
+from unittest.mock import MagicMock
+
+from evennia.utils.test_resources import EvenniaTest
+from django.test import override_settings
+
+from commands.admin import BuilderCmdSet
+from commands.interact import InteractCmdSet
+
+
+@override_settings(DEFAULT_HOME=None)
+class TestConsumableCommands(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.char1.msg = MagicMock()
+        self.char1.cmdset.add_default(InteractCmdSet)
+        self.char1.cmdset.add_default(BuilderCmdSet)
+
+    def _find(self, key):
+        for obj in self.char1.contents:
+            if obj.key.lower() == key.lower():
+                return obj
+        return None
+
+    def test_cfood_create_and_eat(self):
+        self.char1.execute_cmd("cfood apple 4 tasty")
+        food = self._find("apple")
+        self.assertIsNotNone(food)
+        self.assertTrue(food.tags.has("edible"))
+        self.assertEqual(food.db.item_type, "food")
+        self.assertEqual(food.db.sated, 4)
+        self.assertEqual(food.db.desc, "tasty")
+
+        before = self.char1.db.sated or 0
+        self.char1.execute_cmd("eat apple")
+        self.assertIsNone(food.pk)
+        self.assertEqual(self.char1.db.sated, before + 4)
+
+    def test_cdrink_create_and_drink(self):
+        self.char1.execute_cmd("cdrink water 2 clear")
+        drink = self._find("water")
+        self.assertIsNotNone(drink)
+        self.assertTrue(drink.tags.has("edible"))
+        self.assertEqual(drink.db.item_type, "drink")
+        self.assertEqual(drink.db.sated, 2)
+        self.assertEqual(drink.db.desc, "clear")
+
+        before = self.char1.db.sated or 0
+        self.char1.execute_cmd("drink water")
+        self.assertIsNone(drink.pk)
+        self.assertEqual(self.char1.db.sated, before + 2)
+
+    def test_cpotion_create_and_quaff(self):
+        self.char1.execute_cmd("cpotion elixir STR+1, HP+5 magic")
+        potion = self._find("elixir")
+        self.assertIsNotNone(potion)
+        self.assertTrue(potion.tags.has("edible"))
+        self.assertEqual(potion.db.item_type, "drink")
+        self.assertTrue(potion.db.is_potion)
+        self.assertEqual(potion.db.buffs, {"STR": 1, "HP": 5})
+
+        before = self.char1.db.sated or 0
+        self.char1.execute_cmd("quaff elixir")
+        self.assertIsNone(potion.pk)
+        self.assertEqual(self.char1.db.sated, before)
+


### PR DESCRIPTION
## Summary
- add commands to create food, drinks, and potions
- register those commands in the builder cmdset
- add tests covering creation and consumption of new items

## Testing
- `pytest -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6842ca154dd8832c9e0b6a2306ca730e