### PR TITLE
Fix validation for menunode_confirm

### DIFF
--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -397,8 +397,9 @@ def _del_trigger(caller, raw_string, event=None, **kwargs):
 
 def menunode_confirm(caller, raw_string="", **kwargs):
     data = caller.ndb.buildnpc
-    if not isinstance(data, dict):
-        caller.msg("Error: NPC data missing. Restarting builder.")
+    required = {"key"}
+    if not isinstance(data, dict) or not required.issubset(data):
+        caller.msg("Error: NPC data incomplete. Restarting builder.")
         return None
     text = "|wConfirm NPC Creation|n\n"
     for key, val in data.items():

--- a/typeclasses/tests/test_cnpc.py
+++ b/typeclasses/tests/test_cnpc.py
@@ -140,3 +140,12 @@ class TestCNPC(EvenniaTest):
         npc = self._find("chimera")
         self.assertIn("tail", npc.db.equipment_slots)
         self.assertNotIn("offhand", npc.db.equipment_slots)
+
+    def test_confirm_incomplete_data(self):
+        """menunode_confirm should handle missing data gracefully."""
+        self.char1.ndb.buildnpc = {}
+        result = npc_builder.menunode_confirm(self.char1)
+        self.assertIsNone(result)
+        self.char1.msg.assert_called()
+        msg = self.char1.msg.call_args[0][0]
+        self.assertIn("Error", msg)


### PR DESCRIPTION
## Summary
- check NPC data keys in `menunode_confirm`
- test confirm handling incomplete data

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684440f75cac832c988ecfbb1d049d19