### PR TITLE
Fix clothing bonuses and add score test

### DIFF
--- a/typeclasses/objects.py
+++ b/typeclasses/objects.py
@@ -229,19 +229,17 @@ class ClothingObject(ObjectParent, ContribClothing):
                     return
 
         result = super().wear(wearer, wearstyle, quiet=quiet)
-        if result:
-            self.location = None
-            wearer.update_carry_weight()
-            stat_manager.apply_bonuses(wearer, self)
+        self.location = None
+        wearer.update_carry_weight()
+        stat_manager.apply_bonuses(wearer, self)
         return result
 
     def remove(self, wearer, quiet=False):
         """Return to inventory when removed."""
         result = super().remove(wearer, quiet=quiet)
-        if result:
-            self.location = wearer
-            wearer.update_carry_weight()
-            stat_manager.remove_bonuses(wearer, self)
+        self.location = wearer
+        wearer.update_carry_weight()
+        stat_manager.remove_bonuses(wearer, self)
         return result
 
 

--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -115,6 +115,60 @@ class TestInfoCommands(EvenniaTest):
         out = self.char1.msg.call_args[0][0]
         self.assertIn("(+1)", out)
 
+    def test_score_shows_multiple_item_bonuses(self):
+        from evennia.utils import create
+
+        ring = create.create_object(
+            "typeclasses.objects.ClothingObject",
+            key="ring",
+            location=self.char1,
+        )
+        ring.tags.add("equipment", category="flag")
+        ring.tags.add("identified", category="flag")
+        ring.tags.add("jewelry", category="slot")
+        ring.db.stat_mods = {"STR": 1}
+        ring.wear(self.char1, True)
+
+        armor = create.create_object(
+            "typeclasses.objects.ClothingObject",
+            key="helm",
+            location=self.char1,
+        )
+        armor.tags.add("equipment", category="flag")
+        armor.tags.add("identified", category="flag")
+        armor.tags.add("helm", category="slot")
+        armor.db.stat_mods = {"CON": 2}
+        armor.wear(self.char1, True)
+
+        shield = create.create_object(
+            "typeclasses.objects.ClothingObject",
+            key="shield",
+            location=self.char1,
+        )
+        shield.tags.add("equipment", category="flag")
+        shield.tags.add("identified", category="flag")
+        shield.tags.add("shield", category="flag")
+        shield.db.stat_mods = {"DEX": 3}
+        shield.wear(self.char1, True)
+
+        trinket = create.create_object(
+            "typeclasses.objects.ClothingObject",
+            key="trinket",
+            location=self.char1,
+        )
+        trinket.tags.add("equipment", category="flag")
+        trinket.tags.add("identified", category="flag")
+        trinket.tags.add("trinket", category="slot")
+        trinket.db.stat_mods = {"WIS": 4}
+        trinket.wear(self.char1, True)
+
+        self.char1.execute_cmd("score")
+        out = self.char1.msg.call_args[0][0]
+        self.assertIn("(+1)", out)
+        self.assertIn("(+2)", out)
+        self.assertIn("(+3)", out)
+        self.assertIn("(+4)", out)
+
     def test_inventory(self):
         self.char1.execute_cmd("inventory")
         self.assertTrue(self.char1.msg.called)


### PR DESCRIPTION
## Summary
- fix ClothingObject.wear/remove so stat bonuses apply
- test multiple equipped items show bonuses in `score`

## Testing
- `pytest typeclasses/tests/test_commands.py::TestInfoCommands::test_score_shows_gear_bonus typeclasses/tests/test_commands.py::TestInfoCommands::test_score_shows_multiple_item_bonuses -q`

------
https://chatgpt.com/codex/tasks/task_e_68435e29097c832c81296738da586b9d