### PR TITLE
Enable ticking offline NPCs

### DIFF
--- a/typeclasses/global_tick.py
+++ b/typeclasses/global_tick.py
@@ -9,12 +9,11 @@ class GlobalTick(DefaultScript):
 
     def at_repeat(self):
         from evennia.utils.search import search_tag
+        from world.system import state_manager
 
         tickables = search_tag(key="tickable")
         for obj in tickables:
-            if not obj.sessions.count():
-                continue
             if hasattr(obj, "at_tick"):
                 obj.at_tick()
-            elif hasattr(obj, "refresh_prompt"):
-                obj.refresh_prompt()
+            else:
+                state_manager.tick_character(obj)


### PR DESCRIPTION
## Summary
- tick all objects tagged `tickable` in `GlobalTick`
- adjust offline tick tests to check for regen and no prompts

## Testing
- `pytest -q` *(fails: OperationalError - no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6844e5801ef8832cb456f8e76470e52b