### PR TITLE
Fix global healing interval

### DIFF
--- a/server/conf/at_server_startstop.py
+++ b/server/conf/at_server_startstop.py
@@ -88,8 +88,8 @@ def at_server_start():
 
     if script:
         changed = False
-        if script.interval:
-            script.interval = None
+        if script.interval != 0:
+            script.interval = 0
             changed = True
         if not script.persistent:
             script.persistent = True

--- a/typeclasses/global_healing.py
+++ b/typeclasses/global_healing.py
@@ -1,4 +1,8 @@
-"""Regenerate character resources on a global interval."""
+"""Regenerate character resources using the global tick.
+
+This script no longer schedules its own interval but instead reacts to
+``GlobalTickScript`` firing the global tick signal.
+"""
 
 from evennia.scripts.scripts import DefaultScript
 from typeclasses.global_tick import TICK
@@ -10,7 +14,7 @@ class GlobalHealingScript(DefaultScript):
 
     def at_script_creation(self):
         """Configure script to persist without its own interval."""
-        self.interval = None
+        self.interval = 0
         self.persistent = True
 
     def at_start(self):

--- a/typeclasses/tests/test_characters.py
+++ b/typeclasses/tests/test_characters.py
@@ -173,6 +173,13 @@ class TestGlobalTick(EvenniaTest):
 
 
 class TestGlobalHealing(EvenniaTest):
+    def test_interval(self):
+        from typeclasses.global_healing import GlobalHealingScript
+
+        script = GlobalHealingScript()
+        script.at_script_creation()
+        self.assertEqual(script.interval, 0)
+
     def test_tick_offline_characters(self):
         from typeclasses.global_healing import GlobalHealingScript
         from typeclasses.global_tick import TICK


### PR DESCRIPTION
## Summary
- ensure the global healing script no longer repeats on its own
- set the healing script interval to 0 and adjust server startup logic
- test the script interval

## Testing
- `pytest -q` *(fails: OperationalError no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684508872da0832c9e293da821e44342