### PR TITLE
Fix coin pile pickup deletion error

### DIFF
--- a/typeclasses/tests/test_coin_pouch.py
+++ b/typeclasses/tests/test_coin_pouch.py
@@ -40,5 +40,13 @@ class TestCoinPouchCoins(EvenniaTest):
         self.assertEqual(to_copper(self.char1.db.coins), 5)
         self.assertEqual(to_copper(self.char2.db.coins), 5)
 
+        # coin pile object should have been cleaned up
+        piles = [
+            obj
+            for obj in self.char2.contents
+            if obj.is_typeclass("typeclasses.objects.CoinPile", exact=False)
+        ]
+        self.assertFalse(piles)
+
         self.char2.msg.assert_any_call("You receive 5 copper coins.")
 


### PR DESCRIPTION
## Summary
- avoid deleting coin piles until after pickup messaging
- clean up coin pile on `at_get`
- ensure coin pile is deleted when giving coins
- test coverage for giving cleanup

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6843edcd5450832c8bb72cd6f161c8d1