### PR TITLE
Implement prioritized room appearances

### DIFF
--- a/commands/rest.py
+++ b/commands/rest.py
@@ -85,6 +85,13 @@ class CmdLook(DefaultCmdLook):
     """
     Look around the area unless you are sleeping.
 
+    The `look` command shows your current room's description and clearly lists:
+
+    1. Environmental objects (e.g., altars, pools)
+    2. Non-player characters (e.g., guards, merchants)
+    3. Visible items and loot
+    4. Other players in the room
+
     Usage:
         look [<target>]
 

--- a/typeclasses/objects.py
+++ b/typeclasses/objects.py
@@ -37,6 +37,10 @@ class ObjectParent:
 
     """
 
+    def get_display_name(self, looker, **kwargs):
+        """Return the short description or key for display."""
+        return self.db.shortdesc or self.key
+
 
 class Object(ObjectParent, DefaultObject):
     """
@@ -189,6 +193,8 @@ class Object(ObjectParent, DefaultObject):
         super().at_object_creation()
         if getattr(self.db, "weight", None) is None:
             self.db.weight = 0
+        if getattr(self.db, "display_priority", None) is None:
+            self.db.display_priority = "item"
 
     def at_drop(self, dropper, **kwargs):
         """

--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -109,6 +109,43 @@ class RoomParent(ObjectParent):
         else:
             return "|wExits:|n None"
 
+    def return_appearance(self, looker):
+        if not looker:
+            return ""
+
+        text = f"|c{self.key}|n\n"
+        text += f"{self.db.desc}\n"
+
+        exits = self.get_display_exits(looker)
+        if exits:
+            text += f"\n{exits}"
+
+        visible = (
+            obj for obj in self.contents if obj != looker and obj.access(looker, "view")
+        )
+
+        env_objects, npcs, items, players = [], [], [], []
+        for obj in visible:
+            name = obj.get_display_name(looker)
+            if obj.db.display_priority == "environment":
+                env_objects.append(name)
+            elif obj.is_typeclass("typeclasses.npcs.NPC", exact=False):
+                npcs.append(name)
+            elif obj.is_typeclass("typeclasses.characters.Character", exact=False):
+                players.append(name)
+            else:
+                items.append(name)
+
+        for category in (env_objects, npcs, items, players):
+            if category:
+                text += "\n" + "\n".join(category)
+
+        footer = self.get_display_footer(looker)
+        if footer:
+            text += f"\n{footer}"
+
+        return text.strip()
+
 
 class Room(RoomParent, DefaultRoom):
     """

--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -498,15 +498,9 @@ class TestCommandPrompt(EvenniaTest):
 
 class TestReturnAppearance(EvenniaTest):
     def test_room_return_appearance_format(self):
-        self.room1.appearance_template = (
-            "╔{name}\n{desc}\n{exits}\n{characters}\n{things}\n╚"
-        )
         output = self.room1.return_appearance(self.char1)
-        self.assertIn("╔", output)
-        self.assertIn("╚", output)
         self.assertIn("|wExits:|n", output)
-        self.assertIn("|wCharacters:|n", output)
-        self.assertIn("|wYou see:|n", output)
+        self.assertIn(self.room1.key, output)
 
 
 class TestRestCommands(EvenniaTest):

--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -210,6 +210,7 @@ IRON_ORE_NODE = {
     "desc": "An outcropping of rocks here appears to contain raw iron.",
     "spawn_proto": "IRON_ORE",
     "gathers": lambda: randint(2, 10),
+    "display_priority": "environment",
 }
 IRON_ORE = {
     "key": "iron ore",
@@ -225,6 +226,7 @@ COPPER_ORE_NODE = {
     "desc": "An outcropping of rocks here appears to contain raw copper.",
     "spawn_proto": "COPPER_ORE",
     "gathers": lambda: randint(2, 10),
+    "display_priority": "environment",
 }
 COPPER_ORE = {
     "key": "copper ore",
@@ -240,6 +242,7 @@ FRUIT_TREE = {
     "desc": "A tree here is full of fruit, some of which seem to be ripe.",
     "spawn_proto": lambda: choice(("APPLE_FRUIT", "PEAR_FRUIT", "PLUM_FRUIT")),
     "gathers": lambda: randint(5, 10),
+    "display_priority": "environment",
 }
 APPLE_FRUIT = {
     "key": "apple",
@@ -273,6 +276,7 @@ BERRY_BUSH = {
     "desc": "A few bushes nearby are covered in berries",
     "spawn_proto": lambda: choice(("BLACKBERRY", "BLUEBERRY", "RASPBERRY")),
     "gathers": lambda: randint(5, 10),
+    "display_priority": "environment",
 }
 BLACKBERRY = {
     "key": "blackberry",
@@ -321,6 +325,7 @@ LUMBER_TREE = {
     "desc": "This tree looks like a great source of lumber.",
     "spawn_proto": "WOOD_LOG",
     "gathers": lambda: randint(2, 10),
+    "display_priority": "environment",
 }
 WOOD_LOG = {
     "key": "log of wood",
@@ -338,6 +343,7 @@ DRIFTWOOD = {
     "desc": "Some of this wood looks like it would be useful.",
     "spawn_proto": "WOOD_LOG",
     "gathers": lambda: randint(1, 3),
+    "display_priority": "environment",
 }
 
 


### PR DESCRIPTION
## Summary
- add simple `get_display_name` to all base typeclasses via `ObjectParent`
- default new objects to `display_priority: item`
- overhaul room `return_appearance` to show categorized contents
- mark gather nodes as environmental in prototypes
- update look command help text
- adjust related test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684430cc6894832caec4824729eadcc5