### PR TITLE
Remove redundant startup logic and ensure shop restocks

### DIFF
--- a/server/conf/at_server_startstop.py
+++ b/server/conf/at_server_startstop.py
@@ -17,10 +17,6 @@ at_server_cold_stop()
 
 """
 
-# Path to the global tick script typeclass
-GLOBAL_TICK_SCRIPT_PATH = "typeclasses.global_tick.GlobalTickScript"
-# Path to the global healing script typeclass
-GLOBAL_HEALING_SCRIPT_PATH = "typeclasses.global_healing.GlobalHealingScript"
 
 
 def at_server_init():
@@ -31,78 +27,8 @@ def at_server_init():
 
 
 def at_server_start():
-    """
-    This is called every time the server starts up, regardless of
-    how it was shut down.
-    """
-    from evennia.utils import create
-    from evennia.scripts.models import ScriptDB
-
-    scripts = list(ScriptDB.objects.filter(db_key="global_tick"))
-    script = None
-    if scripts:
-        script = scripts[0]
-        for extra in scripts[1:]:
-            extra.stop()
-            extra.delete()
-
-    if script and script.typeclass_path != GLOBAL_TICK_SCRIPT_PATH:
-        script.stop()
-        script.delete()
-        script = None
-
-    if script:
-        # Make sure the script is configured correctly
-        changed = False
-        if script.interval != 60:
-            script.interval = 60
-            changed = True
-        if not script.persistent:
-            script.persistent = True
-            changed = True
-        if changed:
-            script.save()
-            script.restart()
-        elif not script.is_active:
-            script.start()
-
-    if not script:
-        script = create.create_script(GLOBAL_TICK_SCRIPT_PATH, key="global_tick")
-        script.start()
-
-    # ------------------------------------------------------------------
-    # Global healing script
-    # ------------------------------------------------------------------
-    scripts = list(ScriptDB.objects.filter(db_key="global_healing"))
-    script = None
-    if scripts:
-        script = scripts[0]
-        for extra in scripts[1:]:
-            extra.stop()
-            extra.delete()
-
-    if script and script.typeclass_path != GLOBAL_HEALING_SCRIPT_PATH:
-        script.stop()
-        script.delete()
-        script = None
-
-    if script:
-        changed = False
-        if script.interval != 0:
-            script.interval = 0
-            changed = True
-        if not script.persistent:
-            script.persistent = True
-            changed = True
-        if changed:
-            script.save()
-            script.restart()
-        elif not script.is_active:
-            script.start()
-
-    if not script:
-        script = create.create_script(GLOBAL_HEALING_SCRIPT_PATH, key="global_healing")
-        script.start()
+    """Hook called every time the server starts."""
+    pass
 
 
 

--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -209,7 +209,8 @@ class XYGridShop(XYGridRoom):
             home=self,
             location=self,
         )
-        self.scripts.add(RestockScript, key="restock", autostart=False)
+        # start the restock script immediately so the shop refills over time
+        self.scripts.add(RestockScript, key="restock", autostart=True)
 
     def add_stock(self, obj):
         """


### PR DESCRIPTION
## Summary
- rely on Evennia's `GLOBAL_SCRIPTS` setting instead of manually creating global scripts
- autostart the shop's `RestockScript` when the room is created

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68450e8fa52c832c9def44826007d134