### PR TITLE
Adjust global script settings

### DIFF
--- a/server/conf/settings.py
+++ b/server/conf/settings.py
@@ -125,7 +125,8 @@ GLOBAL_SCRIPTS = {
     },
     "global_healing": {
         "key": "global_healing",
-        "typeclass": "typeclasses.global_healing.GlobalHealing",
+        "typeclass": "typeclasses.global_healing.GlobalHealingScript",
+        "interval": 60,
         "persistent": True,
     },
 }


### PR DESCRIPTION
## Summary
- configure GLOBAL_SCRIPTS for new `GlobalHealingScript` class
- ensure both tick and healing scripts run every 60 seconds

## Testing
- `pytest -q` *(fails: django.db.utils.OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6844f8828d20832cbbb15508df0830db