### PR TITLE
Use Character.equipment in equipment display

### DIFF
--- a/commands/info.py
+++ b/commands/info.py
@@ -42,7 +42,9 @@ EQUIPMENT_SLOTS = SLOT_ORDER
 
 def render_equipment(caller):
     """Return formatted equipment display for caller."""
-    eq = caller.db.equipment or {}
+    # use the Character.equipment property which always returns a mapping of
+    # slots to equipped items. Fallback to an empty mapping if unavailable.
+    eq = getattr(caller, "equipment", {}) or {}
     display = ["+=========================+", "| [ EQUIPMENT ]"]
 
     main = eq.get("mainhand")

--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -221,6 +221,24 @@ class TestInfoCommands(EvenniaTest):
         self.assertNotIn("Mainhand", out)
         self.assertNotIn("Offhand", out)
 
+    def test_equipment_wielded_weapon_shown(self):
+        """Verify that wielded weapons show up in the equipment display."""
+        from evennia.utils import create
+
+        weapon = create.create_object(
+            "typeclasses.gear.MeleeWeapon", key="sword", location=self.char1
+        )
+        weapon.tags.add("equipment", category="flag")
+        weapon.tags.add("identified", category="flag")
+
+        self.char1.attributes.add("_wielded", {"left": None, "right": None})
+        self.char1.at_wield(weapon)
+
+        self.char1.msg.reset_mock()
+        self.char1.execute_cmd("equipment")
+        out = self.char1.msg.call_args[0][0]
+        self.assertIn("sword", out)
+
     def test_inspect_identified(self):
         self.obj1.db.desc = "A sharp blade."
         self.obj1.db.weight = 2


### PR DESCRIPTION
## Summary
- render equipment using Character.equipment property
- test that weapons wielded via at_wield show up in output

## Testing
- `pytest typeclasses/tests/test_commands.py::TestInfoCommands::test_equipment_wielded_weapon_shown -q` *(fails: OperationalError no such table)*

------
https://chatgpt.com/codex/tasks/task_e_6843a14864e4832cac1eb4c9bbffba5e