### PR TITLE
Fix circular import for state manager constants

### DIFF
--- a/commands/admin.py
+++ b/commands/admin.py
@@ -15,7 +15,7 @@ from .building import (
 )
 from world.stats import CORE_STAT_KEYS, ALL_STATS
 from world.system import stat_manager
-from world.system.state_manager import MAX_LEVEL
+from world.system.constants import MAX_LEVEL
 from utils.stats_utils import get_display_scroll, normalize_stat_key
 from utils import VALID_SLOTS
 

--- a/commands/interact.py
+++ b/commands/interact.py
@@ -1,7 +1,7 @@
 from .command import Command
 from evennia import CmdSet
 from evennia.utils import make_iter
-from world.system.state_manager import MAX_SATED, MAX_LEVEL
+from world.system.constants import MAX_SATED, MAX_LEVEL
 
 
 class CmdGather(Command):

--- a/utils/stats_utils.py
+++ b/utils/stats_utils.py
@@ -39,7 +39,7 @@ from world.stats import (
     apply_stats,
 )
 from world.system import stat_manager
-from world.system.state_manager import MAX_SATED, MAX_LEVEL
+from world.system.constants import MAX_SATED, MAX_LEVEL
 import math
 import re
 

--- a/world/chargen_menu.py
+++ b/world/chargen_menu.py
@@ -276,7 +276,8 @@ def menunode_finish(caller, **kwargs):
         stat: char.traits.get(stat).base for stat in STAT_LIST
     }
 
-    from world.system import stat_manager, state_manager
+    from world.system import stat_manager
+    from world.system.constants import MAX_SATED
     stat_manager.refresh_stats(char)
 
     # start fully recovered
@@ -286,7 +287,7 @@ def menunode_finish(caller, **kwargs):
         char.traits.mana.current = char.traits.mana.max
     if char.traits.get("stamina"):
         char.traits.stamina.current = char.traits.stamina.max
-    char.db.sated = state_manager.MAX_SATED
+    char.db.sated = MAX_SATED
     stat_manager.refresh_stats(char)
 
     # assign the newly created character to this account

--- a/world/system/__init__.py
+++ b/world/system/__init__.py
@@ -2,5 +2,6 @@
 
 from . import state_manager
 from . import stat_manager
+from . import constants
 
-__all__ = ["state_manager", "stat_manager"]
+__all__ = ["state_manager", "stat_manager", "constants"]

--- a/world/system/constants.py
+++ b/world/system/constants.py
@@ -1,0 +1,9 @@
+# Constants used across the world.system package
+
+# Maximum fullness a character can reach from food or drink.
+MAX_SATED = 100
+
+# Highest level a player character can reach.
+MAX_LEVEL = 100
+
+__all__ = ["MAX_SATED", "MAX_LEVEL"]

--- a/world/system/state_manager.py
+++ b/world/system/state_manager.py
@@ -4,12 +4,7 @@ from typing import Dict, List
 from world import stats
 from world.system import stat_manager
 from world.effects import EFFECTS
-
-# Maximum fullness a character can reach from food or drink.
-MAX_SATED = 100
-
-# Highest level a player character can reach.
-MAX_LEVEL = 100
+from .constants import MAX_SATED, MAX_LEVEL
 
 
 def _get_bonus_dict(chara) -> Dict[str, List[dict]]:


### PR DESCRIPTION
## Summary
- break circular imports by moving constants to `world.system.constants`
- update modules to import `MAX_SATED` and `MAX_LEVEL` from the new module

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: django)*

------
https://chatgpt.com/codex/tasks/task_e_6842d6e3e95c832ca623a6dcbad85de9