### PR TITLE
Update carmor command syntax

### DIFF
--- a/commands/admin.py
+++ b/commands/admin.py
@@ -851,7 +851,7 @@ class CmdCArmor(Command):
     Create a wearable armor item.
 
     Usage:
-        carmor [/unidentified] <name> <slot> <armor> <weight> <description>
+        carmor [/unidentified] <name> <slot> <weight> [stat_mods] <description>
 
     Only Builders may use this command.
     See |whelp carmor|n for details.
@@ -877,7 +877,7 @@ class CmdCArmor(Command):
 
         if not argstr:
             self.msg(
-                "Usage: carmor [/unidentified] <name> <slot> <armor> <weight> [stat_mods] <description>"
+                "Usage: carmor [/unidentified] <name> <slot> <weight> [stat_mods] <description>"
             )
             return
         try:
@@ -885,14 +885,14 @@ class CmdCArmor(Command):
         except ValueError as err:
             self.msg(str(err))
             return
-        if len(parts) < 4:
+        if len(parts) < 3:
             self.msg(
-                "Usage: carmor [/unidentified] <name> <slot> <armor> <weight> [stat_mods] <description>"
+                "Usage: carmor [/unidentified] <name> <slot> <weight> [stat_mods] <description>"
             )
             return
-        name, slot, armor_str, weight_str = parts[:4]
+        name, slot, weight_str = parts[:3]
         name = name.strip("'\"")
-        rest = " ".join(parts[4:])
+        rest = " ".join(parts[3:])
         try:
             bonuses, desc = parse_stat_mods(rest)
         except ValueError as err:
@@ -901,11 +901,6 @@ class CmdCArmor(Command):
         slot = normalize_slot(slot)
         if slot not in VALID_SLOTS:
             self.msg("Invalid slot name.")
-            return
-        try:
-            armor = int(armor_str)
-        except ValueError:
-            self.msg("Armor must be a number.")
             return
         try:
             weight = int(weight_str)
@@ -917,8 +912,6 @@ class CmdCArmor(Command):
             "typeclasses.objects.ClothingObject",
             name,
             slot,
-            armor,
-            attr="armor",
             desc=desc,
             weight=weight,
             identified=identified,
@@ -928,7 +921,7 @@ class CmdCArmor(Command):
             obj.db.stat_mods = bonuses
 
         self.caller.msg(
-            f"Slot: {slot}\nArmor: {armor}\nWeight: {weight}\nDescription: {desc}"
+            f"Slot: {slot}\nWeight: {weight}\nDescription: {desc}"
         )
 
 

--- a/typeclasses/tests/test_admin_commands.py
+++ b/typeclasses/tests/test_admin_commands.py
@@ -217,7 +217,7 @@ class TestAdminCommands(EvenniaTest):
     def test_carmor_tags_and_wear(self):
         """Armor created with carmor gets tags and can be worn."""
 
-        self.char1.execute_cmd("carmor head head 1 1 basic")
+        self.char1.execute_cmd("carmor head head 1 basic")
         armor = next(
             (o for o in self.char1.contents if "head" in list(o.aliases.all())),
             None,
@@ -331,7 +331,7 @@ class TestAdminCommands(EvenniaTest):
         self.assertIn("charm", out.lower())
 
     def test_carmor_with_modifiers(self):
-        self.char1.execute_cmd("carmor head head 2 1 STR+1, Dex+2 A sturdy head.")
+        self.char1.execute_cmd("carmor head head 1 STR+1, Dex+2 A sturdy head.")
         armor = next(
             (
                 o
@@ -411,7 +411,7 @@ class TestAdminCommands(EvenniaTest):
         shield = next((o for o in self.char1.contents if o.key == "kite shield"), None)
         self.assertIsNotNone(shield)
 
-        self.char1.execute_cmd('carmor "iron head" head 1 1 basic')
+        self.char1.execute_cmd('carmor "iron head" head 1 basic')
         armor = next((o for o in self.char1.contents if o.key == "iron head"), None)
         self.assertIsNotNone(armor)
 

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -417,7 +417,7 @@ Help for carmor
 Create a wearable armor item.
 
 Usage:
-    carmor [/unidentified] <name> <slot> <armor> <weight> [modifiers] <description>
+    carmor [/unidentified] <name> <slot> <weight> [stat_mods] <description>
 
 Switches:
     None
@@ -426,7 +426,7 @@ Arguments:
     None
 
 Examples:
-    carmor "Gilded Chestplate" chest 5 4 STR+2, Armor+3 A brilliant golden chest.
+    carmor "Ruby Helm" head 5 hp+5,armor+10,stamina_regen+2 A red magical helmet.
 
 Notes:
     - Slot becomes the clothing type.


### PR DESCRIPTION
## Summary
- update `carmor` command signature and docstring
- update the help entry example
- adjust tests to match new usage

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6843ca8a6ac4832cab9f86fb51568068