### PR TITLE
Fix equipment slot ordering

### DIFF
--- a/commands/info.py
+++ b/commands/info.py
@@ -5,7 +5,7 @@ from utils.currency import to_copper, from_copper
 from evennia.contrib.game_systems.clothing.clothing import get_worn_clothes
 from world.stats import CORE_STAT_KEYS
 from utils.stats_utils import get_display_scroll, _strip_colors, _pad
-from utils import VALID_SLOTS, normalize_slot
+from utils.slots import SLOT_ORDER
 
 
 def is_gettable(obj, caller):
@@ -13,26 +13,9 @@ def is_gettable(obj, caller):
     return obj.access(caller, "get") and obj.db.gettable is not False
 
 
-EQUIPMENT_SLOTS = [
-    "twohanded",
-    "mainhand",
-    "offhand",
-    "head",
-    "neck",
-    "shoulders",
-    "chest",
-    "cloak",
-    "wrists",
-    "hands",
-    "ring1",
-    "ring2",
-    "tabard",
-    "waist",
-    "legs",
-    "feet",
-    "accessory",
-    "trinket",
-]
+# Canonical equipment slot order for displaying items.  This mirrors the
+# ordering used when building ``Character.equipment``.
+EQUIPMENT_SLOTS = SLOT_ORDER
 
 
 def render_equipment(caller):
@@ -49,7 +32,6 @@ def render_equipment(caller):
     )
 
     for slot in EQUIPMENT_SLOTS:
-        canonical = normalize_slot(slot)
         if slot == "twohanded":
             if not show_twohanded:
                 continue
@@ -63,7 +45,7 @@ def render_equipment(caller):
                 continue
             item = off
         else:
-            item = eq.get(canonical)
+            item = eq.get(slot)
 
         name = item.get_display_name(caller) if item else "NOTHING"
         display.append(f"| {slot.capitalize():<10}: {name}")

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -11,6 +11,7 @@ from evennia.contrib.game_systems.cooldowns import CooldownHandler
 from evennia.prototypes.spawner import spawn
 from utils.currency import to_copper, from_copper
 from utils import normalize_slot
+from utils.slots import SLOT_ORDER
 import math
 
 from .objects import ObjectParent
@@ -88,7 +89,9 @@ class Character(ObjectParent, ClothedCharacter):
     @property
     def equipment(self):
         """Return mapping of equipment slots to worn or wielded items."""
-        eq = {}
+        # initialize dictionary with all canonical slots so lookups always
+        # succeed even if nothing is equipped in a given location
+        eq = {slot: None for slot in SLOT_ORDER}
 
         wielded = self.attributes.get("_wielded", {})
         if wielded:

--- a/utils/slots.py
+++ b/utils/slots.py
@@ -1,8 +1,10 @@
-VALID_SLOTS = {
+# Canonical slot names understood by the game.  The order in this
+# list represents the preferred display order when showing equipped
+# items.
+SLOT_ORDER = [
+    "twohanded",
     "mainhand",
     "offhand",
-    "mainhand/offhand",
-    "twohanded",
     "head",
     "neck",
     "shoulders",
@@ -18,7 +20,10 @@ VALID_SLOTS = {
     "feet",
     "accessory",
     "trinket",
-}
+]
+
+# Set of all valid equipment slot identifiers.
+VALID_SLOTS = set(SLOT_ORDER + ["mainhand/offhand"])
 
 # Maps common slot synonyms to their canonical counterparts.
 SLOT_MAP = {


### PR DESCRIPTION
## Summary
- centralize canonical slot ordering in utils.slots
- build `Character.equipment` using canonical slot map
- display equipment using canonical slot order

## Testing
- `pytest typeclasses/tests/test_commands.py::TestInfoCommands::test_equipment -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684373079370832c9610b5b30b42ced9