### PR TITLE
Prevent stacking weapon stat bonuses

### DIFF
--- a/typeclasses/tests/test_stat_manager.py
+++ b/typeclasses/tests/test_stat_manager.py
@@ -239,6 +239,15 @@ class TestBonusPersistence(EvenniaTest):
 
         self.assertEqual(self.char1.db.equip_bonuses, base_bonus)
 
+    def test_recalculate_does_not_stack(self):
+        item = self._equip_item()
+        base_str = self.char1.traits.STR.base
+
+        stat_manager.recalculate_stats(self.char1)
+        stat_manager.recalculate_stats(self.char1)
+
+        self.assertEqual(self.char1.traits.STR.base, base_str)
+
     def test_remove_clears_slot_and_bonus(self):
         item = self._equip_item()
         item.remove(self.char1, True)

--- a/world/system/stat_manager.py
+++ b/world/system/stat_manager.py
@@ -212,13 +212,21 @@ def remove_item_bonuses(chara, item) -> None:
 
 def reset_all_item_bonuses(chara) -> None:
     """Reset and reapply bonuses from all equipped items."""
-    chara.db.equip_bonuses = {}
+
+    # remove any currently applied bonuses so repeated calls don't stack
     for itm in set(chara.equipment.values()):
-        if itm:
+        if itm and getattr(itm.db, "bonuses_applied", False):
+            remove_equip_bonus(chara, itm)
             itm.db.bonuses_applied = False
+
+    chara.db.equip_bonuses = {}
+
     for itm in set(chara.equipment.values()):
         if itm:
-            apply_item_bonuses_once(chara, itm)
+            add_equip_bonus(chara, itm)
+            itm.db.bonuses_applied = True
+
+    refresh_stats(chara)
 
 
 def apply_bonuses(chara, item) -> None:
@@ -241,7 +249,6 @@ def clear_all_equipment_bonuses(chara) -> None:
 def recalculate_stats(chara) -> None:
     """Reapply bonuses from all equipped items and refresh stats."""
     reset_all_item_bonuses(chara)
-    refresh_stats(chara)
 
 
 def _gear_mods(obj) -> Dict[str, int]:  # pragma: no cover - placeholder


### PR DESCRIPTION
## Summary
- fix bonus stacking when recalculating stats
- test that repeated stat recalculation does not stack bonuses

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6843d1ff3a24832c9a96d3d410238391