### PR TITLE
Add canonical slot tagging on wear

### DIFF
--- a/typeclasses/objects.py
+++ b/typeclasses/objects.py
@@ -230,6 +230,11 @@ class ClothingObject(ObjectParent, ContribClothing):
             return
         # honor slot tags by automatically replacing duplicates
         if slots := self.tags.get(category="slot", return_list=True):
+            for slot in slots:
+                canonical = normalize_slot(slot)
+                if canonical and not self.tags.has(canonical, category="slot"):
+                    self.tags.add(canonical, category="slot")
+
             worn_items = get_worn_clothes(wearer)
             for slot in slots:
                 canonical = normalize_slot(slot)

--- a/typeclasses/tests/test_objects_basic.py
+++ b/typeclasses/tests/test_objects_basic.py
@@ -78,6 +78,19 @@ class TestObjectFlags(EvenniaTest):
         self.assertFalse(first.db.worn)
         self.assertEqual(first.location, self.char1)
 
+    def test_wear_adds_canonical_slot_tag(self):
+        item = create_object(
+            "typeclasses.objects.ClothingObject",
+            key="ring",
+            location=self.char1,
+        )
+        item.tags.add("equipment", category="flag")
+        item.tags.add("identified", category="flag")
+        item.tags.add("ring", category="slot")
+
+        item.wear(self.char1, True)
+        self.assertTrue(item.tags.has("ring1", category="slot"))
+
 
 class TestInspectFlags(EvenniaTest):
     def test_inspect_shows_flags(self):


### PR DESCRIPTION
## Summary
- add canonical slot tag when an item is worn
- test that the canonical slot tag is added when using `item.wear`

## Testing
- `pytest typeclasses/tests/test_objects_basic.py::TestObjectFlags::test_wear_adds_canonical_slot_tag -q` *(fails: no such table: accounts_accountdb)*
- `pytest -q` *(fails: OperationalError: no such table)*

------
https://chatgpt.com/codex/tasks/task_e_684383fcc4a0832cb118179bbb984cd0