### PR TITLE
Improve regeneration tests

### DIFF
--- a/typeclasses/tests/test_characters.py
+++ b/typeclasses/tests/test_characters.py
@@ -225,6 +225,11 @@ class TestRegeneration(EvenniaTest):
         for key in ("health", "mana", "stamina"):
             trait = char.traits.get(key)
             trait.current = trait.max // 2
+        char.db.derived_stats = {
+            "health_regen": 2,
+            "mana_regen": 3,
+            "stamina_regen": 4,
+        }
         char.refresh_prompt = MagicMock()
         char.msg = MagicMock()
 
@@ -233,9 +238,13 @@ class TestRegeneration(EvenniaTest):
 
         script.at_repeat()
 
-        for key in ("health", "mana", "stamina"):
+        for key, regen in (
+            ("health", 2),
+            ("mana", 3),
+            ("stamina", 4),
+        ):
             trait = char.traits.get(key)
-            self.assertGreater(trait.current, trait.max // 2)
+            self.assertEqual(trait.current, trait.max // 2 + regen)
 
         char.refresh_prompt.assert_called_once()
         char.msg.assert_called_once()

--- a/typeclasses/tests/test_state_manager.py
+++ b/typeclasses/tests/test_state_manager.py
@@ -78,3 +78,22 @@ class TestStateManager(EvenniaTest):
         self.assertEqual(char.db.sated, 1)
         self.assertFalse(char.tags.has("hungry_thirsty", category="status"))
         self.assertEqual(char.traits.health.current, hp)
+
+    def test_apply_regen_uses_derived_stats(self):
+        char = self.char1
+        for key in ("health", "mana", "stamina"):
+            trait = char.traits.get(key)
+            trait.current = trait.max // 2
+        char.db.derived_stats = {
+            "health_regen": 2,
+            "mana_regen": 3,
+            "stamina_regen": 4,
+        }
+
+        healed = state_manager.apply_regen(char)
+
+        expected = {"health": 2, "mana": 3, "stamina": 4}
+        self.assertEqual(healed, expected)
+        for key, regen in expected.items():
+            trait = char.traits.get(key)
+            self.assertEqual(trait.current, trait.max // 2 + regen)


### PR DESCRIPTION
## Summary
- verify that regeneration uses derived stats in `TestRegeneration`
- add explicit `apply_regen` check to state manager tests

## Testing
- `pytest -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684426be0858832c939bd3679313c244