### PR TITLE
Improve merchant help and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,4 +156,11 @@ sale stock in an internal storage container and offers the commands `list`,
 `buy`, `sell` and `sell all` to nearby players. Selling items automatically adds
 them to the merchant's stock. Prices are based on the item's value with optional
 markups or discounts. Buying or selling adjusts both your coin pouch and the
-merchant's purse.
+merchant's purse. Stand in the same room as the merchant and use these commands
+to interact with them.
+
+## Banking
+
+Banker NPCs can hold your money securely. Use `bank` to check your balance,
+`deposit <amount> <currency>` to store coins and `withdraw <amount> <currency>`
+to take them back out.

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -1957,7 +1957,7 @@ Related:
         "text": """
 Help for list
 
-View items a shop has for sale. Usage: list
+View items a shop has for sale.
 
 Usage:
     list
@@ -1969,7 +1969,7 @@ Arguments:
     None
 
 Examples:
-    None
+    list
 
 Notes:
     - Shows everything a nearby merchant has in stock and their prices.
@@ -1984,19 +1984,19 @@ Related:
         "text": """
 Help for buy
 
-Purchase an item from a shop. Usage: buy <item>
+Purchase an item from a shop.
 
 Usage:
-    buy
+    buy <item>
 
 Switches:
     None
 
 Arguments:
-    None
+    item - name or number of the item to purchase
 
 Examples:
-    None
+    buy sword
 
 Notes:
     - Pays the asking price to the merchant and moves the item to you.
@@ -2012,19 +2012,20 @@ Related:
         "text": """
 Help for sell
 
-Offer an item for sale to a shop. Usage: sell <item>
+Offer an item for sale to a shop.
 
 Usage:
-    sell
+    sell <item>
 
 Switches:
     None
 
 Arguments:
-    None
+    item - name or number of the item to sell
 
 Examples:
-    None
+    sell sword
+    sell all
 
 Notes:
     - Trades your item to the merchant for its value in coins.


### PR DESCRIPTION
## Summary
- detail buy, sell and list syntax in help
- document bank usage with deposit/withdraw commands
- mention merchant interaction and banking in README

## Testing
- `pytest -q` *(fails: many tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_684455da47ec832c903f0f8a7b30c534