### PR TITLE
Fix offline regeneration

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -589,9 +589,6 @@ class Character(ObjectParent, ClothedCharacter):
         Regenerates resources based on current status and refreshes the prompt
         to visually reflect the changes.
         """
-        if not self.sessions.count():
-            return
-
         statuses = self.tags.get(category="status", return_list=True) or []
 
         if "sleeping" in statuses or "unconscious" in statuses:
@@ -620,11 +617,12 @@ class Character(ObjectParent, ClothedCharacter):
             if gained:
                 healed[trait_key] = (gained, color)
 
-        if healed:
+        if healed and self.sessions.count():
             parts = [f"{col}+{amt} {k[:2].upper()}|n" for k, (amt, col) in healed.items()]
             self.msg("You regenerate " + ", ".join(parts) + ".")
 
-        self.refresh_prompt()
+        if self.sessions.count():
+            self.refresh_prompt()
 
     def refresh_prompt(self):
         """Refresh the player's prompt display."""


### PR DESCRIPTION
## Summary
- allow at_tick regeneration to run without an active session
- only send healing messages/prompt updates if the character has a session

## Testing
- `pytest -q` *(fails: django.db.utils.OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684404b5ee94832c82be617c9438ac7e