### PR TITLE
Fix global tick script creation

### DIFF
--- a/server/conf/at_server_startstop.py
+++ b/server/conf/at_server_startstop.py
@@ -37,7 +37,7 @@ def at_server_start():
     if not script or script.typeclass_path != "typeclasses.scripts.GlobalTick":
         if script:
             script.delete()
-        create.script("typeclasses.scripts.GlobalTick", key="global_tick")
+        create.create_script("typeclasses.scripts.GlobalTick", key="global_tick")
 
     # Ensure all characters are marked tickable for the global ticker
     from typeclasses.characters import Character


### PR DESCRIPTION
## Summary
- ensure `create.create_script` is used for global tick creation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68444a25e8d0832cb38c8bad072e600a