### PR TITLE
Fix global tick regeneration

### DIFF
--- a/typeclasses/global_tick.py
+++ b/typeclasses/global_tick.py
@@ -12,5 +12,9 @@ class GlobalTick(DefaultScript):
 
         tickables = search_tag(key="tickable")
         for obj in tickables:
-            if hasattr(obj, "refresh_prompt"):
+            if not obj.sessions.count():
+                continue
+            if hasattr(obj, "at_tick"):
+                obj.at_tick()
+            elif hasattr(obj, "refresh_prompt"):
                 obj.refresh_prompt()

--- a/typeclasses/tests/test_characters.py
+++ b/typeclasses/tests/test_characters.py
@@ -152,18 +152,19 @@ class TestGlobalTick(EvenniaTest):
         self.assertEqual(script.interval, 60)
         self.assertTrue(script.persistent)
 
-    def test_refresh_prompt(self):
+    def test_triggers_at_tick_online(self):
         from typeclasses.global_tick import GlobalTick
 
         script = GlobalTick()
         script.at_script_creation()
 
         self.char1.tags.add("tickable")
-        self.char1.refresh_prompt = MagicMock()
+        self.char1.at_tick = MagicMock()
+        self.char1.sessions.count = MagicMock(return_value=1)
 
         script.at_repeat()
 
-        self.char1.refresh_prompt.assert_called_once()
+        self.char1.at_tick.assert_called_once()
 
     def test_tick_offline_characters(self):
         from typeclasses.global_tick import GlobalTick
@@ -192,6 +193,8 @@ class TestGlobalTick(EvenniaTest):
 
         pc.at_tick = MagicMock()
         npc.at_tick = MagicMock()
+        pc.sessions.count = MagicMock(return_value=0)
+        npc.sessions.count = MagicMock(return_value=0)
 
         script.at_repeat()
 


### PR DESCRIPTION
## Summary
- trigger `at_tick` on online characters from the global ticker
- update tests for the new regeneration behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6844d9da171c832cb33d96d405cedf73