### PR TITLE
Fix equipment bonus handling and neck slot

### DIFF
--- a/commands/info.py
+++ b/commands/info.py
@@ -18,7 +18,7 @@ EQUIPMENT_SLOTS = [
     "mainhand",
     "offhand",
     "helm",
-    "amulet",
+    "neck",
     "shoulders",
     "chest",
     "cloak",

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -386,8 +386,7 @@ class Character(ObjectParent, ClothedCharacter):
         weapon.location = None
         self.update_carry_weight()
         from world.system import stat_manager
-        stat_manager.add_equip_bonus(self, weapon)
-        stat_manager.refresh_stats(self)
+        stat_manager.apply_bonuses(self, weapon)
         # return the list of hands that are now holding the weapon
         return hands
 
@@ -419,8 +418,7 @@ class Character(ObjectParent, ClothedCharacter):
         weapon.location = self
         self.update_carry_weight()
         from world.system import stat_manager
-        stat_manager.remove_equip_bonus(self, weapon)
-        stat_manager.refresh_stats(self)
+        stat_manager.remove_bonuses(self, weapon)
         # return the list of hands that are no longer holding the weapon
         return freed
 

--- a/typeclasses/objects.py
+++ b/typeclasses/objects.py
@@ -232,8 +232,7 @@ class ClothingObject(ObjectParent, ContribClothing):
         if result:
             self.location = None
             wearer.update_carry_weight()
-            stat_manager.add_equip_bonus(wearer, self)
-            stat_manager.refresh_stats(wearer)
+            stat_manager.apply_bonuses(wearer, self)
         return result
 
     def remove(self, wearer, quiet=False):
@@ -242,8 +241,7 @@ class ClothingObject(ObjectParent, ContribClothing):
         if result:
             self.location = wearer
             wearer.update_carry_weight()
-            stat_manager.remove_equip_bonus(wearer, self)
-            stat_manager.refresh_stats(wearer)
+            stat_manager.remove_bonuses(wearer, self)
         return result
 
 

--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -102,7 +102,7 @@ class TestInfoCommands(EvenniaTest):
 
         item = create.create_object(
             "typeclasses.objects.ClothingObject",
-            key="amulet",
+            key="neck",
             location=self.char1,
         )
         item.tags.add("equipment", category="flag")

--- a/typeclasses/tests/test_stat_manager.py
+++ b/typeclasses/tests/test_stat_manager.py
@@ -95,7 +95,7 @@ class TestStatManager(EvenniaTest):
         base_hp = char.db.derived_stats.get("HP")
         item = create.create_object(
             "typeclasses.objects.ClothingObject",
-            key="amulet",
+            key="neck",
             location=char,
         )
         item.tags.add("equipment", category="flag")

--- a/utils/slots.py
+++ b/utils/slots.py
@@ -4,7 +4,7 @@ VALID_SLOTS = {
     "mainhand/offhand",
     "twohanded",
     "helm",
-    "amulet",
+    "neck",
     "shoulders",
     "chest",
     "cloak",

--- a/world/system/stat_manager.py
+++ b/world/system/stat_manager.py
@@ -178,6 +178,18 @@ def remove_equip_bonus(chara, item) -> None:
     chara.db.equip_bonuses = bonuses
 
 
+def apply_bonuses(chara, item) -> None:
+    """Apply bonuses from ``item`` and refresh character stats."""
+    add_equip_bonus(chara, item)
+    refresh_stats(chara)
+
+
+def remove_bonuses(chara, item) -> None:
+    """Remove bonuses from ``item`` and refresh character stats."""
+    remove_equip_bonus(chara, item)
+    refresh_stats(chara)
+
+
 def _gear_mods(obj) -> Dict[str, int]:  # pragma: no cover - placeholder
     """Return cached stat bonuses from equipped gear."""
 


### PR DESCRIPTION
## Summary
- rename amulet equipment slot to `neck`
- introduce `apply_bonuses` and `remove_bonuses` helpers
- apply bonuses when equipping and remove when unequipping
- update tests for neck slot

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'evennia')*

------
https://chatgpt.com/codex/tasks/task_e_6842d5038a04832cb97a3a378a672049