### PR TITLE
Add equipment persistence tests and fix slot handling

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -12,6 +12,7 @@ from evennia.prototypes.spawner import spawn
 from utils.currency import to_copper, from_copper
 from utils import normalize_slot
 from utils.slots import SLOT_ORDER
+from collections.abc import Mapping
 import math
 
 from .objects import ObjectParent
@@ -94,7 +95,9 @@ class Character(ObjectParent, ClothedCharacter):
         eq = {slot: None for slot in SLOT_ORDER}
 
         # start from any stored equipment mapping
-        stored = self.db.equipment if isinstance(self.db.equipment, dict) else {}
+        stored = self.db.equipment
+        if not isinstance(stored, Mapping):
+            stored = {}
         for slot, item in stored.items():
             canonical = normalize_slot(slot) or slot
             eq[canonical] = item


### PR DESCRIPTION
## Summary
- ensure stored equipment mapping uses Mapping for characters and objects
- handle slot lookups from tags when equipping and removing items
- add tests for item bonus persistence after reload and removal

## Testing
- `pytest typeclasses/tests/test_stat_manager.py::TestBonusPersistence::test_equipment_reload_keeps_bonuses typeclasses/tests/test_stat_manager.py::TestBonusPersistence::test_remove_clears_slot_and_bonus -q`

------
https://chatgpt.com/codex/tasks/task_e_6843b5bf3fc0832c9802eaac070c8820