### PR TITLE
Set gauge regen rates to zero

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -642,7 +642,11 @@ class Character(ObjectParent, ClothedCharacter):
             # this sets the current HP to 20% of the max, a.k.a. one fifth
             self.traits.health.current = self.traits.health.max // 5
             self.msg(prompt=self.get_display_status(self))
-            self.traits.health.rate = 0.1
+            self.traits.health.rate = 0.0
+            if self.traits.mana:
+                self.traits.mana.rate = 0.0
+            if self.traits.stamina:
+                self.traits.stamina.rate = 0.0
 
 
 class PlayerCharacter(Character):
@@ -724,7 +728,11 @@ class PlayerCharacter(Character):
         self.tags.remove("unconscious", category="status")
         self.tags.remove("lying down", category="status")
         self.traits.health.reset()
-        self.traits.health.rate = 0.1
+        self.traits.health.rate = 0.0
+        if self.traits.mana:
+            self.traits.mana.rate = 0.0
+        if self.traits.stamina:
+            self.traits.stamina.rate = 0.0
         self.move_to(self.home)
         self.msg(prompt=self.get_display_status(self))
 

--- a/world/stats.py
+++ b/world/stats.py
@@ -26,9 +26,9 @@ CORE_STATS: List[Stat] = [
 
 # Primary resources
 RESOURCE_STATS: List[Stat] = [
-    Stat("health", "Health", trait_type="gauge", base=100, rate=0.1),
-    Stat("mana", "Mana", trait_type="gauge", base=100, rate=0.1),
-    Stat("stamina", "Stamina", trait_type="gauge", base=100, rate=0.1),
+    Stat("health", "Health", trait_type="gauge", base=100, rate=0.0),
+    Stat("mana", "Mana", trait_type="gauge", base=100, rate=0.0),
+    Stat("stamina", "Stamina", trait_type="gauge", base=100, rate=0.0),
 ]
 
 # Base skill for avoiding damage


### PR DESCRIPTION
## Summary
- stop auto-regen on health, mana, and stamina
- ensure respawn/revive set regen rates to zero

## Testing
- `pytest -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68441f514be4832c8b64e92076e10339