### PR TITLE
Add trinket equipment slot

### DIFF
--- a/commands/info.py
+++ b/commands/info.py
@@ -31,6 +31,7 @@ EQUIPMENT_SLOTS = [
     "legs",
     "feet",
     "accessory",
+    "trinket",
 ]
 
 

--- a/utils/slots.py
+++ b/utils/slots.py
@@ -17,4 +17,5 @@ VALID_SLOTS = {
     "legs",
     "feet",
     "accessory",
+    "trinket",
 }


### PR DESCRIPTION
## Summary
- allow `trinket` slot in utils/slots
- show `trinket` in equipment display

## Testing
- `pytest utils/tests/test_currency.py::TestCurrencyConversion::test_round_trip_values -q` *(fails: settings.DEFAULT_HOME does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68434f70fa88832ca2eb554fa68f4e61