### PR TITLE
Update global tick process

### DIFF
--- a/typeclasses/scripts.py
+++ b/typeclasses/scripts.py
@@ -3,6 +3,7 @@ from evennia.utils import make_iter, logger
 from evennia.scripts.scripts import DefaultScript
 from evennia.prototypes.prototypes import PROTOTYPE_TAG_CATEGORY
 from evennia.prototypes.spawner import spawn
+from .characters import Character
 
 
 class Script(DefaultScript):
@@ -243,14 +244,13 @@ class GlobalTick(Script):
         self.persistent = True
 
     def at_repeat(self):
-        from evennia.utils.search import search_tag
         from .characters import PlayerCharacter
         from world.system import state_manager
 
-        for obj in search_tag(key="tickable"):
-            if hasattr(obj, "at_tick"):
-                obj.at_tick()
-            state_manager.tick_character(obj)
+        for char in Character.objects.all():
+            if hasattr(char, "at_tick"):
+                char.at_tick()
+            state_manager.tick_character(char)
 
         for pc in PlayerCharacter.objects.all():
             pc.refresh_prompt()


### PR DESCRIPTION
## Summary
- import `Character` into scripts
- tick every Character in `GlobalTick.at_repeat`

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684403a1bbf8832cae5d559dc5855098