### PR TITLE
Fix coin pouch pickup logic

### DIFF
--- a/commands/info.py
+++ b/commands/info.py
@@ -276,7 +276,7 @@ class CmdDropAll(Command):
             caller.msg("You have nothing to drop.")
             return
         for obj in items:
-            obj.location = caller.location
+            obj.move_to(caller.location, quiet=True, move_type="drop")
             obj.at_drop(caller)
         caller.update_carry_weight()
         caller.msg("You drop everything you are carrying.")
@@ -319,7 +319,7 @@ class CmdDrop(Command):
         obj = caller.search(self.args, location=caller)
         if not obj:
             return
-        obj.location = caller.location
+        obj.move_to(caller.location, quiet=True, move_type="drop")
         obj.at_drop(caller)
         caller.update_carry_weight()
         caller.msg(f"You drop {obj.get_display_name(caller)}.")
@@ -377,8 +377,8 @@ class CmdGive(Command):
         if not obj:
             caller.msg("You aren't carrying that.")
             return
-        obj.location = target
-        obj.at_get(target)
+        if obj.move_to(target, quiet=True, move_type="give"):
+            obj.at_get(target)
         caller.update_carry_weight()
         caller.msg(f"You give {obj.get_display_name(caller)} to {target.get_display_name(caller)}.")
         target.msg(f"{caller.get_display_name(target)} gives you {obj.get_display_name(target)}.")
@@ -406,8 +406,8 @@ class CmdGetAll(Command):
             caller.msg("There is nothing here to pick up.")
             return
         for obj in items:
-            obj.location = caller
-            obj.at_get(caller)
+            if obj.move_to(caller, quiet=True, move_type="get"):
+                obj.at_get(caller)
         caller.update_carry_weight()
         caller.msg("You pick up everything you can.")
 

--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -542,7 +542,7 @@ class CmdCNPC(Command):
             except KeyError:
                 self.msg(f"Unknown prototype: {proto}")
                 return
-            obj.location = self.caller.location
+            obj.move_to(self.caller.location, quiet=True)
             self.msg(f"Spawned {obj.get_display_name(self.caller)}.")
             return
         self.msg("Usage: cnpc start <key> | cnpc edit <npc> | cnpc dev_spawn <proto>")

--- a/commands/quests.py
+++ b/commands/quests.py
@@ -409,7 +409,7 @@ class CmdCompleteQuest(Command):
             except Exception:
                 continue
             for obj in objs:
-                obj.location = caller
+                obj.move_to(caller, quiet=True, move_type="get")
                 rewards.append(obj.key)
 
         if quest.currency_reward:

--- a/commands/shops.py
+++ b/commands/shops.py
@@ -131,7 +131,7 @@ class CmdBuy(Command):
 
         # everything is good! do a capitalism!
         for obj in objs:
-            obj.location = self.caller
+            obj.move_to(self.caller, quiet=True, move_type="get")
 
         self.caller.db.coins = from_copper(to_copper(wallet) - total)
 

--- a/typeclasses/tests/test_coin_pouch.py
+++ b/typeclasses/tests/test_coin_pouch.py
@@ -50,3 +50,20 @@ class TestCoinPouchCoins(EvenniaTest):
 
         self.char2.msg.assert_any_call("You receive 5 copper coins.")
 
+    def test_getall_auto_deposit(self):
+        self.char1.db.coins = from_copper(30)
+        self.char1.execute_cmd("drop 10 copper")
+
+        coin = next(
+            obj
+            for obj in self.char1.location.contents
+            if obj.is_typeclass("typeclasses.objects.CoinPile", exact=False)
+        )
+
+        self.char1.msg.reset_mock()
+        self.char1.execute_cmd("get all")
+
+        self.assertEqual(to_copper(self.char1.db.coins), 30)
+        self.assertIsNone(coin.pk)
+        self.char1.msg.assert_any_call("You receive 10 copper coins.")
+


### PR DESCRIPTION
## Summary
- use `move_to` for object transfers so hooks run
- test picking up coins with `get all`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6844481249e4832c95cbcbf7c792903d