### PR TITLE
Fix equipment display uses Character.equipment

### DIFF
--- a/commands/info.py
+++ b/commands/info.py
@@ -42,10 +42,10 @@ EQUIPMENT_SLOTS = SLOT_ORDER
 
 def render_equipment(caller):
     """Return formatted equipment display for caller."""
-    # pull the raw equipment mapping from caller.db so tests can easily
-    # manipulate equipped items without relying on Character.equipment. If
-    # nothing is stored, fall back to an empty mapping.
-    eq = caller.db.equipment if isinstance(caller.db.equipment, dict) else {}
+    # use the Character.equipment property to include both worn and wielded
+    # items.  Tests can still manipulate caller.db.equipment directly since the
+    # property merges those values.
+    eq = caller.equipment
     display = ["+=========================+", "| [ EQUIPMENT ]"]
 
     main = eq.get("mainhand")

--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -217,11 +217,12 @@ class TestInfoCommands(EvenniaTest):
         self.char1.attributes.add("_wielded", {"left": weapon, "right": weapon})
         self.char1.execute_cmd("equipment")
         out = self.char1.msg.call_args[0][0]
-        # weapons are not stored in caller.db.equipment so no twohanded slot is
-        # shown. Mainhand and Offhand remain listed.
-        self.assertNotIn("Twohanded", out)
-        self.assertIn("Mainhand", out)
-        self.assertIn("Offhand", out)
+        # when wielding a two-handed weapon, the display should show the
+        # Twohanded slot with the weapon name and omit individual hand slots
+        self.assertIn("Twohanded", out)
+        self.assertIn("great", out)
+        self.assertNotIn("Mainhand", out)
+        self.assertNotIn("Offhand", out)
 
     def test_equipment_wielded_weapon_shown(self):
         """Verify that wielded weapons show up in the equipment display."""
@@ -239,8 +240,8 @@ class TestInfoCommands(EvenniaTest):
         self.char1.msg.reset_mock()
         self.char1.execute_cmd("equipment")
         out = self.char1.msg.call_args[0][0]
-        # wielded weapons are not included in the equipment display
-        self.assertNotIn("sword", out)
+        # wielded weapons should appear in the equipment list
+        self.assertIn("sword", out)
 
     def test_inspect_identified(self):
         self.obj1.db.desc = "A sharp blade."


### PR DESCRIPTION
## Summary
- show all equipped items in `eq`
- update tests for new display

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6843bb59343c832c9dc4e1baf91d5c16