### PR TITLE
Refactor tick script

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -181,8 +181,7 @@ class Character(ObjectParent, ClothedCharacter):
         self.db.stat_overrides = {}
         self.db.equip_bonuses = {}
         self.db.sated = 5
-        from typeclasses.global_tick import register_character
-        register_character(self)
+        self.tags.add("tickable")
 
     def at_post_puppet(self, **kwargs):
         """Ensure stats refresh when a character is controlled."""
@@ -228,8 +227,6 @@ class Character(ObjectParent, ClothedCharacter):
         stat_manager.refresh_stats(self)
 
     def at_object_delete(self):
-        from typeclasses.global_tick import unregister_character
-        unregister_character(self)
         return super().at_object_delete()
         
     def at_pre_move(self, destination, **kwargs):

--- a/typeclasses/global_tick.py
+++ b/typeclasses/global_tick.py
@@ -2,29 +2,7 @@
 
 from django.dispatch import Signal
 from evennia.scripts.scripts import DefaultScript
-from typeclasses.characters import Character
-
-# registry of character IDs that should receive ticks
-REGISTERED = set()
-# mapping of registered IDs to character objects for fast access
-REGISTERED_OBJS = {}
-_SCRIPT = None
-
-
-def register_character(char):
-    """Add a character to the tick registry."""
-    REGISTERED.add(char.id)
-    REGISTERED_OBJS[char.id] = char
-    if _SCRIPT:
-        _SCRIPT.db.registry = list(REGISTERED)
-
-
-def unregister_character(char):
-    """Remove a character from the tick registry."""
-    REGISTERED.discard(char.id)
-    REGISTERED_OBJS.pop(char.id, None)
-    if _SCRIPT:
-        _SCRIPT.db.registry = list(REGISTERED)
+from evennia.utils.search import search_tag
 
 # ----------------------------------------------------------------------------
 # Tick signal
@@ -44,49 +22,26 @@ class GlobalTickScript(DefaultScript):
     def at_script_creation(self):
         self.interval = 60
         self.persistent = True
-        if self.db.registry is None:
-            self.db.registry = []
 
     def at_start(self):
-        global _SCRIPT, REGISTERED, REGISTERED_OBJS
-        _SCRIPT = self
-        REGISTERED.update(self.db.registry or [])
-        # cache object references for all stored ids
-        for cid in list(REGISTERED):
-            try:
-                REGISTERED_OBJS[cid] = Character.objects.get(id=cid)
-            except Character.DoesNotExist:
-                pass
+        pass
 
     def at_repeat(self):
         """Handle one global tick."""
-        global REGISTERED, REGISTERED_OBJS
-        dead_ids = []
-        for cid in list(REGISTERED):
-            obj = REGISTERED_OBJS.get(cid)
-            if obj is None:
-                try:
-                    obj = Character.objects.get(id=cid)
-                    REGISTERED_OBJS[cid] = obj
-                except Character.DoesNotExist:
-                    dead_ids.append(cid)
-                    continue
-            if obj.pk is None:
-                dead_ids.append(cid)
-                REGISTERED_OBJS.pop(cid, None)
-                continue
+        from world.system import state_manager
+
+        for obj in search_tag("tickable"):
             if hasattr(obj, "at_tick"):
                 changed = obj.at_tick()
-                if changed and obj.sessions.count():
+            else:
+                changed = bool(state_manager.apply_regen(obj))
+            if changed and hasattr(obj, "sessions") and obj.sessions.count():
+                if hasattr(obj, "msg"):
                     obj.msg("You have recovered some.")
+                if hasattr(obj, "refresh_prompt"):
                     obj.refresh_prompt()
-        for cid in dead_ids:
-            REGISTERED.discard(cid)
-        self.db.registry = list(REGISTERED)
 
         TICK.send(sender=self)
 
     def at_stop(self):
-        global _SCRIPT
-        self.db.registry = list(REGISTERED)
-        _SCRIPT = None
+        pass

--- a/typeclasses/tests/test_characters.py
+++ b/typeclasses/tests/test_characters.py
@@ -248,9 +248,10 @@ class TestGlobalHealing(EvenniaTest):
         char.refresh_prompt.assert_called_once()
 
 
-class TestTickRegistry(EvenniaTest):
-    def test_register_unregister(self):
-        from typeclasses.global_tick import GlobalTickScript, REGISTERED
+class TestTickableTag(EvenniaTest):
+    def test_character_searchable_by_tick_tag(self):
+        from typeclasses.global_tick import GlobalTickScript
+        from evennia.utils.search import search_tag
 
         script = GlobalTickScript()
         script.at_script_creation()
@@ -263,13 +264,12 @@ class TestTickRegistry(EvenniaTest):
             home=self.room1,
         )
 
-        self.assertIn(char.id, REGISTERED)
-        self.assertIn(char.id, script.db.registry)
+        self.assertTrue(char.tags.has("tickable"))
+        self.assertIn(char, search_tag("tickable"))
 
         char.delete()
 
-        self.assertNotIn(char.id, REGISTERED)
-        self.assertNotIn(char.id, script.db.registry)
+        self.assertNotIn(char, search_tag("tickable"))
 
         script.at_stop()
 


### PR DESCRIPTION
## Summary
- rework global tick handler to act on `tickable` tagged objects
- mark Characters with `tickable` tag and drop registration helpers
- adjust tests for new tickable workflow

## Testing
- `pytest -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68452495335c832c99a0719647a36f3f