### PR TITLE
Add greeting trigger helper in CNPC builder

### DIFF
--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -319,9 +319,14 @@ def _set_ai(caller, raw_string, **kwargs):
 
 def menunode_triggers(caller, raw_string="", **kwargs):
     """Main trigger menu."""
-    text = "|wTrigger Menu|n"
+    text = (
+        "|wTrigger Menu|n\n"
+        "Use triggers to react automatically to events.\n"
+        "Common example: greeting players when they enter."
+    )
     options = [
         {"desc": "Add trigger", "goto": "menunode_trigger_add"},
+        {"desc": "Add greeting", "goto": _add_greeting},
         {"desc": "Delete trigger", "goto": "menunode_trigger_delete"},
         {"desc": "List triggers", "goto": "menunode_trigger_list"},
         {"desc": "Finish", "goto": "menunode_confirm"},
@@ -397,6 +402,13 @@ def _save_trigger(caller, raw_string, **kwargs):
     caller.ndb.trigger_event = None
     caller.ndb.trigger_match = None
     caller.msg("Trigger added.")
+    return "menunode_triggers"
+
+def _add_greeting(caller, raw_string="", **kwargs):
+    """Add a simple greeting trigger."""
+    triggers = caller.ndb.buildnpc.setdefault("triggers", [])
+    triggers.append({"event": "on_enter", "match": "", "action": 'say "Hello there!"'})
+    caller.msg("Greeting trigger added.")
     return "menunode_triggers"
 
 def menunode_trigger_delete(caller, raw_string="", **kwargs):

--- a/typeclasses/tests/test_cnpc.py
+++ b/typeclasses/tests/test_cnpc.py
@@ -97,17 +97,19 @@ class TestCNPC(EvenniaTest):
         npc_builder._set_skills(self.char1, "")
         npc_builder._set_ai(self.char1, "passive")
 
-        self.char1.ndb.buildnpc["triggers"] = [
+        npc_builder._add_greeting(self.char1)
+        self.char1.ndb.buildnpc["triggers"].extend([
             {"event": "on_speak", "match": "hello", "action": "say Squawk!"},
             {"event": "on_speak", "match": "hello", "action": "emote flaps"},
             {"event": "on_give_item", "match": "", "action": "say Thanks!"},
-        ]
+        ])
 
         npc_builder._create_npc(self.char1, "")
 
         npc = self._find("parrot")
         self.assertIsNotNone(npc)
         self.assertEqual(npc.db.triggers, self.char1.ndb.buildnpc["triggers"])
+        self.assertEqual(len(npc.db.triggers), 4)
 
         with patch.object(npc, "execute_cmd") as mock_exec:
             npc.at_say(self.char2, "hello there")

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -2427,11 +2427,13 @@ Notes:
     - At the triggers step you will see a menu to add, delete or list
       automatic reactions. Example:
           1) Add trigger
-          2) Delete trigger
-          3) List triggers
-          4) Finish
+          2) Add greeting
+          3) Delete trigger
+          4) List triggers
+          5) Finish
       Choosing Add prompts for the event type, match text and reaction
-      command.
+      command. |wAdd greeting|n quickly sets up an |won_enter|n trigger
+      with `say "Hello there!"`.
     - |wcnpc dev_spawn|n quickly spawns prototype NPCs for testing (Developer only).
     - Example: |wcnpc dev_spawn test_blacksmith|n
     - See |whelp triggers|n for available events and reactions.


### PR DESCRIPTION
## Summary
- improve Trigger menu instructions and add "Add greeting" option
- document greeting trigger in help entry
- test greeting addition with menu utility

## Testing
- `pytest typeclasses/tests/test_cnpc.py::TestCNPC::test_triggers_and_reactions -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68445735d4f4832caf0de4ff7960bbbf