### PR TITLE
Enable stat-based regeneration

### DIFF
--- a/typeclasses/tests/test_characters.py
+++ b/typeclasses/tests/test_characters.py
@@ -2,7 +2,7 @@
 Tests for custom character logic
 """
 
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, call
 from evennia.utils.test_resources import EvenniaTest
 from evennia.utils import create
 
@@ -203,8 +203,7 @@ class TestGlobalTick(EvenniaTest):
         pc.at_tick = MagicMock(side_effect=pc.at_tick)
         npc.at_tick = MagicMock(side_effect=npc.at_tick)
 
-        with patch("random.randint", return_value=2):
-            script.at_repeat()
+        script.at_repeat()
 
         pc.at_tick.assert_not_called()
         npc.at_tick.assert_not_called()
@@ -232,16 +231,15 @@ class TestRegeneration(EvenniaTest):
         script = GlobalTick()
         script.at_script_creation()
 
-        with patch("random.randint", return_value=2):
-            script.at_repeat()
+        script.at_repeat()
 
         for key in ("health", "mana", "stamina"):
             trait = char.traits.get(key)
             self.assertGreater(trait.current, trait.max // 2)
 
         char.refresh_prompt.assert_called_once()
-        # Healing during the global tick should not produce a message.
-        char.msg.assert_not_called()
+        char.msg.assert_called_once()
+        self.assertIn("You regenerate", char.msg.call_args[0][0])
 
 
 class TestCharacterCreationStats(EvenniaTest):


### PR DESCRIPTION
## Summary
- implement `state_manager.apply_regen` helper
- use helper in `GlobalTick` and `Character.at_tick`
- adjust messaging of regeneration amounts
- update unit test for new behaviour

## Testing
- `pytest -q` *(fails: OperationalError no such table)*

------
https://chatgpt.com/codex/tasks/task_e_684420a2b348832cb571ff277b482b54