### PR TITLE
Implement coin-pile-based giving

### DIFF
--- a/commands/info.py
+++ b/commands/info.py
@@ -356,9 +356,15 @@ class CmdGive(Command):
                 return
             wallet[ctype] -= amount
             caller.db.coins = wallet
-            twallet = target.db.coins or {}
-            twallet[ctype] = int(twallet.get(ctype, 0)) + amount
-            target.db.coins = twallet
+            coin = create_object(
+                "typeclasses.objects.CoinPile",
+                key=f"{ctype} coins",
+                location=caller.location,
+            )
+            coin.db.coin_type = ctype
+            coin.db.amount = amount
+            coin.db.from_pouch = True
+            coin.move_to(target, quiet=True)
             caller.msg(
                 f"You give {amount} {ctype} coin{'s' if amount != 1 else ''} to {target.get_display_name(caller)}."
             )

--- a/typeclasses/objects.py
+++ b/typeclasses/objects.py
@@ -380,3 +380,7 @@ class CoinPile(Object):
                 f"You receive {self.db.amount} {ctype} coin{'s' if int(self.db.amount or 0) != 1 else ''}."
             )
             self.delete()
+
+    def at_post_move(self, source_location, **kwargs):
+        """Alias for at_after_move for compatibility."""
+        self.at_after_move(source_location, **kwargs)

--- a/typeclasses/tests/test_coin_pouch.py
+++ b/typeclasses/tests/test_coin_pouch.py
@@ -10,6 +10,7 @@ class TestCoinPouchCoins(EvenniaTest):
     def setUp(self):
         super().setUp()
         self.char1.msg = MagicMock()
+        self.char2.msg = MagicMock()
 
     def test_pouch_coins_auto_deposit(self):
         self.char1.db.coins = from_copper(20)
@@ -29,4 +30,15 @@ class TestCoinPouchCoins(EvenniaTest):
         self.assertEqual(to_copper(self.char1.db.coins), 20)
         self.assertIsNone(coin.pk)
         self.char1.msg.assert_any_call("You receive 5 copper coins.")
+
+    def test_give_coins_auto_deposit(self):
+        self.char1.db.coins = from_copper(10)
+        self.char2.db.coins = from_copper(0)
+
+        self.char1.execute_cmd(f"give 5 copper={self.char2.key}")
+
+        self.assertEqual(to_copper(self.char1.db.coins), 5)
+        self.assertEqual(to_copper(self.char2.db.coins), 5)
+
+        self.char2.msg.assert_any_call("You receive 5 copper coins.")
 


### PR DESCRIPTION
## Summary
- update `CmdGive` to create a `CoinPile` that moves to the target
- support coin pile auto-deposit via a new `at_post_move` hook
- test giving coins between characters

## Testing
- `pytest typeclasses/tests/test_coin_pouch.py::TestCoinPouchCoins::test_give_coins_auto_deposit -q`
- `pytest -q` *(fails: 70 failed, 28 passed, 8 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6843e992e0dc832cb5919a21034ceb2e