### PR TITLE
Suppress regen msg

### DIFF
--- a/typeclasses/scripts.py
+++ b/typeclasses/scripts.py
@@ -278,9 +278,8 @@ class GlobalTick(Script):
                 trait.current = min(trait.current + amount, trait.max)
                 healed[trait_key] = (amount, color)
 
-            if healed and hasattr(obj, "msg"):
-                parts = [f"{col}+{amt} {k[:2].upper()}|n" for k, (amt, col) in healed.items()]
-                obj.msg("You regenerate " + ", ".join(parts) + ".")
+            # We silently apply regeneration to avoid tick message spam
+            # when the global tick heals resources.
 
             if hasattr(obj, "refresh_prompt"):
                 obj.refresh_prompt()

--- a/typeclasses/tests/test_characters.py
+++ b/typeclasses/tests/test_characters.py
@@ -240,7 +240,8 @@ class TestRegeneration(EvenniaTest):
             self.assertGreater(trait.current, trait.max // 2)
 
         char.refresh_prompt.assert_called_once()
-        char.msg.assert_called()
+        # Healing during the global tick should not produce a message.
+        char.msg.assert_not_called()
 
 
 class TestCharacterCreationStats(EvenniaTest):


### PR DESCRIPTION
## Summary
- remove regeneration message from `GlobalTick`
- adjust regeneration test to expect no messages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684418ca3100832c9ab332aa624441e7