### PR TITLE
Handle ANSI names when creating gear

### DIFF
--- a/commands/admin.py
+++ b/commands/admin.py
@@ -2,6 +2,7 @@ from evennia import CmdSet, create_object
 from evennia.objects.models import ObjectDB
 import shlex
 import re
+from evennia.utils.ansi import strip_ansi
 from .command import Command
 from .info import CmdScan
 from .building import (
@@ -390,8 +391,10 @@ def _create_gear(
     lowercase base alias matching ``name`` is always added.
     """
 
-    key = name
-    alias_base = key.lower()
+    from utils import format_ansi_title
+
+    key = format_ansi_title(name)
+    alias_base = strip_ansi(key).lower()
     count = ObjectDB.objects.filter(db_key__iexact=key).count()
 
     obj = create_object(typeclass, key=key, location=caller)

--- a/typeclasses/tests/test_admin_commands.py
+++ b/typeclasses/tests/test_admin_commands.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock
 
 from evennia import create_object
+from evennia.utils.ansi import strip_ansi
 from commands.admin import AdminCmdSet
 from commands.default_cmdsets import CharacterCmdSet
 from evennia.utils.test_resources import EvenniaTest
@@ -436,4 +437,10 @@ class TestAdminCommands(EvenniaTest):
         self.char1.execute_cmd('ocreate "strange box" 1')
         obj = next((o for o in self.char1.contents if o.key == "strange box"), None)
         self.assertIsNotNone(obj)
+
+    def test_cweapon_color_name_capitalization(self):
+        self.char1.execute_cmd('cweapon "|BBigger Ass Sword|n" mainhand 3 1 sharp')
+        weapon = next((o for o in self.char1.contents if strip_ansi(o.key) == "Bigger Ass Sword"), None)
+        self.assertIsNotNone(weapon)
+        self.assertEqual(weapon.key, "|BBigger Ass Sword|n")
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -2,3 +2,4 @@ from .roles import has_role, is_guildmaster, is_receptionist
 
 
 from .slots import VALID_SLOTS, normalize_slot
+from .ansi_utils import format_ansi_title

--- a/utils/ansi_utils.py
+++ b/utils/ansi_utils.py
@@ -1,0 +1,8 @@
+import re
+
+
+def format_ansi_title(name: str) -> str:
+    """Return ``name`` title-cased while preserving Evennia ANSI codes."""
+    tokens = re.split(r'(\|.)', str(name))
+    return "".join(token if token.startswith("|") else token.title() for token in tokens)
+


### PR DESCRIPTION
## Summary
- keep capitalization when creating gear with ANSI-coloured names
- expose `format_ansi_title` helper
- test coloured name creation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6843d9806b68832cbecda3804cc53b4d