### PR TITLE
Fix tick resource updates

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -586,23 +586,23 @@ class Character(ObjectParent, ClothedCharacter):
         pass
 
     def at_tick(self):
-        """Called by the global ticker.
+        """Handle one tick of regeneration.
 
-        Regenerates resources based on current status and refreshes the prompt
-        to visually reflect the changes.
+        The global ticker calls this once every minute. Any passive healing or
+        status effects are advanced here.
+
+        Returns:
+            bool: ``True`` if any resources were changed.
         """
         from world.system import state_manager
 
         # advance effect and status timers
         state_manager.tick_character(self)
 
-        # apply passive regeneration
+        # apply passive regeneration and report if anything changed
         healed = state_manager.apply_regen(self)
 
-        if self.sessions.count():
-            self.refresh_prompt()
-
-        return healed
+        return bool(healed)
 
     def refresh_prompt(self):
         """Refresh the player's prompt display."""
@@ -1004,5 +1004,7 @@ class NPC(Character):
         wielder.cooldowns.add("attack", speed)
 
     def at_tick(self):
-        super().at_tick()
+        """Propagate tick handling and evaluate triggers."""
+        changed = super().at_tick()
         self.check_triggers("on_timer")
+        return changed

--- a/typeclasses/global_tick.py
+++ b/typeclasses/global_tick.py
@@ -32,11 +32,9 @@ class GlobalTickScript(DefaultScript):
                 continue
             seen.add(obj)
             if hasattr(obj, "at_tick"):
-                healed = obj.at_tick() or {}
-                if healed and obj.sessions.count():
-                    obj.msg(
-                        "You have recovered some.",
-                        prompt=obj.get_resource_prompt(),
-                    )
+                changed = obj.at_tick()
+                if changed and obj.sessions.count():
+                    obj.msg("You have recovered some.")
+                    obj.refresh_prompt()
 
         TICK.send(sender=self)

--- a/typeclasses/tests/test_characters.py
+++ b/typeclasses/tests/test_characters.py
@@ -239,13 +239,13 @@ class TestGlobalHealing(EvenniaTest):
         }
         char.sessions.count = MagicMock(return_value=1)
         char.msg = MagicMock()
+        char.refresh_prompt = MagicMock()
 
         script.at_repeat()
         script.at_stop()
 
-        char.msg.assert_called_once_with(
-            "You have recovered some.", prompt=char.get_resource_prompt()
-        )
+        char.msg.assert_called_once_with("You have recovered some.")
+        char.refresh_prompt.assert_called_once()
 
 
 
@@ -263,7 +263,8 @@ class TestRegeneration(EvenniaTest):
         char.refresh_prompt = MagicMock()
         char.msg = MagicMock()
 
-        char.at_tick()
+        changed = char.at_tick()
+        self.assertTrue(changed)
 
         for key, regen in (
             ("health", 2),
@@ -273,7 +274,7 @@ class TestRegeneration(EvenniaTest):
             trait = char.traits.get(key)
             self.assertEqual(trait.current, trait.max // 2 + regen)
 
-        char.refresh_prompt.assert_called_once()
+        char.refresh_prompt.assert_not_called()
         char.msg.assert_not_called()
 
 


### PR DESCRIPTION
## Summary
- return boolean from `Character.at_tick`
- trigger prompt refresh in `GlobalTickScript`
- update corresponding tests

## Testing
- `pytest` *(fails: OperationalError no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684513e11ac8832c8576f29fdba2ff0e