### PR TITLE
Fix global tick regeneration

### DIFF
--- a/server/conf/at_server_startstop.py
+++ b/server/conf/at_server_startstop.py
@@ -39,6 +39,13 @@ def at_server_start():
             script.delete()
         create.script("typeclasses.scripts.GlobalTick", key="global_tick")
 
+    # Ensure all characters are marked tickable for the global ticker
+    from typeclasses.characters import Character
+
+    for char in Character.objects.all():
+        if not char.tags.has("tickable"):
+            char.tags.add("tickable")
+
 
 def at_server_stop():
     """

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -174,6 +174,9 @@ class Character(ObjectParent, ClothedCharacter):
         stats.apply_stats(self)
         stat_manager.refresh_stats(self)
 
+        # Mark character as tickable so the global tick script processes it
+        self.tags.add("tickable")
+
         self.db.guild = ""
         self.db.guild_points = {}
         self.db.guild_rank = ""


### PR DESCRIPTION
## Summary
- mark all characters tickable so global tick processes them
- ensure tickable tag is added to existing characters at server start

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68442c637b58832cbd720fcf1c8f0c55