### PR TITLE
Track equipped items

### DIFF
--- a/commands/info.py
+++ b/commands/info.py
@@ -42,7 +42,7 @@ EQUIPMENT_SLOTS = SLOT_ORDER
 
 def render_equipment(caller):
     """Return formatted equipment display for caller."""
-    eq = caller.equipment
+    eq = caller.db.equipment or {}
     display = ["+=========================+", "| [ EQUIPMENT ]"]
 
     main = eq.get("mainhand")

--- a/typeclasses/objects.py
+++ b/typeclasses/objects.py
@@ -260,10 +260,19 @@ class ClothingObject(ObjectParent, ContribClothing):
                     )
                     return
 
+        # ensure equipment mapping exists
+        if not isinstance(wearer.db.equipment, dict):
+            wearer.db.equipment = {}
+
         result = super().wear(wearer, wearstyle, quiet=quiet)
         self.location = None
         wearer.update_carry_weight()
+        # store equipped item in the character's equipment mapping
+        slot = self.db.slot
+        if slot:
+            wearer.db.equipment[slot] = self
         stat_manager.apply_item_bonuses_once(wearer, self)
+        self.db.worn = True
         return result
 
     def remove(self, wearer, quiet=False):
@@ -271,7 +280,10 @@ class ClothingObject(ObjectParent, ContribClothing):
         result = super().remove(wearer, quiet=quiet)
         self.location = wearer
         wearer.update_carry_weight()
+        if isinstance(wearer.db.equipment, dict) and self.db.slot:
+            wearer.db.equipment.pop(self.db.slot, None)
         stat_manager.remove_item_bonuses(wearer, self)
+        self.db.worn = False
         return result
 
 


### PR DESCRIPTION
## Summary
- track worn gear in `wearer.db.equipment`
- clear entry on remove
- show equipment from `caller.db.equipment` in info panel

## Testing
- `pytest -q` *(fails: OperationalError no such table)*

------
https://chatgpt.com/codex/tasks/task_e_68439da80204832cb5fb1d949c22ed20