### PR TITLE
Handle forced equipment removal

### DIFF
--- a/typeclasses/tests/test_stat_manager.py
+++ b/typeclasses/tests/test_stat_manager.py
@@ -246,3 +246,12 @@ class TestBonusPersistence(EvenniaTest):
 
         self.assertFalse(self.char1.db.equipment.get("neck"))
         self.assertFalse(self.char1.db.equip_bonuses)
+
+    def test_forced_move_clears_bonus(self):
+        item = self._equip_item()
+        # forcibly move the equipped item out of inventory
+        item.location = self.room2
+        stat_manager.refresh_stats(self.char1)
+
+        self.assertFalse(self.char1.db.equip_bonuses)
+        self.assertFalse(any(itm == item for itm in self.char1.db.equipment.values()))


### PR DESCRIPTION
## Summary
- ensure characters clean up when equipped items are forcibly moved
- test that forced movement clears equipment bonuses

## Testing
- `evennia migrate`
- `pytest -q` *(fails: OperationalError and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6843c83c027c832c9f12fffd5429db30