### PR TITLE
Add pouch coin flag

### DIFF
--- a/commands/info.py
+++ b/commands/info.py
@@ -312,6 +312,7 @@ class CmdDrop(Command):
             )
             coin.db.coin_type = ctype
             coin.db.amount = amount
+            coin.db.from_pouch = True
             caller.msg(f"You drop {amount} {ctype} coin{'s' if amount != 1 else ''}.")
             return
 

--- a/typeclasses/objects.py
+++ b/typeclasses/objects.py
@@ -359,6 +359,7 @@ class CoinPile(Object):
         self.db.coin_type = "copper"
         self.db.amount = 0
         self.db.weight = 0
+        self.db.from_pouch = False
 
     def get_display_name(self, looker, **kwargs):
         ctype = (self.db.coin_type or "coin").capitalize()
@@ -370,7 +371,7 @@ class CoinPile(Object):
         dest = self.location
         if not dest:
             return
-        if dest.is_typeclass("typeclasses.characters.Character", exact=False):
+        if dest.is_typeclass("typeclasses.characters.Character", exact=False) and self.db.from_pouch:
             wallet = dest.db.coins or {}
             ctype = self.db.coin_type
             wallet[ctype] = int(wallet.get(ctype, 0)) + int(self.db.amount or 0)

--- a/typeclasses/tests/test_coin_pouch.py
+++ b/typeclasses/tests/test_coin_pouch.py
@@ -1,0 +1,32 @@
+from unittest.mock import MagicMock
+
+from evennia.utils.test_resources import EvenniaTest
+from django.test import override_settings
+from utils.currency import from_copper, to_copper
+
+
+@override_settings(DEFAULT_HOME=None)
+class TestCoinPouchCoins(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.char1.msg = MagicMock()
+
+    def test_pouch_coins_auto_deposit(self):
+        self.char1.db.coins = from_copper(20)
+        self.char1.execute_cmd("drop 5 copper")
+
+        coin = next(
+            obj
+            for obj in self.char1.location.contents
+            if obj.is_typeclass("typeclasses.objects.CoinPile", exact=False)
+        )
+        self.assertTrue(coin.db.from_pouch)
+        self.assertEqual(to_copper(self.char1.db.coins), 15)
+
+        self.char1.msg.reset_mock()
+        self.char1.execute_cmd("get copper coins")
+
+        self.assertEqual(to_copper(self.char1.db.coins), 20)
+        self.assertIsNone(coin.pk)
+        self.char1.msg.assert_any_call("You receive 5 copper coins.")
+


### PR DESCRIPTION
## Summary
- mark coins dropped from the pouch with `from_pouch`
- deposit pouch coins automatically when picked up
- test pouch coin auto-deposit logic

## Testing
- `evennia migrate`
- `pytest typeclasses/tests/test_coin_pouch.py -q` *(fails: OperationalError/AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_6843e59241e4832cb21d6c8ec2f5afb3