### PR TITLE
Add tick registry for characters

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -181,6 +181,8 @@ class Character(ObjectParent, ClothedCharacter):
         self.db.stat_overrides = {}
         self.db.equip_bonuses = {}
         self.db.sated = 5
+        from typeclasses.global_tick import register_character
+        register_character(self)
 
     def at_post_puppet(self, **kwargs):
         """Ensure stats refresh when a character is controlled."""
@@ -224,6 +226,11 @@ class Character(ObjectParent, ClothedCharacter):
 
         self.update_carry_weight()
         stat_manager.refresh_stats(self)
+
+    def at_object_delete(self):
+        from typeclasses.global_tick import unregister_character
+        unregister_character(self)
+        return super().at_object_delete()
         
     def at_pre_move(self, destination, **kwargs):
         """

--- a/typeclasses/global_tick.py
+++ b/typeclasses/global_tick.py
@@ -4,6 +4,24 @@ from django.dispatch import Signal
 from evennia.scripts.scripts import DefaultScript
 from typeclasses.characters import Character
 
+# registry of character IDs that should receive ticks
+REGISTERED = set()
+_SCRIPT = None
+
+
+def register_character(char):
+    """Add a character to the tick registry."""
+    REGISTERED.add(char.id)
+    if _SCRIPT:
+        _SCRIPT.db.registry = list(REGISTERED)
+
+
+def unregister_character(char):
+    """Remove a character from the tick registry."""
+    REGISTERED.discard(char.id)
+    if _SCRIPT:
+        _SCRIPT.db.registry = list(REGISTERED)
+
 # ----------------------------------------------------------------------------
 # Tick signal
 # ----------------------------------------------------------------------------
@@ -22,15 +40,36 @@ class GlobalTickScript(DefaultScript):
     def at_script_creation(self):
         self.interval = 60
         self.persistent = True
+        if self.db.registry is None:
+            self.db.registry = []
+
+    def at_start(self):
+        global _SCRIPT, REGISTERED
+        _SCRIPT = self
+        REGISTERED.update(self.db.registry or [])
 
     def at_repeat(self):
         """Handle one global tick."""
-        targets = Character.objects.all()
-        for obj in targets:
+        global REGISTERED
+        dead_ids = []
+        for cid in list(REGISTERED):
+            try:
+                obj = Character.objects.get(id=cid)
+            except Character.DoesNotExist:
+                dead_ids.append(cid)
+                continue
             if hasattr(obj, "at_tick"):
                 changed = obj.at_tick()
                 if changed and obj.sessions.count():
                     obj.msg("You have recovered some.")
                     obj.refresh_prompt()
+        for cid in dead_ids:
+            REGISTERED.discard(cid)
+        self.db.registry = list(REGISTERED)
 
         TICK.send(sender=self)
+
+    def at_stop(self):
+        global _SCRIPT
+        self.db.registry = list(REGISTERED)
+        _SCRIPT = None

--- a/typeclasses/tests/test_characters.py
+++ b/typeclasses/tests/test_characters.py
@@ -248,6 +248,32 @@ class TestGlobalHealing(EvenniaTest):
         char.refresh_prompt.assert_called_once()
 
 
+class TestTickRegistry(EvenniaTest):
+    def test_register_unregister(self):
+        from typeclasses.global_tick import GlobalTickScript, REGISTERED
+
+        script = GlobalTickScript()
+        script.at_script_creation()
+        script.at_start()
+
+        char = create.create_object(
+            "typeclasses.characters.PlayerCharacter",
+            key="Ticker",
+            location=self.room1,
+            home=self.room1,
+        )
+
+        self.assertIn(char.id, REGISTERED)
+        self.assertIn(char.id, script.db.registry)
+
+        char.delete()
+
+        self.assertNotIn(char.id, REGISTERED)
+        self.assertNotIn(char.id, script.db.registry)
+
+        script.at_stop()
+
+
 
 class TestRegeneration(EvenniaTest):
     def test_at_tick_heals_resources(self):


### PR DESCRIPTION
## Summary
- maintain a list of character IDs that require ticking
- register/unregister characters on creation/deletion
- global tick script now iterates over registry
- test registry behavior

## Testing
- `pytest typeclasses/tests/test_characters.py::TestTickRegistry::test_register_unregister -q` *(fails: django.db.utils.OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684517003e1c832c9398e65c1b823553