### PR TITLE
Add Banker NPC and commands

### DIFF
--- a/commands/banking.py
+++ b/commands/banking.py
@@ -1,0 +1,82 @@
+from evennia import CmdSet
+from utils.currency import COIN_VALUES, format_wallet
+from commands.command import Command
+
+
+class CmdDeposit(Command):
+    """Deposit coins into your bank account."""
+
+    key = "deposit"
+    help_category = "Here"
+
+    def func(self):
+        if not self.args:
+            self.msg("Usage: deposit <amount> <coin>")
+            return
+        parts = self.args.split()
+        if len(parts) != 2 or not parts[0].isdigit() or parts[1].lower() not in COIN_VALUES:
+            self.msg("Usage: deposit <amount> <coin>")
+            return
+        amount = int(parts[0])
+        ctype = parts[1].lower()
+        wallet = self.caller.db.coins or {}
+        if amount <= 0 or wallet.get(ctype, 0) < amount:
+            self.msg("You don't have that many coins.")
+            return
+        wallet[ctype] = wallet.get(ctype, 0) - amount
+        self.caller.db.coins = wallet
+        bank = self.caller.db.bank or {}
+        bank[ctype] = int(bank.get(ctype, 0)) + amount
+        self.caller.db.bank = bank
+        self.msg(f"You deposit {amount} {ctype} coin{'s' if amount != 1 else ''}.")
+
+
+class CmdWithdraw(Command):
+    """Withdraw coins from your bank account."""
+
+    key = "withdraw"
+    help_category = "Here"
+
+    def func(self):
+        if not self.args:
+            self.msg("Usage: withdraw <amount> <coin>")
+            return
+        parts = self.args.split()
+        if len(parts) != 2 or not parts[0].isdigit() or parts[1].lower() not in COIN_VALUES:
+            self.msg("Usage: withdraw <amount> <coin>")
+            return
+        amount = int(parts[0])
+        ctype = parts[1].lower()
+        bank = self.caller.db.bank or {}
+        if amount <= 0 or bank.get(ctype, 0) < amount:
+            self.msg("You don't have that much stored.")
+            return
+        bank[ctype] = bank.get(ctype, 0) - amount
+        self.caller.db.bank = bank
+        wallet = self.caller.db.coins or {}
+        wallet[ctype] = int(wallet.get(ctype, 0)) + amount
+        self.caller.db.coins = wallet
+        self.msg(f"You withdraw {amount} {ctype} coin{'s' if amount != 1 else ''}.")
+
+
+class CmdBank(Command):
+    """Show your bank balance."""
+
+    key = "bank"
+    help_category = "Here"
+
+    def func(self):
+        funds = self.caller.db.bank or {}
+        self.msg(f"You have {format_wallet(funds)} stored in the bank.")
+
+
+class BankCmdSet(CmdSet):
+    """Command set for banker NPCs."""
+
+    key = "Bank CmdSet"
+
+    def at_cmdset_creation(self):
+        super().at_cmdset_creation()
+        self.add(CmdDeposit)
+        self.add(CmdWithdraw)
+        self.add(CmdBank)

--- a/typeclasses/npcs.py
+++ b/typeclasses/npcs.py
@@ -41,3 +41,16 @@ class Merchant(NPC):
         super().at_object_receive(obj, source_location, **kwargs)
         if source_location and source_location.has_account:
             self.add_stock(obj)
+
+from commands.banking import BankCmdSet
+
+
+class Banker(NPC):
+    """NPC that manages player bank accounts."""
+
+    banker = AttributeProperty(True)
+
+    def at_object_creation(self):
+        super().at_object_creation()
+        self.cmdset.add(BankCmdSet, persistent=True)
+

--- a/typeclasses/tests/test_bank.py
+++ b/typeclasses/tests/test_bank.py
@@ -1,0 +1,30 @@
+from unittest.mock import MagicMock
+from evennia.utils.test_resources import EvenniaTest
+from evennia.utils import create
+
+
+class TestBanker(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        from typeclasses.npcs import Banker
+        self.banker = create.create_object(Banker, key="banker", location=self.room1)
+        self.char1.msg = MagicMock()
+
+    def test_deposit_and_withdraw(self):
+        self.char1.db.coins = {"gold": 2, "silver": 5}
+        self.char1.execute_cmd("deposit 1 gold")
+        self.assertEqual(self.char1.db.bank.get("gold"), 1)
+        self.assertEqual(self.char1.db.coins.get("gold"), 1)
+        self.char1.execute_cmd("withdraw 1 gold")
+        self.assertEqual(self.char1.db.bank.get("gold", 0), 0)
+        self.assertEqual(self.char1.db.coins.get("gold"), 2)
+
+    def test_multiple_currencies(self):
+        self.char1.db.coins = {"copper": 10, "silver": 2}
+        self.char1.execute_cmd("deposit 5 copper")
+        self.char1.execute_cmd("deposit 1 silver")
+        self.assertEqual(self.char1.db.bank.get("copper"), 5)
+        self.assertEqual(self.char1.db.bank.get("silver"), 1)
+        self.char1.execute_cmd("withdraw 1 copper")
+        self.assertEqual(self.char1.db.bank.get("copper"), 4)
+        self.assertEqual(self.char1.db.coins.get("copper"), 6)

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -2035,6 +2035,37 @@ Related:
 """,
     },
     {
+        "key": 'bank',
+        "category": 'Here',
+        "text": """\
+Help for bank
+
+Manage your account with a banker NPC.
+
+Usage:
+    bank
+    deposit <amount> <coin>
+    withdraw <amount> <coin>
+
+Switches:
+    None
+
+Arguments:
+    amount - how many coins
+    coin   - copper, silver, gold or platinum
+
+Examples:
+    deposit 50 silver
+    withdraw 1 gold
+
+Notes:
+    - Deposit moves coins from your coin pouch into the bank.
+    - Withdraw moves coins from the bank into your coin pouch.
+
+Related:
+    help ansi
+""",
+    },
         "key": 'guild',
         "category": 'General',
         "text": """


### PR DESCRIPTION
## Summary
- implement banker NPC with deposit/withdraw/bank commands
- support player bank account tracking
- document banking commands in help entries
- test depositing and withdrawing coins

## Testing
- `pytest -q` *(fails: AttributeError during test collection)*

------
https://chatgpt.com/codex/tasks/task_e_684451602874832ca89e38901a98c99b