### PR TITLE
Rename GlobalTick script

### DIFF
--- a/server/conf/at_server_startstop.py
+++ b/server/conf/at_server_startstop.py
@@ -41,7 +41,7 @@ def at_server_start():
             extra.stop()
             extra.delete()
 
-    if script and script.typeclass_path != "typeclasses.global_tick.GlobalTick":
+    if script and script.typeclass_path != "typeclasses.global_tick.GlobalTickScript":
         script.stop()
         script.delete()
         script = None
@@ -62,7 +62,7 @@ def at_server_start():
             script.start()
 
     if not script:
-        script = create.create_script("typeclasses.global_tick.GlobalTick", key="global_tick")
+        script = create.create_script("typeclasses.global_tick.GlobalTickScript", key="global_tick")
         script.start()
 
     # Ensure all characters are marked tickable for the global ticker

--- a/server/conf/settings.py
+++ b/server/conf/settings.py
@@ -119,7 +119,7 @@ except ImportError:
 GLOBAL_SCRIPTS = {
     "global_tick": {
         "key": "global_tick",
-        "typeclass": "typeclasses.global_tick.GlobalTick",
+        "typeclass": "typeclasses.global_tick.GlobalTickScript",
         "interval": 60,
         "persistent": True,
     },

--- a/typeclasses/global_tick.py
+++ b/typeclasses/global_tick.py
@@ -8,13 +8,14 @@ from evennia.scripts.scripts import DefaultScript
 # ----------------------------------------------------------------------------
 #
 # Other modules can subscribe to this signal to run code once per minute.
+# Other systems should subscribe to this tick via their own repeating scripts.
 # Import ``TICK`` from this module and ``connect`` a handler. Handlers will
 # receive ``sender`` as this script instance and any keyword arguments passed
 # to :func:`Signal.send`.
 
 TICK = Signal()
 
-class GlobalTick(DefaultScript):
+class GlobalTickScript(DefaultScript):
     """Script emitting the :data:`TICK` signal every minute."""
 
     def at_script_creation(self):

--- a/typeclasses/tests/test_characters.py
+++ b/typeclasses/tests/test_characters.py
@@ -145,17 +145,17 @@ class TestCharacterProperties(EvenniaTest):
 
 class TestGlobalTick(EvenniaTest):
     def test_interval(self):
-        from typeclasses.global_tick import GlobalTick
+        from typeclasses.global_tick import GlobalTickScript
 
-        script = GlobalTick()
+        script = GlobalTickScript()
         script.at_script_creation()
         self.assertEqual(script.interval, 60)
         self.assertTrue(script.persistent)
 
     def test_emits_tick_signal(self):
-        from typeclasses.global_tick import GlobalTick, TICK
+        from typeclasses.global_tick import GlobalTickScript, TICK
 
-        script = GlobalTick()
+        script = GlobalTickScript()
         script.at_script_creation()
 
         called = []


### PR DESCRIPTION
## Summary
- rename `GlobalTick` script class
- update settings, start hooks and tests
- note that other systems must subscribe via their own repeating scripts

## Testing
- `evennia migrate`
- `pytest typeclasses/tests/test_characters.py::TestGlobalTick::test_interval -q` *(fails: OperationalError no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6844f36a7c00832c8c72ff3fe8420348