### PR TITLE
Implement armor bonuses on gear

### DIFF
--- a/typeclasses/tests/test_stat_manager.py
+++ b/typeclasses/tests/test_stat_manager.py
@@ -169,6 +169,25 @@ class TestStatManager(EvenniaTest):
         self.assertEqual(char.db.derived_stats.get("HP"), base_hp + 25)
         self.assertEqual(char.db.derived_stats.get("ATK"), base_atk + 3)
 
+    @override_settings(DEFAULT_HOME=None)
+    def test_armor_increases_with_gear(self):
+        char = self.char1
+        stat_manager.refresh_stats(char)
+        base_armor = char.traits.armor.base
+        item = create.create_object(
+            "typeclasses.objects.ClothingObject",
+            key="helmet",
+            location=char,
+            nohome=True,
+        )
+        item.tags.add("equipment", category="flag")
+        item.tags.add("identified", category="flag")
+        item.db.armor = 5
+        item.wear(char, True)
+        self.assertEqual(char.traits.armor.base, base_armor + 5)
+        item.remove(char, True)
+        self.assertEqual(char.traits.armor.base, base_armor)
+
 
 @override_settings(DEFAULT_HOME=None)
 class TestBonusPersistence(EvenniaTest):

--- a/world/system/stat_manager.py
+++ b/world/system/stat_manager.py
@@ -162,6 +162,8 @@ def collect_item_mods(item) -> Dict[str, int]:  # pragma: no cover - helper
 def add_equip_bonus(chara, item) -> None:
     """Add ``item`` modifiers to ``chara.db.equip_bonuses``."""
     mods = collect_item_mods(item)
+    if getattr(item.db, "armor", 0):
+        chara.traits.armor.base += int(item.db.armor)
     if not mods:
         return
     bonuses = chara.db.equip_bonuses or {}
@@ -174,6 +176,8 @@ def add_equip_bonus(chara, item) -> None:
 def remove_equip_bonus(chara, item) -> None:
     """Remove ``item`` modifiers from ``chara.db.equip_bonuses``."""
     mods = collect_item_mods(item)
+    if getattr(item.db, "armor", 0):
+        chara.traits.armor.base -= int(item.db.armor)
     if not mods:
         return
     bonuses = chara.db.equip_bonuses or {}


### PR DESCRIPTION
## Summary
- apply armor bonuses when equipping items
- subtract armor bonuses when removing items
- test that armor trait adjusts when wearing or removing gear

## Testing
- `pytest -q` *(fails: settings.DEFAULT_HOME does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6843c18017ac832ca95b2f57ce07d2c4