### PR TITLE
Remove tickable tag from PCs

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -653,7 +653,6 @@ class PlayerCharacter(Character):
         super().at_object_creation()
         # initialize hands
         self.db._wielded = {"left": None, "right": None}
-        self.tags.add("tickable")
 
     def get_display_name(self, looker, **kwargs):
         """

--- a/typeclasses/tests/test_characters.py
+++ b/typeclasses/tests/test_characters.py
@@ -158,7 +158,6 @@ class TestGlobalTick(EvenniaTest):
         script = GlobalTick()
         script.at_script_creation()
 
-        self.char1.tags.add("tickable")
         self.char1.at_tick = MagicMock()
         self.char1.refresh_prompt = MagicMock()
         from world.system import state_manager


### PR DESCRIPTION
## Summary
- stop giving newly created PlayerCharacters the `tickable` tag
- adjust GlobalTick prompt test

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6844082660fc832c904e1e9758101a54