### PR TITLE
Show armor in inspect

### DIFF
--- a/commands/info.py
+++ b/commands/info.py
@@ -390,6 +390,10 @@ class CmdInspect(Command):
                     label = label.title()
                 lines.append(f"  {label} {amt:+d}")
 
+        armor = getattr(obj.db, "armor", 0)
+        if armor:
+            lines.append(f"  Armor +{armor}")
+
         req = obj.db.required_perception_to_identify
         if obj.tags.has("unidentified") and req is not None:
             from world.system import stat_manager

--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -372,12 +372,14 @@ class TestInfoCommands(EvenniaTest):
         )
         weapon = next(o for o in self.char1.contents if "longsword" in o.key.lower())
         weapon.db.identified = True
+        weapon.db.armor = 3
         self.char1.msg.reset_mock()
         self.char1.execute_cmd("inspect longsword")
         out = self.char1.msg.call_args[0][0]
         self.assertIn("Bonuses:", out)
         self.assertIn("STR +2", out)
         self.assertIn("Attack Power +5", out)
+        self.assertIn("Armor +3", out)
 
     def test_buffs(self):
         self.char1.execute_cmd("buffs")


### PR DESCRIPTION
## Summary
- display armor rating in `inspect` command output
- test that inspect shows armor

## Testing
- `evennia test` *(fails: failures=27, errors=26)*

------
https://chatgpt.com/codex/tasks/task_e_6843bdc404ac832c97d06697e426e178