### PR TITLE
Add status ticking each heartbeat

### DIFF
--- a/typeclasses/scripts.py
+++ b/typeclasses/scripts.py
@@ -254,6 +254,7 @@ class GlobalTick(Script):
                 continue
 
             state_manager.apply_regen(obj)
+            state_manager.tick_character(obj)
 
             if hasattr(obj, "refresh_prompt"):
                 obj.refresh_prompt()


### PR DESCRIPTION
## Summary
- run the game (migrate, start then stop) to verify it runs
- tick status effects in the global ticker

## Testing
- `pytest -q` *(fails: OperationalError: no such table: accounts_accountdb)*
- `evennia start` then `evennia stop`

------
https://chatgpt.com/codex/tasks/task_e_684467827fd8832c92bb3dcde1e31c65