### PR TITLE
Add Developer NPC spawn command

### DIFF
--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -1,6 +1,7 @@
 from evennia.utils.evmenu import EvMenu
 from evennia.utils import make_iter
 from evennia import create_object
+from evennia.prototypes import spawner
 from typeclasses.characters import NPC
 from utils.slots import SLOT_ORDER
 from .command import Command
@@ -488,7 +489,7 @@ class CmdCNPC(Command):
 
     def func(self):
         if not self.args:
-            self.msg("Usage: cnpc start <key> | cnpc edit <npc>")
+            self.msg("Usage: cnpc start <key> | cnpc edit <npc> | cnpc dev_spawn <proto>")
             return
         parts = self.args.split(None, 1)
         sub = parts[0].lower()
@@ -528,5 +529,21 @@ class CmdCNPC(Command):
             self.caller.ndb.buildnpc = data
             EvMenu(self.caller, "commands.npc_builder", startnode="menunode_desc")
             return
-        self.msg("Usage: cnpc start <key> | cnpc edit <npc>")
+        if sub == "dev_spawn":
+            if not self.caller.check_permstring("Developer"):
+                self.msg("Developer permission required.")
+                return
+            if not rest:
+                self.msg("Usage: cnpc dev_spawn <proto>")
+                return
+            proto = rest
+            try:
+                obj = spawner.spawn(proto)[0]
+            except KeyError:
+                self.msg(f"Unknown prototype: {proto}")
+                return
+            obj.location = self.caller.location
+            self.msg(f"Spawned {obj.get_display_name(self.caller)}.")
+            return
+        self.msg("Usage: cnpc start <key> | cnpc edit <npc> | cnpc dev_spawn <proto>")
 

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -2365,7 +2365,7 @@ Create or edit an NPC using a guided menu.
 Usage:
     cnpc start <key>
     cnpc edit <npc>
-    cnpc dev_spawn <proto> [amt]
+    cnpc dev_spawn <proto>
 
 Switches:
     None
@@ -2376,7 +2376,7 @@ Arguments:
 Examples:
     cnpc start guard_01
     cnpc edit Bob
-    cnpc dev_spawn guard_01 5
+    cnpc dev_spawn test_blacksmith
 
 Notes:
     - NPC types include merchant, guard, questgiver, guildmaster,
@@ -2397,7 +2397,8 @@ Notes:
           4) Finish
       Choosing Add prompts for the event type, match text and reaction
       command.
-    - |wcnpc dev_spawn|n quickly spawns prototype NPCs for testing.
+    - |wcnpc dev_spawn|n quickly spawns prototype NPCs for testing (Developer only).
+    - Example: |wcnpc dev_spawn test_blacksmith|n
     - See |whelp triggers|n for available events and reactions.
     - ANSI color codes are supported in names and descriptions.
 

--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -451,6 +451,15 @@ STAG_DEER = {
     "can_attack": True,
 }
 
+# Example NPC used for development testing
+TEST_BLACKSMITH = {
+    "typeclass": "typeclasses.characters.NPC",
+    "key": "test blacksmith",
+    "desc": "A sturdy blacksmith created for testing purposes.",
+    "gender": "male",
+    "can_attack": False,
+}
+
 ### Mob drops
 
 RAW_MEAT = {


### PR DESCRIPTION
## Summary
- enable `cnpc dev_spawn <proto>` for Developers
- add a `TEST_BLACKSMITH` NPC prototype for testing
- document the new dev_spawn command in help

## Testing
- `evennia migrate`
- `pytest -q` *(fails: OperationalError and AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_6844443581d0832c95eb9877055c38d2