### PR TITLE
Add slot normalization helper

### DIFF
--- a/commands/admin.py
+++ b/commands/admin.py
@@ -17,7 +17,7 @@ from world.stats import CORE_STAT_KEYS, ALL_STATS
 from world.system import stat_manager
 from world.system.constants import MAX_LEVEL
 from utils.stats_utils import get_display_scroll, normalize_stat_key
-from utils import VALID_SLOTS
+from utils import VALID_SLOTS, normalize_slot
 
 
 def _safe_split(text):
@@ -399,6 +399,7 @@ def _create_gear(
     obj.aliases.add(alias_base)
     obj.aliases.add(f"{alias_base}-{count + 1}")
     if slot:
+        slot = normalize_slot(slot)
         if obj.is_typeclass("typeclasses.objects.ClothingObject", exact=False):
             obj.db.clothing_type = slot
         else:
@@ -462,7 +463,7 @@ class CmdCGear(Command):
         idx = 2
         slot = None
         if idx < len(parts) and not parts[idx].lstrip("-+").isdigit():
-            slot = parts[idx]
+            slot = normalize_slot(parts[idx])
             idx += 1
         val = None
         if idx < len(parts):
@@ -486,6 +487,10 @@ class CmdCGear(Command):
         except ValueError as err:
             self.msg(f"Invalid stat modifier: {err}")
             return
+        if slot and slot not in VALID_SLOTS:
+            self.msg("Invalid slot name.")
+            return
+
         obj = _create_gear(
             self.caller,
             tclass,
@@ -586,7 +591,7 @@ class CmdCWeapon(Command):
             )
             return
         name = parts[0].strip("'\"")
-        slot = parts[1].lower()
+        slot = normalize_slot(parts[1])
 
         dmg_arg = parts[2]
         weight_str = parts[3]
@@ -787,7 +792,7 @@ class CmdCShield(Command):
         if desc is None and rest:
             desc = rest.strip()
 
-        slot = "offhand"
+        slot = normalize_slot("offhand")
         obj = _create_gear(
             self.caller,
             "typeclasses.objects.ClothingObject",
@@ -863,7 +868,7 @@ class CmdCArmor(Command):
         except ValueError as err:
             self.msg(f"Invalid stat modifier: {err}")
             return
-        slot = slot.lower()
+        slot = normalize_slot(slot)
         if slot not in VALID_SLOTS:
             self.msg("Invalid slot name.")
             return
@@ -1007,7 +1012,7 @@ class CmdCRing(Command):
                 weight = int(parts[idx])
                 idx += 1
             else:
-                slot = parts[idx].lower()
+                slot = normalize_slot(parts[idx])
                 idx += 1
                 if idx < len(parts) and parts[idx].isdigit():
                     weight = int(parts[idx])
@@ -1020,6 +1025,10 @@ class CmdCRing(Command):
             bonuses, desc = parse_stat_mods(rest)
         except ValueError as err:
             self.msg(f"Invalid stat modifier: {err}")
+            return
+
+        if slot not in VALID_SLOTS:
+            self.msg("Invalid slot name.")
             return
 
         obj = _create_gear(
@@ -1094,7 +1103,7 @@ class CmdCTrinket(Command):
             self.caller,
             "typeclasses.objects.ClothingObject",
             name,
-            "trinket",
+            normalize_slot("trinket"),
             desc=desc,
             weight=weight,
             identified=identified,

--- a/commands/info.py
+++ b/commands/info.py
@@ -5,7 +5,7 @@ from utils.currency import to_copper, from_copper
 from evennia.contrib.game_systems.clothing.clothing import get_worn_clothes
 from world.stats import CORE_STAT_KEYS
 from utils.stats_utils import get_display_scroll, _strip_colors, _pad
-from utils import VALID_SLOTS
+from utils import VALID_SLOTS, normalize_slot
 
 
 def is_gettable(obj, caller):
@@ -49,6 +49,7 @@ def render_equipment(caller):
     )
 
     for slot in EQUIPMENT_SLOTS:
+        canonical = normalize_slot(slot)
         if slot == "twohanded":
             if not show_twohanded:
                 continue
@@ -62,7 +63,7 @@ def render_equipment(caller):
                 continue
             item = off
         else:
-            item = eq.get(slot)
+            item = eq.get(canonical)
 
         name = item.get_display_name(caller) if item else "NOTHING"
         display.append(f"| {slot.capitalize():<10}: {name}")

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -10,6 +10,7 @@ from evennia.contrib.game_systems.clothing.clothing import (
 from evennia.contrib.game_systems.cooldowns import CooldownHandler
 from evennia.prototypes.spawner import spawn
 from utils.currency import to_copper, from_copper
+from utils import normalize_slot
 import math
 
 from .objects import ObjectParent
@@ -105,6 +106,7 @@ class Character(ObjectParent, ClothedCharacter):
                 slots = [ctype]
             for slot in slots:
                 if slot:
+                    slot = normalize_slot(slot)
                     eq[slot] = item
 
         return eq

--- a/typeclasses/objects.py
+++ b/typeclasses/objects.py
@@ -19,6 +19,7 @@ from evennia.contrib.game_systems.clothing.clothing import get_worn_clothes
 
 from commands.interact import GatherCmdSet
 from world.system import stat_manager
+from utils import normalize_slot
 
 
 class ObjectParent:
@@ -229,8 +230,9 @@ class ClothingObject(ObjectParent, ContribClothing):
         if slots := self.tags.get(category="slot", return_list=True):
             worn_items = get_worn_clothes(wearer)
             for slot in slots:
+                canonical = normalize_slot(slot)
                 for item in worn_items:
-                    if item.tags.has(slot, category="slot"):
+                    if item.tags.has(canonical, category="slot"):
                         item.remove(wearer, quiet=quiet)
 
         # shields can't be worn with two-handed weapons

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,4 +1,4 @@
 from .roles import has_role, is_guildmaster, is_receptionist
 
 
-from .slots import VALID_SLOTS
+from .slots import VALID_SLOTS, normalize_slot

--- a/utils/slots.py
+++ b/utils/slots.py
@@ -19,3 +19,35 @@ VALID_SLOTS = {
     "accessory",
     "trinket",
 }
+
+# Maps common slot synonyms to their canonical counterparts.
+SLOT_MAP = {
+    "helm": "head",
+    "helmet": "head",
+    "hat": "head",
+    "amulet": "neck",
+    "necklace": "neck",
+    "pendant": "neck",
+    "belt": "waist",
+    "boots": "feet",
+    "gloves": "hands",
+    "bracelet": "wrists",
+    "ring": "ring1",
+}
+
+
+def normalize_slot(name):
+    """Return the canonical slot name for ``name``."""
+
+    if not name:
+        return None
+
+    name = name.lower().strip()
+
+    # return canonical slot if already valid
+    if name in VALID_SLOTS:
+        return name
+
+    # look up alias
+    return SLOT_MAP.get(name)
+


### PR DESCRIPTION
## Summary
- map common slot synonyms to canonical names via `SLOT_MAP`
- expose `normalize_slot` in utils
- normalize slot names during gear creation
- normalize slots for equipment handling and display

## Testing
- `pytest -q` *(fails: OperationalError - no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68436c3b4898832cbdcf20b46a66ee5a