### PR TITLE
Remove resource caps for HP, MP and SP

### DIFF
--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -87,7 +87,7 @@ Examples:
     None
 
 Notes:
-    - Primary stats cap at 999 and HP/MP/SP cannot exceed 9999.
+    - Primary stats cap at 999.
 
 Related:
     help ansi
@@ -124,7 +124,7 @@ Notes:
     - {copper}, {silver}, {gold}, {platinum} - coins carried
     - {carry}, {capacity} - carry weight and capacity
     - {enc} - encumbrance level
-    - Primary stats are capped at 999 and HP/MP/SP at 9999.
+    - Primary stats are capped at 999.
 
 Related:
     help ansi
@@ -650,7 +650,7 @@ Notes:
     - This modifies the target's stat permanently. Creating or adjusting
     - stats incorrectly may break the character, so double-check your
     - inputs before committing changes.
-    - Primary stats cannot exceed 999 and HP/MP/SP cap at 9999.
+    - Primary stats cannot exceed 999.
 
 Related:
     help ansi

--- a/world/system/constants.py
+++ b/world/system/constants.py
@@ -14,11 +14,6 @@ MAX_INT = 999
 MAX_WIS = 999
 MAX_LUCK = 999
 
-# Derived resource caps
-MAX_HP = 9999
-MAX_MP = 9999
-MAX_SP = 9999
-
 __all__ = [
     "MAX_SATED",
     "MAX_LEVEL",
@@ -28,7 +23,4 @@ __all__ = [
     "MAX_INT",
     "MAX_WIS",
     "MAX_LUCK",
-    "MAX_HP",
-    "MAX_MP",
-    "MAX_SP",
 ]

--- a/world/system/stat_manager.py
+++ b/world/system/stat_manager.py
@@ -16,9 +16,6 @@ from .constants import (
     MAX_INT,
     MAX_WIS,
     MAX_LUCK,
-    MAX_HP,
-    MAX_MP,
-    MAX_SP,
 )
 from world.scripts import races, classes
 
@@ -283,13 +280,6 @@ def refresh_stats(obj) -> None:
         value += gear_bonus.get(dkey, 0)
         value += buff_bonus.get(dkey, 0)
         result = int(round(value))
-        cap_map = {
-            "HP": MAX_HP,
-            "MP": MAX_MP,
-            "SP": MAX_SP,
-        }
-        if dkey in cap_map:
-            result = min(result, cap_map[dkey])
         derived[dkey] = result
 
     # perception scales off primary stats but keeps its base value
@@ -318,15 +308,15 @@ def refresh_stats(obj) -> None:
 
     # update resource traits
     if hp := obj.traits.get("health"):
-        hp.base = min(derived.get("HP", hp.base), MAX_HP)
+        hp.base = derived.get("HP", hp.base)
         if hp.current > hp.max:
             hp.current = hp.max
     if mp := obj.traits.get("mana"):
-        mp.base = min(derived.get("MP", mp.base), MAX_MP)
+        mp.base = derived.get("MP", mp.base)
         if mp.current > mp.max:
             mp.current = mp.max
     if sp := obj.traits.get("stamina"):
-        sp.base = min(derived.get("SP", sp.base), MAX_SP)
+        sp.base = derived.get("SP", sp.base)
         if sp.current > sp.max:
             sp.current = sp.max
 


### PR DESCRIPTION
## Summary
- drop MAX_HP, MAX_MP and MAX_SP constants
- stop clamping derived resource values
- update help entries to remove references to HP/MP/SP caps

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68437d3549f8832c9061a5919cf0f946