### PR TITLE
Update equipment tests for head slot

### DIFF
--- a/typeclasses/tests/test_admin_commands.py
+++ b/typeclasses/tests/test_admin_commands.py
@@ -217,9 +217,9 @@ class TestAdminCommands(EvenniaTest):
     def test_carmor_tags_and_wear(self):
         """Armor created with carmor gets tags and can be worn."""
 
-        self.char1.execute_cmd("carmor helm head 1 1 basic")
+        self.char1.execute_cmd("carmor head head 1 1 basic")
         armor = next(
-            (o for o in self.char1.contents if "helm" in list(o.aliases.all())),
+            (o for o in self.char1.contents if "head" in list(o.aliases.all())),
             None,
         )
         self.assertIsNotNone(armor)
@@ -331,18 +331,18 @@ class TestAdminCommands(EvenniaTest):
         self.assertIn("charm", out.lower())
 
     def test_carmor_with_modifiers(self):
-        self.char1.execute_cmd("carmor helm head 2 1 STR+1, Dex+2 A sturdy helm.")
+        self.char1.execute_cmd("carmor head head 2 1 STR+1, Dex+2 A sturdy head.")
         armor = next(
             (
                 o
                 for o in self.char1.contents
-                if "helm" in [al.lower() for al in o.aliases.all()]
+                if "head" in [al.lower() for al in o.aliases.all()]
             ),
             None,
         )
         self.assertIsNotNone(armor)
         self.assertEqual(armor.db.stat_mods, {"str": 1, "dex": 2})
-        self.assertEqual(armor.db.desc, "A sturdy helm.")
+        self.assertEqual(armor.db.desc, "A sturdy head.")
 
     def test_ctool_with_modifiers(self):
         self.char1.execute_cmd(
@@ -411,8 +411,8 @@ class TestAdminCommands(EvenniaTest):
         shield = next((o for o in self.char1.contents if o.key == "kite shield"), None)
         self.assertIsNotNone(shield)
 
-        self.char1.execute_cmd('carmor "iron helm" head 1 1 basic')
-        armor = next((o for o in self.char1.contents if o.key == "iron helm"), None)
+        self.char1.execute_cmd('carmor "iron head" head 1 1 basic')
+        armor = next((o for o in self.char1.contents if o.key == "iron head"), None)
         self.assertIsNotNone(armor)
 
         self.char1.execute_cmd('ctool "rock hammer" smith 2 heavy')

--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -131,7 +131,7 @@ class TestInfoCommands(EvenniaTest):
 
         armor = create.create_object(
             "typeclasses.objects.ClothingObject",
-            key="helm",
+            key="head",
             location=self.char1,
         )
         armor.tags.add("equipment", category="flag")
@@ -184,7 +184,7 @@ class TestInfoCommands(EvenniaTest):
         self.assertIn("Mainhand", out)
         self.assertIn("Offhand", out)
         self.assertIn("Head", out)
-        self.assertIn("Jewelry", out)
+        self.assertIn("Accessory", out)
         self.assertIn("Trinket", out)
 
     def test_equipment_twohanded(self):


### PR DESCRIPTION
## Summary
- adjust armor creation tests to use the `head` slot
- rename helm object references to head
- expect `Accessory` label in equipment display

## Testing
- `pytest -q typeclasses/tests/test_admin_commands.py::TestAdminCommands::test_carmor_tags_and_wear -q` *(fails: no such table `accounts_accountdb`)*
- `pytest -q typeclasses/tests/test_commands.py::TestInfoCommands::test_equipment -q` *(fails: no such table `accounts_accountdb`)*

------
https://chatgpt.com/codex/tasks/task_e_684378435b7c832c8050bebf835755fd