### PR TITLE
Adjust tick script startup

### DIFF
--- a/server/conf/at_server_startstop.py
+++ b/server/conf/at_server_startstop.py
@@ -17,6 +17,9 @@ at_server_cold_stop()
 
 """
 
+# Path to the global tick script typeclass
+GLOBAL_TICK_SCRIPT_PATH = "typeclasses.global_tick.GlobalTickScript"
+
 
 def at_server_init():
     """
@@ -41,7 +44,7 @@ def at_server_start():
             extra.stop()
             extra.delete()
 
-    if script and script.typeclass_path != "typeclasses.global_tick.GlobalTickScript":
+    if script and script.typeclass_path != GLOBAL_TICK_SCRIPT_PATH:
         script.stop()
         script.delete()
         script = None
@@ -62,15 +65,9 @@ def at_server_start():
             script.start()
 
     if not script:
-        script = create.create_script("typeclasses.global_tick.GlobalTickScript", key="global_tick")
+        script = create.create_script(GLOBAL_TICK_SCRIPT_PATH, key="global_tick")
         script.start()
 
-    # Ensure all characters are marked tickable for the global ticker
-    from typeclasses.characters import Character
-
-    for char in Character.objects.all():
-        if not char.tags.has("tickable"):
-            char.tags.add("tickable")
 
 
 def at_server_stop():

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -174,8 +174,6 @@ class Character(ObjectParent, ClothedCharacter):
         stats.apply_stats(self)
         stat_manager.refresh_stats(self)
 
-        # Mark character as tickable so the global tick script processes it
-        self.tags.add("tickable")
 
         self.db.guild = ""
         self.db.guild_points = {}


### PR DESCRIPTION
## Summary
- configure global tick path
- stop tagging every character for ticks

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6844f98e3360832c8ad3d035289724ef