### PR TITLE
Ensure zero regen rate after revive and respawn

### DIFF
--- a/typeclasses/tests/test_characters.py
+++ b/typeclasses/tests/test_characters.py
@@ -252,3 +252,28 @@ class TestCharacterCreationStats(EvenniaTest):
         )
         self.assertIsNotNone(char.traits.get("armor"))
         self.assertEqual(char.traits.armor.base, 0)
+
+
+class TestReviveRespawn(EvenniaTest):
+    def test_revive_sets_partial_health_without_regen(self):
+        char = self.char1
+        char2 = self.char2
+        char.traits.health.current = 0
+        char.tags.add("unconscious", category="status")
+        char.tags.add("lying down", category="status")
+        char.traits.health.rate = 1.0
+        char.revive(char2)
+        self.assertEqual(char.traits.health.current, char.traits.health.max // 5)
+        self.assertEqual(char.traits.health.rate, 0.0)
+        self.assertFalse(char.tags.has("unconscious", category="status"))
+
+    def test_respawn_restores_full_health_without_regen(self):
+        char = self.char1
+        char.traits.health.current = 0
+        char.tags.add("unconscious", category="status")
+        char.tags.add("lying down", category="status")
+        char.traits.health.rate = 1.0
+        char.respawn()
+        self.assertEqual(char.traits.health.current, char.traits.health.max)
+        self.assertEqual(char.traits.health.rate, 0.0)
+        self.assertFalse(char.tags.has("unconscious", category="status"))


### PR DESCRIPTION
## Summary
- add regression tests for revive and respawn health
- confirm regen rate remains 0 after reviving or respawning

## Testing
- `evennia migrate`
- `pytest typeclasses/tests/test_characters.py::TestReviveRespawn::test_revive_sets_partial_health_without_regen -q` *(fails: ObjectDB.DoesNotExist)*

------
https://chatgpt.com/codex/tasks/task_e_684422c807a8832c8eb49d46e62605b1