### PR TITLE
Apply stats on login and test armor initialization

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -182,7 +182,10 @@ class Character(ObjectParent, ClothedCharacter):
 
     def at_post_puppet(self, **kwargs):
         """Ensure stats refresh when a character is controlled."""
+        from world import stats
         from world.system import stat_manager
+
+        stats.apply_stats(self)
         stat_manager.recalculate_stats(self)
 
     def at_object_receive(self, obj, source_location, **kwargs):

--- a/typeclasses/tests/test_characters.py
+++ b/typeclasses/tests/test_characters.py
@@ -179,3 +179,15 @@ class TestRegeneration(EvenniaTest):
 
         char.refresh_prompt.assert_called_once()
         char.msg.assert_called()
+
+
+class TestCharacterCreationStats(EvenniaTest):
+    def test_armor_trait_defaults_to_zero(self):
+        char = create.create_object(
+            "typeclasses.characters.PlayerCharacter",
+            key="Newbie",
+            location=self.room1,
+            home=self.room1,
+        )
+        self.assertIsNotNone(char.traits.get("armor"))
+        self.assertEqual(char.traits.armor.base, 0)


### PR DESCRIPTION
## Summary
- call `stats.apply_stats()` during character log in
- ensure newly created characters start with an `armor` trait

## Testing
- `evennia migrate`
- `pytest -q` *(fails: OperationalError no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6843c4048fc8832cb10e881c75c3bd88