### PR TITLE
Map equipment slot labels

### DIFF
--- a/commands/info.py
+++ b/commands/info.py
@@ -7,6 +7,28 @@ from world.stats import CORE_STAT_KEYS
 from utils.stats_utils import get_display_scroll, _strip_colors, _pad
 from utils.slots import SLOT_ORDER
 
+# Mapping of canonical equipment slot keys to the labels shown to players.
+SLOT_LABELS = {
+    "twohanded": "Twohanded",
+    "mainhand": "Mainhand",
+    "offhand": "Offhand",
+    "head": "Head",
+    "neck": "Neck",
+    "shoulders": "Shoulders",
+    "chest": "Chest",
+    "cloak": "Cloak",
+    "wrists": "Wrists",
+    "hands": "Hands",
+    "ring1": "Ring1",
+    "ring2": "Ring2",
+    "tabard": "Tabard",
+    "waist": "Waist",
+    "legs": "Legs",
+    "feet": "Feet",
+    "accessory": "Accessory",
+    "trinket": "Trinket",
+}
+
 
 def is_gettable(obj, caller):
     """Return True if caller can pick up obj."""
@@ -48,7 +70,8 @@ def render_equipment(caller):
             item = eq.get(slot)
 
         name = item.get_display_name(caller) if item else "NOTHING"
-        display.append(f"| {slot.capitalize():<10}: {name}")
+        label = SLOT_LABELS.get(slot, slot.capitalize())
+        display.append(f"| {label:<10}: {name}")
 
     display.append("+=========================+")
     return "\n".join(display)

--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -187,6 +187,24 @@ class TestInfoCommands(EvenniaTest):
         self.assertIn("Accessory", out)
         self.assertIn("Trinket", out)
 
+    def test_equipment_shows_ring_label(self):
+        from evennia.utils import create
+
+        ring = create.create_object(
+            "typeclasses.objects.ClothingObject",
+            key="ruby ring",
+            location=self.char1,
+        )
+        ring.tags.add("equipment", category="flag")
+        ring.tags.add("identified", category="flag")
+        ring.tags.add("ring1", category="slot")
+        ring.wear(self.char1, True)
+
+        self.char1.msg.reset_mock()
+        self.char1.execute_cmd("equipment")
+        out = self.char1.msg.call_args[0][0]
+        self.assertIn("Ring1", out)
+
     def test_equipment_twohanded(self):
         from evennia.utils import create
 


### PR DESCRIPTION
## Summary
- map canonical equipment slots to display labels
- use mapping when rendering equipment list
- test ring1 label output

## Testing
- `pytest -q` *(fails: OperationalError - no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6843808e9704832c8364153e1eb6edf6