### PR TITLE
Fix startup of global healing script

### DIFF
--- a/server/conf/at_server_startstop.py
+++ b/server/conf/at_server_startstop.py
@@ -19,6 +19,8 @@ at_server_cold_stop()
 
 # Path to the global tick script typeclass
 GLOBAL_TICK_SCRIPT_PATH = "typeclasses.global_tick.GlobalTickScript"
+# Path to the global healing script typeclass
+GLOBAL_HEALING_SCRIPT_PATH = "typeclasses.global_healing.GlobalHealingScript"
 
 
 def at_server_init():
@@ -66,6 +68,40 @@ def at_server_start():
 
     if not script:
         script = create.create_script(GLOBAL_TICK_SCRIPT_PATH, key="global_tick")
+        script.start()
+
+    # ------------------------------------------------------------------
+    # Global healing script
+    # ------------------------------------------------------------------
+    scripts = list(ScriptDB.objects.filter(db_key="global_healing"))
+    script = None
+    if scripts:
+        script = scripts[0]
+        for extra in scripts[1:]:
+            extra.stop()
+            extra.delete()
+
+    if script and script.typeclass_path != GLOBAL_HEALING_SCRIPT_PATH:
+        script.stop()
+        script.delete()
+        script = None
+
+    if script:
+        changed = False
+        if script.interval != 60:
+            script.interval = 60
+            changed = True
+        if not script.persistent:
+            script.persistent = True
+            changed = True
+        if changed:
+            script.save()
+            script.restart()
+        elif not script.is_active:
+            script.start()
+
+    if not script:
+        script = create.create_script(GLOBAL_HEALING_SCRIPT_PATH, key="global_healing")
         script.start()
 
 


### PR DESCRIPTION
## Summary
- ensure the global healing script is managed at server start

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68450186c3c4832c8857ab1dd5eb2a87