### PR TITLE
Add full secondary stat support

### DIFF
--- a/commands/admin.py
+++ b/commands/admin.py
@@ -71,6 +71,8 @@ def parse_stat_mods(text):
                 desc_parts.extend(p.strip() for p in pieces[i + 1 :])
                 break
         else:
+            if "+" in piece:
+                raise ValueError(piece)
             desc_parts.append(piece)
             desc_parts.extend(p.strip() for p in pieces[i + 1 :])
             break
@@ -491,7 +493,7 @@ class CmdCGear(Command):
         try:
             bonuses, desc = parse_stat_mods(rest)
         except ValueError as err:
-            self.msg(f"Invalid stat modifier: {err}")
+            self.msg(f"Invalid stat modifier: {err}. See 'help statmods' for valid stats.")
             return
         if slot and slot not in VALID_SLOTS:
             self.msg("Invalid slot name.")
@@ -654,7 +656,9 @@ class CmdCWeapon(Command):
                     amount = int(match.group(2))
                     key = normalize_stat_key(stat_name)
                     if key not in VALID_STATS:
-                        self.msg(f"Invalid stat modifier: {stat_name}")
+                        self.msg(
+                            f"Invalid stat modifier: {stat_name}. See 'help statmods' for valid stats."
+                        )
                         return
                     bonuses[key] = amount
                     remainder = piece[match.end() :].strip()
@@ -794,7 +798,9 @@ class CmdCShield(Command):
                     amount = int(match.group(2))
                     key = normalize_stat_key(stat_name)
                     if key not in VALID_STATS:
-                        self.msg(f"Invalid stat modifier: {stat_name}")
+                        self.msg(
+                            f"Invalid stat modifier: {stat_name}. See 'help statmods' for valid stats."
+                        )
                         return
                     bonuses[key] = amount
                     remainder = piece[match.end() :].strip()
@@ -895,7 +901,7 @@ class CmdCArmor(Command):
         try:
             bonuses, desc = parse_stat_mods(rest)
         except ValueError as err:
-            self.msg(f"Invalid stat modifier: {err}")
+            self.msg(f"Invalid stat modifier: {err}. See 'help statmods' for valid stats.")
             return
         slot = normalize_slot(slot)
         if slot not in VALID_SLOTS:
@@ -977,7 +983,7 @@ class CmdCTool(Command):
         try:
             bonuses, desc = parse_stat_mods(rest)
         except ValueError as err:
-            self.msg(f"Invalid stat modifier: {err}")
+            self.msg(f"Invalid stat modifier: {err}. See 'help statmods' for valid stats.")
             return
         obj = _create_gear(
             self.caller,
@@ -1058,7 +1064,7 @@ class CmdCRing(Command):
         try:
             bonuses, desc = parse_stat_mods(rest)
         except ValueError as err:
-            self.msg(f"Invalid stat modifier: {err}")
+            self.msg(f"Invalid stat modifier: {err}. See 'help statmods' for valid stats.")
             return
 
         if slot not in VALID_SLOTS:
@@ -1136,7 +1142,7 @@ class CmdCTrinket(Command):
         try:
             bonuses, desc = parse_stat_mods(rest)
         except ValueError as err:
-            self.msg(f"Invalid stat modifier: {err}")
+            self.msg(f"Invalid stat modifier: {err}. See 'help statmods' for valid stats.")
             return
 
         obj = _create_gear(
@@ -1275,7 +1281,7 @@ class CmdCPotion(Command):
         try:
             bonuses, desc = parse_stat_mods(rest)
         except ValueError as err:
-            self.msg(f"Invalid stat modifier: {err}")
+            self.msg(f"Invalid stat modifier: {err}. See 'help statmods' for valid stats.")
             return
 
         obj = _create_gear(

--- a/utils/stats_utils.py
+++ b/utils/stats_utils.py
@@ -17,9 +17,13 @@ ALIAS_MAP = {
     "eva": "EVA",
     "per": "perception",
     "critical_chance": "crit_chance",
+    "critchance": "crit_chance",
     "critical_damage_bonus": "crit_bonus",
+    "crit_dmg_bonus": "crit_bonus",
     "critical_resist": "crit_resist",
     "armor_penetration": "piercing",
+    "armor_pen": "piercing",
+    "spell_pen": "spell_penetration",
     "crafting_bonus": "craft_bonus",
     "guild_honor_rank_modifiers": "guild_honor_mod",
 }

--- a/utils/tests/test_parse_stat_mods.py
+++ b/utils/tests/test_parse_stat_mods.py
@@ -1,0 +1,18 @@
+from evennia.utils.test_resources import EvenniaTest
+from commands.admin import parse_stat_mods
+
+class TestParseStatMods(EvenniaTest):
+    def test_alias_and_lowercase(self):
+        mods, desc = parse_stat_mods("armor_pen+5, crit_chance+3 test")
+        self.assertEqual(mods, {"piercing": 5, "crit_chance": 3})
+        self.assertEqual(desc, "test")
+
+    def test_invalid_mod_format(self):
+        with self.assertRaises(ValueError):
+            parse_stat_mods("hp+g")
+        with self.assertRaises(ValueError):
+            parse_stat_mods("critchance++5")
+
+    def test_underscore_names(self):
+        mods, _ = parse_stat_mods("critical_chance+2")
+        self.assertEqual(mods, {"crit_chance": 2})

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -2302,4 +2302,21 @@ Related:
     help ansi
 """,
     },
+    {
+        "key": 'statmods',
+        "aliases": ['stat mods', 'gear bonuses'],
+        "category": 'Building',
+        "text": """
+Help for statmods
+
+These are the secondary stats that can be modified by gear creation commands.
+
+Evasion, Armor, Magic Resist, Dodge, Block Rate, Parry Rate, Status Resist,
+Critical Resist, Attack Power, Spell Power, Critical Chance, Critical Damage
+Bonus, Accuracy, Armor Penetration, Spell Penetration, Health Regen, Mana Regen,
+Stamina Regen, Lifesteal, Leech, Cooldown Reduction, Initiative, Stealth,
+Detection, Threat, Movement Speed, Crafting Bonus, PvP Power, PvP Resilience,
+Guild Honor Rank Modifiers.
+""",
+    },
 ]


### PR DESCRIPTION
## Summary
- support `armor_pen` alias for piercing and handle other stat aliases
- detect invalid stat modifiers in parse_stat_mods
- add 'statmods' help file listing valid secondary stats
- improve error messages referencing new help entry
- add tests for parse_stat_mods aliasing and error handling

## Testing
- `pytest utils/tests/test_parse_stat_mods.py::TestParseStatMods::test_alias_and_lowercase -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6843d5cd86f0832c861b05f97d0b0efc