### PR TITLE
Remove weapon bonuses attr

### DIFF
--- a/commands/admin.py
+++ b/commands/admin.py
@@ -703,7 +703,6 @@ class CmdCWeapon(Command):
             obj.attributes.add("dice_num", dice_num)
             obj.attributes.add("dice_sides", dice_sides)
         if bonuses:
-            obj.db.bonuses = bonuses
             obj.db.stat_mods = bonuses
 
         damage_display = dmg_arg

--- a/typeclasses/tests/test_admin_commands.py
+++ b/typeclasses/tests/test_admin_commands.py
@@ -209,7 +209,7 @@ class TestAdminCommands(EvenniaTest):
         self.assertIsNotNone(weapon)
         self.assertEqual(weapon.db.weight, 5)
         self.assertEqual(
-            weapon.db.bonuses,
+            weapon.db.stat_mods,
             {"str": 2, "attack_power": 5, "accuracy": 3},
         )
         self.assertEqual(weapon.db.desc, "A vicious longsword.")


### PR DESCRIPTION
## Summary
- fix admin weapon creation to store stat_mods only
- update tests for stat_mods instead of bonuses

## Testing
- `pytest -q` *(fails: django.db.utils.OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6843ce45eedc832cbe331aa841302f61