### PR TITLE
Start inactive global tick script

### DIFF
--- a/server/conf/at_server_startstop.py
+++ b/server/conf/at_server_startstop.py
@@ -34,6 +34,9 @@ def at_server_start():
     from evennia.scripts.models import ScriptDB
 
     script = ScriptDB.objects.filter(db_key="global_tick").first()
+    if script and not script.is_active:
+        script.start()
+
     if not script or script.typeclass_path != "typeclasses.scripts.GlobalTick":
         if script:
             script.delete()


### PR DESCRIPTION
## Summary
- ensure the global tick script starts when the server boots

## Testing
- `pytest -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6844666ebb88832c807a57c198c721b9