### PR TITLE
Rename helm slot to head

### DIFF
--- a/commands/info.py
+++ b/commands/info.py
@@ -17,7 +17,7 @@ EQUIPMENT_SLOTS = [
     "twohanded",
     "mainhand",
     "offhand",
-    "helm",
+    "head",
     "neck",
     "shoulders",
     "chest",

--- a/typeclasses/tests/test_admin_commands.py
+++ b/typeclasses/tests/test_admin_commands.py
@@ -217,7 +217,7 @@ class TestAdminCommands(EvenniaTest):
     def test_carmor_tags_and_wear(self):
         """Armor created with carmor gets tags and can be worn."""
 
-        self.char1.execute_cmd("carmor helm helm 1 1 basic")
+        self.char1.execute_cmd("carmor helm head 1 1 basic")
         armor = next(
             (o for o in self.char1.contents if "helm" in list(o.aliases.all())),
             None,
@@ -225,7 +225,7 @@ class TestAdminCommands(EvenniaTest):
         self.assertIsNotNone(armor)
         self.assertTrue(armor.tags.has("equipment", category="flag"))
         self.assertTrue(armor.tags.has("identified", category="flag"))
-        self.assertTrue(armor.tags.has("helm", category="slot"))
+        self.assertTrue(armor.tags.has("head", category="slot"))
         armor.wear(self.char1, True)
         self.assertTrue(armor.db.worn)
 
@@ -331,7 +331,7 @@ class TestAdminCommands(EvenniaTest):
         self.assertIn("charm", out.lower())
 
     def test_carmor_with_modifiers(self):
-        self.char1.execute_cmd("carmor helm helm 2 1 STR+1, Dex+2 A sturdy helm.")
+        self.char1.execute_cmd("carmor helm head 2 1 STR+1, Dex+2 A sturdy helm.")
         armor = next(
             (
                 o
@@ -411,7 +411,7 @@ class TestAdminCommands(EvenniaTest):
         shield = next((o for o in self.char1.contents if o.key == "kite shield"), None)
         self.assertIsNotNone(shield)
 
-        self.char1.execute_cmd('carmor "iron helm" helm 1 1 basic')
+        self.char1.execute_cmd('carmor "iron helm" head 1 1 basic')
         armor = next((o for o in self.char1.contents if o.key == "iron helm"), None)
         self.assertIsNotNone(armor)
 

--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -136,7 +136,7 @@ class TestInfoCommands(EvenniaTest):
         )
         armor.tags.add("equipment", category="flag")
         armor.tags.add("identified", category="flag")
-        armor.tags.add("helm", category="slot")
+        armor.tags.add("head", category="slot")
         armor.db.stat_mods = {"CON": 2}
         armor.wear(self.char1, True)
 
@@ -507,7 +507,7 @@ class TestRemoveCommand(EvenniaTest):
         )
         item.tags.add("equipment", category="flag")
         item.tags.add("identified", category="flag")
-        item.tags.add("helm", category="slot")
+        item.tags.add("head", category="slot")
         item.wear(self.char1, True)
         self.assertTrue(item.db.worn)
         self.assertIsNone(item.location)
@@ -527,7 +527,7 @@ class TestRemoveCommand(EvenniaTest):
         item.aliases.add("capper")
         item.tags.add("equipment", category="flag")
         item.tags.add("identified", category="flag")
-        item.tags.add("helm", category="slot")
+        item.tags.add("head", category="slot")
         item.wear(self.char1, True)
 
         # partial key
@@ -553,7 +553,7 @@ class TestRemoveAllCommand(EvenniaTest):
         )
         armor.tags.add("equipment", category="flag")
         armor.tags.add("identified", category="flag")
-        armor.tags.add("helm", category="slot")
+        armor.tags.add("head", category="slot")
         armor.wear(self.char1, True)
 
         weapon = create.create_object(

--- a/typeclasses/tests/test_objects_basic.py
+++ b/typeclasses/tests/test_objects_basic.py
@@ -59,7 +59,7 @@ class TestObjectFlags(EvenniaTest):
         )
         first.tags.add("equipment", category="flag")
         first.tags.add("identified", category="flag")
-        first.tags.add("helm", category="slot")
+        first.tags.add("head", category="slot")
 
         second = create_object(
             "typeclasses.objects.ClothingObject",
@@ -68,7 +68,7 @@ class TestObjectFlags(EvenniaTest):
         )
         second.tags.add("equipment", category="flag")
         second.tags.add("identified", category="flag")
-        second.tags.add("helm", category="slot")
+        second.tags.add("head", category="slot")
 
         first.wear(self.char1, "wear")
         self.assertTrue(first.db.worn)

--- a/utils/slots.py
+++ b/utils/slots.py
@@ -3,7 +3,7 @@ VALID_SLOTS = {
     "offhand",
     "mainhand/offhand",
     "twohanded",
-    "helm",
+    "head",
     "neck",
     "shoulders",
     "chest",


### PR DESCRIPTION
## Summary
- rename equipment slot `helm` to `head`
- update equipment display list
- adjust tests for new `head` slot

## Testing
- `pytest -q` *(fails: OperationalError no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684368281898832c95567107a02e12c1