### PR TITLE
Adjust match handling for NPC builder triggers

### DIFF
--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -40,6 +40,11 @@ ALLOWED_NPC_TYPES = (
     "craftsman",
 )
 
+# Trigger events that require specifying a match string before the reaction.
+# Any event not listed here is assumed to not use a match and will skip
+# directly to setting the reaction in the builder menu.
+MATCH_REQUIRED_EVENTS = ["on_speak", "on_give_item", "on_look"]
+
 
 # Menu nodes for NPC creation
 
@@ -377,7 +382,21 @@ def _set_custom_event(caller, raw_string, **kwargs):
 
 def _set_trigger_event(caller, raw_string, event=None, **kwargs):
     caller.ndb.trigger_event = event
-    return "menunode_trigger_match"
+
+    # determine if this event requires a match string before entering the
+    # reaction prompt. Unrecognized events are treated as custom events and
+    # therefore also require a match.
+    if event in MATCH_REQUIRED_EVENTS or event not in (
+        "on_enter",
+        "on_attack",
+        "on_timer",
+        *MATCH_REQUIRED_EVENTS,
+    ):
+        return "menunode_trigger_match"
+
+    # events that don't use match text skip directly to setting the reaction
+    caller.ndb.trigger_match = ""
+    return "menunode_trigger_react"
 
 def menunode_trigger_match(caller, raw_string="", **kwargs):
     text = "|wEnter match text (blank for none)|n"

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -2431,8 +2431,9 @@ Notes:
           3) Delete trigger
           4) List triggers
           5) Finish
-      Choosing Add prompts for the event type, match text and reaction
-      command. |wAdd greeting|n quickly sets up an |won_enter|n trigger
+      Choosing Add prompts for the event type and reaction command. Some
+      events also ask for optional match text. |wAdd greeting|n quickly
+      sets up an |won_enter|n trigger
       with `say "Hello there!"`.
     - |wcnpc dev_spawn|n quickly spawns prototype NPCs for testing (Developer only).
     - Example: |wcnpc dev_spawn test_blacksmith|n
@@ -2470,7 +2471,8 @@ Reactions:
     script <module.fn> - call a Python function
     <command>          - run any other command string
 
-The match text only applies to some events like |won_speak|n and |won_look|n.
+The match text only applies to the events |won_speak|n, |won_give_item|n and
+|won_look|n, as well as any custom events.
 Use multiple triggers to provide several reactions.
 
 Examples:


### PR DESCRIPTION
## Summary
- clarify which trigger events require match text
- only ask for match text on matching events and custom events
- update trigger builder help accordingly

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68445fc3a864832c946671979240f8b8