### PR TITLE
Handle missing NPC build data

### DIFF
--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -106,6 +106,9 @@ def _set_ai(caller, raw_string, **kwargs):
 
 def menunode_confirm(caller, raw_string="", **kwargs):
     data = caller.ndb.buildnpc
+    if not isinstance(data, dict):
+        caller.msg("Error: NPC data missing. Restarting builder.")
+        return None
     text = "|wConfirm NPC Creation|n\n"
     for key, val in data.items():
         if key == "primary_stats":
@@ -123,6 +126,9 @@ def menunode_confirm(caller, raw_string="", **kwargs):
 
 def _create_npc(caller, raw_string, register=False, **kwargs):
     data = caller.ndb.buildnpc
+    if not isinstance(data, dict):
+        caller.msg("Error: NPC data missing. Aborting.")
+        return None
     npc = data.get("edit_obj") or create_object(NPC, key=data.get("key"), location=caller.location)
     npc.db.desc = data.get("desc")
     npc.tags.add("npc")

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -2321,6 +2321,7 @@ Guild Honor Rank Modifiers.
     },
     {
         "key": 'cnpc',
+        "aliases": ['npc'],
         "category": 'Building',
         "text": """
 Help for cnpc
@@ -2342,10 +2343,12 @@ Examples:
     cnpc edit Bob
 
 Notes:
-    - Supported NPC types include merchant, guard, questgiver, trainer or any custom value.
-    - Behaviour and AI type are entered during the menu to define reactions.
-    - Humanoids gain all equipment slots; quadrupeds lack twohanded, mainhand and offhand slots.
-    - After reviewing the summary choose |wYes|n to confirm and create or update the NPC.
+    - The builder prompts for description, NPC type, creature type, level,
+      HP MP SP, primary stats, behavior, skills and AI type.
+    - Humanoids gain all equipment slots; quadrupeds lack twohanded,
+      mainhand and offhand slots.
+    - After reviewing the summary choose |wYes|n to confirm and create or
+      update the NPC.
     - Use |wcnpc edit <npc>|n to modify an existing NPC.
     - ANSI color codes are supported in names and descriptions.
 


### PR DESCRIPTION
## Summary
- avoid crashes when NPC build data is lost
- improve CNPC help entry and add `npc` alias

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6843fc7a2eac832c8eea6ec65a8de47b