### PR TITLE
Clarify AI and behavior fields

### DIFF
--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -267,7 +267,11 @@ def _set_stats(caller, raw_string, **kwargs):
 
 def menunode_behavior(caller, raw_string="", **kwargs):
     default = caller.ndb.buildnpc.get("behavior", "")
-    text = "|wDescribe basic behavior or reactions|n"
+    text = (
+        "|wDescribe basic behavior or reactions|n "
+        "(e.g. passive, aggressive). This is only informational unless "
+        "your game code interprets it."
+    )
     if default:
         text += f" [default: {default}]"
     text += "\n(back to go back, skip for default)"
@@ -306,7 +310,10 @@ def _set_skills(caller, raw_string, **kwargs):
 
 def menunode_ai(caller, raw_string="", **kwargs):
     default = caller.ndb.buildnpc.get("ai_type", "")
-    text = "|wAI type (e.g. passive, aggressive)|n"
+    text = (
+        "|wAI type|n (e.g. passive, aggressive). This is informational only "
+        "unless your code makes use of it."
+    )
     if default:
         text += f" [default: {default}]"
     text += "\n(back to go back, skip for default)"

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -2418,6 +2418,8 @@ Notes:
       guild_receptionist, banker and craftsman.
     - The builder prompts for description, NPC type, creature type, level,
       HP MP SP, primary stats, behavior, skills and AI type.
+    - Behavior and AI type are descriptive only; they have no effect unless
+      your game code uses them.
     - Humanoid body type grants the standard equipment slots automatically.
       Quadrupeds receive head, body, front_legs and hind_legs and lack weapon
       slots. Unique lets you add or remove any slots in the next step.


### PR DESCRIPTION
## Summary
- clarify that 'behavior' and 'AI type' are informational
- mention this in cnpc help entry

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684463d167d0832c860dc7d3c5d2d7be