### PR TITLE
Implement merchant NPC with buy/sell commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,3 +147,13 @@ Add `/unidentified` before the name to create the weapon unidentified.
 When a weapon is identified, `inspect` shows its damage, slot, any bonuses and
 effects, so `inspect epee-2` will display the full details of the second
 "Epee" you created.
+
+
+## Merchants and Shopping
+
+NPCs can act as merchants if they use the `Merchant` typeclass. A merchant keeps
+sale stock in an internal storage container and offers the commands `list`,
+`buy`, `sell` and `sell all` to nearby players. Selling items automatically adds
+them to the merchant's stock. Prices are based on the item's value with optional
+markups or discounts. Buying or selling adjusts both your coin pouch and the
+merchant's purse.

--- a/typeclasses/npcs.py
+++ b/typeclasses/npcs.py
@@ -1,0 +1,43 @@
+from evennia import AttributeProperty
+from evennia.utils import create
+
+from .characters import NPC
+from commands.shops import MerchantCmdSet
+
+
+class Merchant(NPC):
+    """An NPC that buys and sells items."""
+
+    merchant = AttributeProperty(True)
+    merchant_type = AttributeProperty("")
+    buy_markup = AttributeProperty(2)
+    sell_discount = AttributeProperty(1)
+
+    def at_object_creation(self):
+        super().at_object_creation()
+        self.cmdset.add(MerchantCmdSet, persistent=True)
+        if not self.db.storage:
+            self.db.storage = create.object(
+                key=f"{self.key} storage",
+                locks="view:perm(Builder);get:perm(Builder);search:perm(Builder)",
+                home=self,
+                location=self,
+            )
+
+    @property
+    def shop_inventory(self):
+        storage = self.db.storage or self
+        return [obj for obj in storage.contents if obj.db.price]
+
+    def add_stock(self, obj):
+        storage = self.db.storage or self
+        obj.location = storage
+        val = obj.db.value or 0
+        markup = self.db.buy_markup or 1
+        obj.db.price = int(val * markup)
+        return True
+
+    def at_object_receive(self, obj, source_location, **kwargs):
+        super().at_object_receive(obj, source_location, **kwargs)
+        if source_location and source_location.has_account:
+            self.add_stock(obj)

--- a/typeclasses/tests/test_merchants.py
+++ b/typeclasses/tests/test_merchants.py
@@ -1,0 +1,33 @@
+from unittest.mock import MagicMock
+from evennia.utils.test_resources import EvenniaTest
+from evennia.utils import create
+from utils.currency import from_copper, to_copper
+
+
+class TestMerchantTrading(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        from typeclasses.npcs import Merchant
+        self.merchant = create.create_object(Merchant, key="shopkeep", location=self.room1)
+        self.char1.db.coins = from_copper(20)
+        self.merchant.db.coins = from_copper(0)
+        item = create.create_object("typeclasses.objects.Object", key="gem", location=self.merchant.db.storage)
+        item.db.price = 10
+        item.db.value = 5
+        self.item = item
+        self.char1.msg = MagicMock()
+        self.merchant.msg = MagicMock()
+
+    def test_buy_transfers_coins(self):
+        self.char1.execute_cmd("buy gem")
+        self.assertEqual(to_copper(self.char1.db.coins), 10)
+        self.assertEqual(to_copper(self.merchant.db.coins), 10)
+        self.assertEqual(self.item.location, self.char1)
+
+    def test_sell_transfers_coins(self):
+        obj = create.create_object("typeclasses.objects.Object", key="rock", location=self.char1)
+        obj.db.value = 4
+        self.char1.execute_cmd("sell rock")
+        self.assertEqual(to_copper(self.char1.db.coins), 24)
+        self.assertEqual(to_copper(self.merchant.db.coins), 4)
+

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -1972,7 +1972,7 @@ Examples:
     None
 
 Notes:
-    - None
+    - Shows everything a nearby merchant has in stock and their prices.
 
 Related:
     help ansi
@@ -1999,7 +1999,8 @@ Examples:
     None
 
 Notes:
-    - None
+    - Pays the asking price to the merchant and moves the item to you.
+    - Prices may vary depending on the merchant's markup.
 
 Related:
     help ansi
@@ -2026,7 +2027,8 @@ Examples:
     None
 
 Notes:
-    - None
+    - Trades your item to the merchant for its value in coins.
+    - Use |wsell all|n to sell everything you are carrying.
 
 Related:
     help ansi


### PR DESCRIPTION
## Summary
- add `Merchant` NPC typeclass for buying and selling items
- provide merchant-aware commands and cmdset
- document merchant usage in README and help entries
- test merchant buying and selling

## Testing
- `pytest -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68444ea9dbd0832c8e26a0c10036ebd1