### PR TITLE
Handle equipped items on deletion and eating

### DIFF
--- a/commands/interact.py
+++ b/commands/interact.py
@@ -69,6 +69,10 @@ class CmdEat(Command):
             caller.msg("You cannot eat that.")
             return
 
+        if obj in caller.equipment.values():
+            caller.msg("You must unequip that first.")
+            return
+
         stamina = obj.attributes.get("stamina", 0)
         caller.traits.stamina.current += stamina
 

--- a/typeclasses/objects.py
+++ b/typeclasses/objects.py
@@ -202,6 +202,19 @@ class Object(ObjectParent, DefaultObject):
             return False
         return super().at_pre_move(destination, move_type=move_type, **kwargs)
 
+    def at_object_delete(self):
+        """Clean up bonuses if this item is equipped when deleted."""
+        from evennia import search_object
+        from evennia.utils.utils import inherits_from
+
+        for char in search_object("*"):
+            if not inherits_from(char, "typeclasses.characters.Character"):
+                continue
+            if self in char.equipment.values():
+                stat_manager.remove_bonuses(char, self)
+                break
+        return True
+
 
 class ClothingObject(ObjectParent, ContribClothing):
     def wear(self, wearer, wearstyle, quiet=False):


### PR DESCRIPTION
## Summary
- ensure bonuses from equipped items are removed when the object is deleted
- block eating items that are currently equipped

## Testing
- `pytest -q` *(fails: OperationalError - no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6843699c5a68832c965a0c2acb392ce7