### PR TITLE
Add player level cap and disable hunger at max

### DIFF
--- a/commands/admin.py
+++ b/commands/admin.py
@@ -15,6 +15,7 @@ from .building import (
 )
 from world.stats import CORE_STAT_KEYS, ALL_STATS
 from world.system import stat_manager
+from world.system.state_manager import MAX_LEVEL
 from utils.stats_utils import get_display_scroll, normalize_stat_key
 from utils import VALID_SLOTS
 
@@ -135,6 +136,7 @@ class CmdSetStat(Command):
             return
 
         if stat_key_low == "level":
+            value = min(value, MAX_LEVEL)
             target.db.level = value
             stat_manager.refresh_stats(target)
             self.msg(f"level set to {value} on {target.key}.")

--- a/commands/interact.py
+++ b/commands/interact.py
@@ -1,7 +1,7 @@
 from .command import Command
 from evennia import CmdSet
 from evennia.utils import make_iter
-from world.system.state_manager import MAX_SATED
+from world.system.state_manager import MAX_SATED, MAX_LEVEL
 
 
 class CmdGather(Command):
@@ -73,7 +73,8 @@ class CmdEat(Command):
         caller.traits.stamina.current += stamina
 
         sated = obj.attributes.get("sated", 0)
-        caller.db.sated = min((caller.db.sated or 0) + sated, MAX_SATED)
+        if (caller.db.level or 1) < MAX_LEVEL:
+            caller.db.sated = min((caller.db.sated or 0) + sated, MAX_SATED)
 
         caller.at_emote(
             f"$conj({self.cmdstring}) the {{target}}.", mapping={"target": obj}

--- a/typeclasses/tests/test_state_manager.py
+++ b/typeclasses/tests/test_state_manager.py
@@ -68,3 +68,13 @@ class TestStateManager(EvenniaTest):
         char.db.sated = 150
         state_manager.tick_character(char)
         self.assertLessEqual(char.db.sated, state_manager.MAX_SATED)
+
+    def test_hunger_ignored_at_max_level(self):
+        char = self.char1
+        char.db.level = state_manager.MAX_LEVEL
+        char.db.sated = 1
+        hp = char.traits.health.current
+        state_manager.tick_character(char)
+        self.assertEqual(char.db.sated, 1)
+        self.assertFalse(char.tags.has("hungry_thirsty", category="status"))
+        self.assertEqual(char.traits.health.current, hp)

--- a/utils/stats_utils.py
+++ b/utils/stats_utils.py
@@ -39,7 +39,7 @@ from world.stats import (
     apply_stats,
 )
 from world.system import stat_manager
-from world.system.state_manager import MAX_SATED
+from world.system.state_manager import MAX_SATED, MAX_LEVEL
 import math
 import re
 
@@ -180,21 +180,24 @@ def get_display_scroll(chara):
         hp_disp = mp_disp = sp_disp = "--/--"
 
     sated_val = 0
-    if hasattr(chara.db, "sated"):
-        sated_val = min(chara.db.sated or 0, MAX_SATED)
-    elif chara.traits.get("sated"):
-        sated_val = min(chara.traits.sated.value, MAX_SATED)
-    if sated_val <= 0:
-        sated_disp = "|r0 (URGENT)|n"
-    elif sated_val < 5:
-        sated_disp = f"|y{sated_val}|n"
-    else:
-        sated_disp = f"|g{sated_val}|n"
+    show_sated = level < MAX_LEVEL
+    if show_sated:
+        if hasattr(chara.db, "sated"):
+            sated_val = min(chara.db.sated or 0, MAX_SATED)
+        elif chara.traits.get("sated"):
+            sated_val = min(chara.traits.sated.value, MAX_SATED)
+        if sated_val <= 0:
+            sated_disp = "|r0 (URGENT)|n"
+        elif sated_val < 5:
+            sated_disp = f"|y{sated_val}|n"
+        else:
+            sated_disp = f"|g{sated_val}|n"
 
     lines.append(
         f"|YLvl {level}|n  |CXP|n {xp}  |yTNL|n {tnl}  |rHP|n {hp_disp}  |cMP|n {mp_disp}  |gSP|n {sp_disp}"
     )
-    lines.append(f"|ySated|n {sated_disp}")
+    if show_sated:
+        lines.append(f"|ySated|n {sated_disp}")
 
     coins = {
         "copper": _db_get(chara, "copper", 0),

--- a/utils/tests/test_stats_utils.py
+++ b/utils/tests/test_stats_utils.py
@@ -22,3 +22,10 @@ class TestDisplayScroll(EvenniaTest):
         sheet = get_display_scroll(char)
         self.assertIn("Sated", sheet)
         self.assertIn("100", sheet)
+
+    def test_sated_hidden_at_max_level(self):
+        char = self.char1
+        char.db.level = 100
+        char.db.sated = 50
+        sheet = get_display_scroll(char)
+        self.assertNotIn("Sated", sheet)

--- a/world/system/state_manager.py
+++ b/world/system/state_manager.py
@@ -8,6 +8,9 @@ from world.effects import EFFECTS
 # Maximum fullness a character can reach from food or drink.
 MAX_SATED = 100
 
+# Highest level a player character can reach.
+MAX_LEVEL = 100
+
 
 def _get_bonus_dict(chara) -> Dict[str, List[dict]]:
     return chara.db.temp_bonuses or {}
@@ -208,8 +211,8 @@ def tick_character(chara):
         _save_status_dict(chara, statuses)
         stat_manager.refresh_stats(chara)
 
-    # Hunger and thirst
-    if hasattr(chara.db, "sated"):
+    # Hunger and thirst is ignored for max-level characters
+    if hasattr(chara.db, "sated") and (chara.db.level or 1) < MAX_LEVEL:
         sated = min(chara.db.sated or 0, MAX_SATED)
         if sated > 0:
             chara.db.sated = sated - 1


### PR DESCRIPTION
## Summary
- define `MAX_LEVEL` constant alongside `MAX_SATED`
- stop hunger tick and sated adjustments for characters at level 100
- hide sated line from score output when at max level
- clamp admin-set levels to max level
- update eating command to respect level cap
- add tests for sated display and hunger at max level

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6842d31f02b0832c949d578d5d6ed6db