### PR TITLE
Remove regeneration messaging

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -592,14 +592,7 @@ class Character(ObjectParent, ClothedCharacter):
         """
         from world.system import state_manager
 
-        healed = state_manager.apply_regen(self)
-
-        if healed and self.sessions.count():
-            mapping = {"health": "|r", "mana": "|b", "stamina": "|g"}
-            parts = [
-                f"{mapping[k]}+{amt} {k[:2].upper()}|n" for k, amt in healed.items()
-            ]
-            self.msg("You regenerate " + ", ".join(parts) + ".")
+        state_manager.apply_regen(self)
 
         if self.sessions.count():
             self.refresh_prompt()

--- a/typeclasses/scripts.py
+++ b/typeclasses/scripts.py
@@ -253,12 +253,7 @@ class GlobalTick(Script):
             if not hasattr(obj, "traits"):
                 continue
 
-            healed = state_manager.apply_regen(obj)
-
-            if healed and obj.sessions.count():
-                mapping = {"health": "|r", "mana": "|b", "stamina": "|g"}
-                parts = [f"{mapping[k]}+{amt} {k[:2].upper()}|n" for k, amt in healed.items()]
-                obj.msg("You regenerate " + ", ".join(parts) + ".")
+            state_manager.apply_regen(obj)
 
             if hasattr(obj, "refresh_prompt"):
                 obj.refresh_prompt()

--- a/typeclasses/tests/test_characters.py
+++ b/typeclasses/tests/test_characters.py
@@ -247,8 +247,7 @@ class TestRegeneration(EvenniaTest):
             self.assertEqual(trait.current, trait.max // 2 + regen)
 
         char.refresh_prompt.assert_called_once()
-        char.msg.assert_called_once()
-        self.assertIn("You regenerate", char.msg.call_args[0][0])
+        char.msg.assert_not_called()
 
 
 class TestCharacterCreationStats(EvenniaTest):


### PR DESCRIPTION
## Summary
- remove regen messages from Character.at_tick and GlobalTick
- expect no regeneration text in at_tick test

## Testing
- `pytest -q` *(fails: OperationalError no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684429b30e00832cb1e325cca13c2d80