### PR TITLE
Update regeneration test for new healing logic

### DIFF
--- a/typeclasses/tests/test_characters.py
+++ b/typeclasses/tests/test_characters.py
@@ -217,7 +217,6 @@ class TestGlobalHealing(EvenniaTest):
 class TestRegeneration(EvenniaTest):
     def test_at_tick_heals_resources(self):
         char = self.char1
-        char.tags.add("tickable")
         for key in ("health", "mana", "stamina"):
             trait = char.traits.get(key)
             trait.current = trait.max // 2


### PR DESCRIPTION
## Summary
- remove obsolete `tickable` tag usage

## Testing
- `pytest -q typeclasses/tests/test_characters.py::TestRegeneration::test_at_tick_heals_resources` *(fails: settings.DEFAULT_HOME does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6844fde99cc4832cb3b6d057c34c90e8