### PR TITLE
Refactor global tick

### DIFF
--- a/server/conf/at_server_startstop.py
+++ b/server/conf/at_server_startstop.py
@@ -41,7 +41,7 @@ def at_server_start():
             extra.stop()
             extra.delete()
 
-    if script and script.typeclass_path != "typeclasses.scripts.GlobalTick":
+    if script and script.typeclass_path != "typeclasses.global_tick.GlobalTick":
         script.stop()
         script.delete()
         script = None
@@ -62,7 +62,7 @@ def at_server_start():
             script.start()
 
     if not script:
-        script = create.create_script("typeclasses.scripts.GlobalTick", key="global_tick")
+        script = create.create_script("typeclasses.global_tick.GlobalTick", key="global_tick")
         script.start()
 
     # Ensure all characters are marked tickable for the global ticker

--- a/server/conf/settings.py
+++ b/server/conf/settings.py
@@ -119,7 +119,7 @@ except ImportError:
 GLOBAL_SCRIPTS = {
     "global_tick": {
         "key": "global_tick",
-        "typeclass": "typeclasses.scripts.GlobalTick",
+        "typeclass": "typeclasses.global_tick.GlobalTick",
         "interval": 60,
         "persistent": True,
     }

--- a/typeclasses/global_tick.py
+++ b/typeclasses/global_tick.py
@@ -1,0 +1,16 @@
+from evennia.scripts.scripts import DefaultScript
+
+class GlobalTick(DefaultScript):
+    """Standalone global ticker that refreshes prompts every minute."""
+
+    def at_script_creation(self):
+        self.interval = 60
+        self.persistent = True
+
+    def at_repeat(self):
+        from evennia.utils.search import search_tag
+
+        tickables = search_tag(key="tickable")
+        for obj in tickables:
+            if hasattr(obj, "refresh_prompt"):
+                obj.refresh_prompt()

--- a/typeclasses/scripts.py
+++ b/typeclasses/scripts.py
@@ -234,28 +234,3 @@ class RestockScript(Script):
                     self.obj.add_stock(obj)
 
 
-class GlobalTick(Script):
-    """A global ticker that regenerates health/mana/stamina and refreshes prompts."""
-
-    def at_script_creation(self):
-        self.interval = 60
-        self.persistent = True
-
-    def at_repeat(self):
-        from evennia.utils.search import search_tag
-        from world.system import state_manager
-
-        state_manager.tick_all()
-
-        tickables = search_tag(key="tickable")
-        for obj in tickables:
-            if not hasattr(obj, "traits"):
-                continue
-
-            if hasattr(obj, "at_tick"):
-                obj.at_tick()
-            else:
-                state_manager.apply_regen(obj)
-
-            if hasattr(obj, "refresh_prompt") and not hasattr(obj, "at_tick"):
-                obj.refresh_prompt()


### PR DESCRIPTION
## Summary
- split the global tick into its own module
- update settings and startup to use the new path
- keep only prompt refresh behaviour in the tick
- adjust tests for the new script

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6844cf9c4e58832c806b002eb44980d0