### PR TITLE
Ensure global tick is recreated if misconfigured

### DIFF
--- a/server/conf/at_server_startstop.py
+++ b/server/conf/at_server_startstop.py
@@ -33,7 +33,10 @@ def at_server_start():
     from evennia.utils import create
     from evennia.scripts.models import ScriptDB
 
-    if not ScriptDB.objects.filter(db_key="global_tick").exists():
+    script = ScriptDB.objects.filter(db_key="global_tick").first()
+    if not script or script.typeclass_path != "typeclasses.scripts.GlobalTick":
+        if script:
+            script.delete()
         create.script("typeclasses.scripts.GlobalTick", key="global_tick")
 
 


### PR DESCRIPTION
## Summary
- fix `at_server_start` logic to recreate the global tick script if it's missing or wrong

## Testing
- `pytest -q` *(fails: django.db.utils.OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6843fae9f690832ca83073517b3ee173