### PR TITLE
Fix global ticker start logic

### DIFF
--- a/server/conf/settings.py
+++ b/server/conf/settings.py
@@ -110,3 +110,17 @@ try:
     from server.conf.secret_settings import *
 except ImportError:
     print("secret_settings.py file not found or failed to import.")
+
+######################################################################
+# Global scripts
+######################################################################
+
+# Ensure the global tick script always runs at server start
+GLOBAL_SCRIPTS = {
+    "global_tick": {
+        "key": "global_tick",
+        "typeclass": "typeclasses.scripts.GlobalTick",
+        "interval": 60,
+        "persistent": True,
+    }
+}


### PR DESCRIPTION
## Summary
- ensure the GlobalTick script is always configured and running when the server starts
- add a settings entry to auto-start the global ticker as a global script

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68446e3f56bc832c91706e0ab5d54f3b