### PR TITLE
Fix display for extra equipment slots

### DIFF
--- a/utils/slots.py
+++ b/utils/slots.py
@@ -38,6 +38,11 @@ SLOT_MAP = {
     "gloves": "hands",
     "bracelet": "wrists",
     "ring": "ring1",
+    # additional synonyms used by game prototypes
+    "top": "chest",
+    "chestguard": "chest",
+    "legguard": "legs",
+    "shoes": "feet",
 }
 
 


### PR DESCRIPTION
## Summary
- map more slot aliases in `normalize_slot`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68438af6e62c832cade2e1d7d7fb2606