### PR TITLE
Update GlobalTick behavior and tests

### DIFF
--- a/typeclasses/scripts.py
+++ b/typeclasses/scripts.py
@@ -253,8 +253,12 @@ class GlobalTick(Script):
             if not hasattr(obj, "traits"):
                 continue
 
-            state_manager.apply_regen(obj)
             state_manager.tick_character(obj)
 
-            if hasattr(obj, "refresh_prompt"):
+            if hasattr(obj, "at_tick"):
+                obj.at_tick()
+            else:
+                state_manager.apply_regen(obj)
+
+            if hasattr(obj, "refresh_prompt") and not hasattr(obj, "at_tick"):
                 obj.refresh_prompt()

--- a/typeclasses/tests/test_characters.py
+++ b/typeclasses/tests/test_characters.py
@@ -167,9 +167,9 @@ class TestGlobalTick(EvenniaTest):
 
         script.at_repeat()
 
-        self.char1.at_tick.assert_not_called()
-        self.char1.refresh_prompt.assert_called()
-        state_manager.tick_character.assert_not_called()
+        self.char1.at_tick.assert_called_once()
+        self.char1.refresh_prompt.assert_not_called()
+        state_manager.tick_character.assert_called_once_with(self.char1)
 
     def test_tick_offline_characters(self):
         from typeclasses.scripts import GlobalTick
@@ -205,10 +205,10 @@ class TestGlobalTick(EvenniaTest):
 
         script.at_repeat()
 
-        pc.at_tick.assert_not_called()
-        npc.at_tick.assert_not_called()
+        pc.at_tick.assert_called_once()
+        npc.at_tick.assert_called_once()
 
-        state_manager.tick_character.assert_not_called()
+        state_manager.tick_character.assert_has_calls([call(pc), call(npc)], any_order=True)
 
         for char in (pc, npc):
             for key in ("health", "mana", "stamina"):


### PR DESCRIPTION
## Summary
- call `state_manager.tick_character` on each tickable
- invoke `at_tick` when available
- fall back to manual regeneration otherwise
- test expectations updated

## Testing
- `pytest -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68446aa6a8b0832c98e69570adbef6c8