### PR TITLE
Add NPC prototype registry and registration option

### DIFF
--- a/typeclasses/tests/test_cnpc.py
+++ b/typeclasses/tests/test_cnpc.py
@@ -59,3 +59,24 @@ class TestCNPC(EvenniaTest):
             self.char2.execute_cmd("cnpc start thief")
         self.assertIsNone(getattr(self.char2.ndb, "buildnpc", None))
         self.assertIsNone(self._find("thief", location=self.char2.location))
+
+    def test_prototype_registration(self):
+        with patch("commands.npc_builder.EvMenu"):
+            self.char1.execute_cmd("cnpc start ogre")
+
+        npc_builder._set_desc(self.char1, "A big ogre")
+        npc_builder._set_npc_type(self.char1, "monster")
+        npc_builder._set_creature_type(self.char1, "humanoid")
+        npc_builder._set_level(self.char1, "1")
+        npc_builder._set_resources(self.char1, "20 5 5")
+        npc_builder._set_stats(self.char1, "5 5 5 5 5 5")
+        npc_builder._set_behavior(self.char1, "dumb")
+        npc_builder._set_skills(self.char1, "smash")
+        npc_builder._set_ai(self.char1, "passive")
+        npc_builder._create_npc(self.char1, "", register=True)
+
+        from world.prototypes import get_npc_prototypes
+
+        registry = get_npc_prototypes()
+        self.assertIn("ogre", registry)
+        self.assertEqual(registry["ogre"]["desc"], "A big ogre")

--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -1,5 +1,8 @@
-"""
-Prototypes
+"""Game object and NPC prototypes.
+
+This module contains sample prototypes used throughout the game. It also
+provides a small registry helper for storing NPC prototypes so they can be
+spawned again later via the prototype spawner.
 """
 
 from random import randint, choice
@@ -466,3 +469,29 @@ DEER_ANTLER = {
         ("bone", "crafting_material"),
     ],
 }
+
+# ------------------------------------------------------------
+# NPC prototype registry utilities
+# ------------------------------------------------------------
+
+from typing import Dict
+from evennia.server.models import ServerConfig
+
+_NPC_REGISTRY_KEY = "npc_prototype_registry"
+
+
+def _load_npc_registry() -> Dict[str, dict]:
+    """Return the stored NPC prototypes."""
+    return ServerConfig.objects.conf(_NPC_REGISTRY_KEY, default={})
+
+
+def get_npc_prototypes() -> Dict[str, dict]:
+    """Expose all registered NPC prototypes."""
+    return _load_npc_registry()
+
+
+def register_npc_prototype(key: str, prototype: dict):
+    """Save ``prototype`` under ``key`` in the persistent registry."""
+    registry = _load_npc_registry()
+    registry[key] = prototype
+    ServerConfig.objects.conf(_NPC_REGISTRY_KEY, value=registry)


### PR DESCRIPTION
## Summary
- document prototypes module
- allow registering NPC prototypes
- update cnpc menu to save prototypes
- test saving prototypes

## Testing
- `pytest -q typeclasses/tests/test_cnpc.py::TestCNPC::test_prototype_registration -q`
- `pytest -q` *(fails: AssertionError in TestInfoCommands::test_inspect_unidentified)*

------
https://chatgpt.com/codex/tasks/task_e_6843f6158358832c9ca44485e6a6a566