### PR TITLE
Implement equipment bonus recalculation

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -166,7 +166,7 @@ class Character(ObjectParent, ClothedCharacter):
     def at_post_puppet(self, **kwargs):
         """Ensure stats refresh when a character is controlled."""
         from world.system import stat_manager
-        stat_manager.refresh_stats(self)
+        stat_manager.recalculate_stats(self)
 
     def at_object_receive(self, obj, source_location, **kwargs):
         """Update carry weight when gaining an item."""

--- a/typeclasses/objects.py
+++ b/typeclasses/objects.py
@@ -193,6 +193,8 @@ class Object(ObjectParent, DefaultObject):
         if self in dropper.wielding:
             dropper.at_unwield(self)
         super().at_drop(dropper, **kwargs)
+        from world.system import stat_manager
+        stat_manager.recalculate_stats(dropper)
 
     def at_pre_move(self, destination, move_type="move", **kwargs):
         """Prevent moving if the stationary flag is set."""
@@ -247,6 +249,7 @@ class ClothingObject(ObjectParent, ContribClothing):
         self.location = None
         wearer.update_carry_weight()
         stat_manager.apply_bonuses(wearer, self)
+        stat_manager.recalculate_stats(wearer)
         return result
 
     def remove(self, wearer, quiet=False):
@@ -255,6 +258,7 @@ class ClothingObject(ObjectParent, ContribClothing):
         self.location = wearer
         wearer.update_carry_weight()
         stat_manager.remove_bonuses(wearer, self)
+        stat_manager.recalculate_stats(wearer)
         return result
 
 

--- a/world/system/stat_manager.py
+++ b/world/system/stat_manager.py
@@ -190,6 +190,20 @@ def remove_bonuses(chara, item) -> None:
     refresh_stats(chara)
 
 
+def clear_all_equipment_bonuses(chara) -> None:
+    """Remove all cached equipment bonuses for ``chara``."""
+    chara.db.equip_bonuses = {}
+
+
+def recalculate_stats(chara) -> None:
+    """Reapply bonuses from all equipped items and refresh stats."""
+    clear_all_equipment_bonuses(chara)
+    for item in chara.equipment.values():
+        if item:
+            apply_bonuses(chara, item)
+    refresh_stats(chara)
+
+
 def _gear_mods(obj) -> Dict[str, int]:  # pragma: no cover - placeholder
     """Return cached stat bonuses from equipped gear."""
 


### PR DESCRIPTION
## Summary
- add helper functions to recalc equipment bonuses
- refresh all bonuses after equipment changes and login

## Testing
- `pytest -q` *(fails: OperationalError - no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68436eb0d2c0832c99fa1896853a44b4