### PR TITLE
Cap Sated stat at 100

### DIFF
--- a/commands/interact.py
+++ b/commands/interact.py
@@ -1,6 +1,7 @@
 from .command import Command
 from evennia import CmdSet
 from evennia.utils import make_iter
+from world.system.state_manager import MAX_SATED
 
 
 class CmdGather(Command):
@@ -72,7 +73,7 @@ class CmdEat(Command):
         caller.traits.stamina.current += stamina
 
         sated = obj.attributes.get("sated", 0)
-        caller.db.sated = (caller.db.sated or 0) + sated
+        caller.db.sated = min((caller.db.sated or 0) + sated, MAX_SATED)
 
         caller.at_emote(
             f"$conj({self.cmdstring}) the {{target}}.", mapping={"target": obj}

--- a/typeclasses/tests/test_interact_commands.py
+++ b/typeclasses/tests/test_interact_commands.py
@@ -46,3 +46,10 @@ class TestInteractCommands(EvenniaTest):
         self.assertIsNone(potion.pk)
         self.assertEqual(self.char1.traits.stamina.current, stam + 2)
         self.assertEqual(self.char1.db.sated, sated + 3)
+
+    def test_sated_cap(self):
+        food = self._make_food()
+        food.db.sated = 10
+        self.char1.db.sated = 95
+        self.char1.execute_cmd(f"eat {food.key}")
+        self.assertEqual(self.char1.db.sated, 100)

--- a/typeclasses/tests/test_state_manager.py
+++ b/typeclasses/tests/test_state_manager.py
@@ -62,3 +62,9 @@ class TestStateManager(EvenniaTest):
         self.assertEqual(char.db.sated, 0)
         self.assertTrue(char.tags.has("hungry_thirsty", category="status"))
         self.assertEqual(char.traits.health.current, hp - 1)
+
+    def test_hunger_cap(self):
+        char = self.char1
+        char.db.sated = 150
+        state_manager.tick_character(char)
+        self.assertLessEqual(char.db.sated, state_manager.MAX_SATED)

--- a/utils/stats_utils.py
+++ b/utils/stats_utils.py
@@ -39,6 +39,7 @@ from world.stats import (
     apply_stats,
 )
 from world.system import stat_manager
+from world.system.state_manager import MAX_SATED
 import math
 import re
 
@@ -180,9 +181,9 @@ def get_display_scroll(chara):
 
     sated_val = 0
     if hasattr(chara.db, "sated"):
-        sated_val = chara.db.sated or 0
+        sated_val = min(chara.db.sated or 0, MAX_SATED)
     elif chara.traits.get("sated"):
-        sated_val = chara.traits.sated.value
+        sated_val = min(chara.traits.sated.value, MAX_SATED)
     if sated_val <= 0:
         sated_disp = "|r0 (URGENT)|n"
     elif sated_val < 5:

--- a/utils/tests/test_stats_utils.py
+++ b/utils/tests/test_stats_utils.py
@@ -15,3 +15,10 @@ class TestDisplayScroll(EvenniaTest):
         char.db.equip_bonuses = {"STR": 2}
         sheet = get_display_scroll(char)
         self.assertIn("(+2)", sheet)
+
+    def test_sated_display_full(self):
+        char = self.char1
+        char.db.sated = 150
+        sheet = get_display_scroll(char)
+        self.assertIn("Sated", sheet)
+        self.assertIn("100", sheet)

--- a/world/chargen_menu.py
+++ b/world/chargen_menu.py
@@ -276,7 +276,7 @@ def menunode_finish(caller, **kwargs):
         stat: char.traits.get(stat).base for stat in STAT_LIST
     }
 
-    from world.system import stat_manager
+    from world.system import stat_manager, state_manager
     stat_manager.refresh_stats(char)
 
     # start fully recovered
@@ -286,7 +286,7 @@ def menunode_finish(caller, **kwargs):
         char.traits.mana.current = char.traits.mana.max
     if char.traits.get("stamina"):
         char.traits.stamina.current = char.traits.stamina.max
-    char.db.sated = 100
+    char.db.sated = state_manager.MAX_SATED
     stat_manager.refresh_stats(char)
 
     # assign the newly created character to this account

--- a/world/system/state_manager.py
+++ b/world/system/state_manager.py
@@ -5,6 +5,9 @@ from world import stats
 from world.system import stat_manager
 from world.effects import EFFECTS
 
+# Maximum fullness a character can reach from food or drink.
+MAX_SATED = 100
+
 
 def _get_bonus_dict(chara) -> Dict[str, List[dict]]:
     return chara.db.temp_bonuses or {}
@@ -207,7 +210,7 @@ def tick_character(chara):
 
     # Hunger and thirst
     if hasattr(chara.db, "sated"):
-        sated = chara.db.sated or 0
+        sated = min(chara.db.sated or 0, MAX_SATED)
         if sated > 0:
             chara.db.sated = sated - 1
         if chara.db.sated <= 0:


### PR DESCRIPTION
## Summary
- limit `sated` value to `MAX_SATED` via new constant
- use clamp when eating or on hunger tick
- show capped value in character sheet
- initialize new characters at `MAX_SATED`
- test new cap logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6842d19f08f4832ca9ae731650e5c385