### PR TITLE
Update stat display functions with buff support

### DIFF
--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -96,6 +96,25 @@ class TestInfoCommands(EvenniaTest):
         self.assertIn("PRIMARY STATS", out)
         self.assertIn("+", out)
 
+    def test_score_shows_gear_bonus(self):
+        from evennia.utils import create
+        from world.system import stat_manager
+
+        item = create.create_object(
+            "typeclasses.objects.ClothingObject",
+            key="amulet",
+            location=self.char1,
+        )
+        item.tags.add("equipment", category="flag")
+        item.tags.add("identified", category="flag")
+        item.db.stat_mods = {"STR": 1}
+        item.wear(self.char1, True)
+        stat_manager.refresh_stats(self.char1)
+
+        self.char1.execute_cmd("score")
+        out = self.char1.msg.call_args[0][0]
+        self.assertIn("(+1)", out)
+
     def test_inventory(self):
         self.char1.execute_cmd("inventory")
         self.assertTrue(self.char1.msg.called)


### PR DESCRIPTION
## Summary
- handle equip and buff bonuses in `get_primary_stats` and `get_secondary_stats`
- test score output shows gear bonuses

## Testing
- `pytest utils/tests/test_stats_utils.py::TestDisplayScroll::test_bonus_display -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6842cc9f5fb8832c8dc722cd894a5533