### PR TITLE
Fix food creation, inspect & eat feedback

### DIFF
--- a/commands/admin.py
+++ b/commands/admin.py
@@ -1141,10 +1141,14 @@ class CmdCFood(Command):
             "typeclasses.objects.Object",
             name,
             desc=rest,
+            weight=1,
         )
         obj.tags.add("edible")
         obj.db.item_type = "food"
+        obj.db.type = "food"
         obj.db.sated = boost
+        obj.db.sated_boost = boost
+        obj.db.identified = True
 
 
 class CmdCDrink(Command):
@@ -1176,10 +1180,14 @@ class CmdCDrink(Command):
             "typeclasses.objects.Object",
             name,
             desc=rest,
+            weight=1,
         )
         obj.tags.add("edible")
         obj.db.item_type = "drink"
+        obj.db.type = "drink"
         obj.db.sated = boost
+        obj.db.sated_boost = boost
+        obj.db.identified = True
 
 
 class CmdCPotion(Command):
@@ -1211,10 +1219,13 @@ class CmdCPotion(Command):
             "typeclasses.objects.Object",
             name,
             desc=desc,
+            weight=1,
         )
         obj.tags.add("edible")
         obj.db.item_type = "drink"
+        obj.db.type = "drink"
         obj.db.is_potion = True
+        obj.db.identified = True
         if bonuses:
             obj.db.buffs = bonuses
 

--- a/commands/info.py
+++ b/commands/info.py
@@ -398,14 +398,19 @@ class CmdInspect(Command):
         is_admin = caller.check_permstring("Admin") or caller.check_permstring("Builder")
 
         if obj.db.identified or is_admin:
-            width = max(len(label) for label in [
-                "Slot",
-                "Damage",
-                "Buffs",
-                "Flags",
-                "Weight",
-                "Identified",
-            ])
+            width = max(
+                len(label)
+                for label in [
+                    "Slot",
+                    "Damage",
+                    "Buffs",
+                    "Flags",
+                    "Weight",
+                    "Identified",
+                    "Type",
+                    "Sated Boost",
+                ]
+            )
             lines.append("")
             lines.append("|Y[ ITEM INFO ]|n")
 
@@ -443,6 +448,17 @@ class CmdInspect(Command):
 
             if (weight := obj.db.weight) is not None:
                 add("Weight", weight)
+
+            if (itype := getattr(obj.db, "item_type", None) or getattr(obj.db, "type", None)):
+                add("Type", str(itype).capitalize())
+
+            boost = (
+                getattr(obj.db, "sated_boost", None)
+                if hasattr(obj.db, "sated_boost")
+                else getattr(obj.db, "sated", None)
+            )
+            if boost is not None:
+                add("Sated Boost", f"+{boost}")
 
             add("Identified", "yes" if obj.db.identified else "no")
 

--- a/commands/interact.py
+++ b/commands/interact.py
@@ -83,6 +83,8 @@ class CmdEat(Command):
         caller.at_emote(
             f"$conj({self.cmdstring}) the {{target}}.", mapping={"target": obj}
         )
+        if sated:
+            caller.msg(f"(Sated +{sated})")
         obj.delete()
 
 

--- a/typeclasses/tests/test_consumable_commands.py
+++ b/typeclasses/tests/test_consumable_commands.py
@@ -27,13 +27,20 @@ class TestConsumableCommands(EvenniaTest):
         self.assertIsNotNone(food)
         self.assertTrue(food.tags.has("edible"))
         self.assertEqual(food.db.item_type, "food")
+        self.assertEqual(food.db.type, "food")
         self.assertEqual(food.db.sated, 4)
+        self.assertEqual(food.db.sated_boost, 4)
+        self.assertEqual(food.db.weight, 1)
+        self.assertTrue(food.db.identified)
         self.assertEqual(food.db.desc, "tasty")
 
         before = self.char1.db.sated or 0
+        self.char1.msg.reset_mock()
         self.char1.execute_cmd("eat apple")
         self.assertIsNone(food.pk)
         self.assertEqual(self.char1.db.sated, before + 4)
+        out = "".join(call.args[0] for call in self.char1.msg.call_args_list)
+        self.assertIn("(Sated +4)", out)
 
     def test_cdrink_create_and_drink(self):
         self.char1.execute_cmd("cdrink water 2 clear")
@@ -62,4 +69,17 @@ class TestConsumableCommands(EvenniaTest):
         self.char1.execute_cmd("quaff elixir")
         self.assertIsNone(potion.pk)
         self.assertEqual(self.char1.db.sated, before)
+
+    def test_inspect_food(self):
+        self.char1.execute_cmd("cfood cake 5 yummy")
+        self.char1.msg.reset_mock()
+        self.char1.execute_cmd("inspect cake")
+        out = self.char1.msg.call_args[0][0]
+        self.assertIn("[ ITEM INFO ]", out)
+        self.assertIn("Type", out)
+        self.assertIn("Food", out)
+        self.assertIn("Sated Boost", out)
+        self.assertIn("+5", out)
+        self.assertIn("Weight", out)
+        self.assertIn("Identified: yes", out)
 

--- a/typeclasses/tests/test_interact_commands.py
+++ b/typeclasses/tests/test_interact_commands.py
@@ -53,3 +53,10 @@ class TestInteractCommands(EvenniaTest):
         self.char1.db.sated = 95
         self.char1.execute_cmd(f"eat {food.key}")
         self.assertEqual(self.char1.db.sated, 100)
+
+    def test_eat_feedback(self):
+        food = self._make_food()
+        self.char1.msg.reset_mock()
+        self.char1.execute_cmd(f"eat {food.key}")
+        out = "".join(call.args[0] for call in self.char1.msg.call_args_list)
+        self.assertIn("(Sated +3)", out)


### PR DESCRIPTION
## Summary
- show food attributes in inspect
- make cfood/cdrink/cpotion items typed and identified
- show sated bonus on eat
- test coverage for new info

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684397c6d124832ca193a275ab63201a