### PR TITLE
Update NPC trigger handling

### DIFF
--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -2066,6 +2066,7 @@ Related:
     help ansi
 """,
     },
+    {
         "key": 'guild',
         "category": 'General',
         "text": """
@@ -2446,8 +2447,9 @@ Related:
         "text": """
 Help for triggers
 
-NPCs may react automatically to events. Each trigger defines an event,
-an optional match text and one or more reactions to perform.
+NPCs may react automatically to events. Triggers are stored as a list of
+dictionaries ``{"event": <event>, "match": <text>, "action": <command>}``.
+Multiple entries for the same event are allowed.
 
 Events:
     on_speak   - someone speaks in the room
@@ -2466,8 +2468,7 @@ Reactions:
     <command>          - run any other command string
 
 The match text only applies to some events like |won_speak|n and |won_look|n.
-Multiple reactions can be listed separated by commas or by using multiple
-triggers.
+Use multiple triggers to provide several reactions.
 
 Examples:
     Trigger Menu


### PR DESCRIPTION
## Summary
- switch NPC `triggers` attribute to a list of dicts
- update trigger evaluation logic
- adapt NPC builder to new structure
- maintain compatibility for old trigger formats
- extend trigger tests
- document trigger data layout in help entry

## Testing
- `pytest typeclasses/tests/test_cnpc.py::TestCNPC::test_triggers_and_reactions -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684453814440832caa662990df6bca49