### PR TITLE
Support rest area regeneration bonus

### DIFF
--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -2316,6 +2316,8 @@ Your current status modifies regeneration:
     - Standing: normal rates
     - Resting: 2x rates
     - Sleeping: 3x rates
+Rooms flagged with |wrest_area|n grant an additional +1 multiplier on top of
+your current status.
 
 Usage:
     regeneration

--- a/world/system/state_manager.py
+++ b/world/system/state_manager.py
@@ -188,6 +188,10 @@ def apply_regen(chara):
     else:
         multiplier = 1
 
+    location = getattr(chara, "location", None)
+    if location and location.tags.has("rest_area", category="room_flag"):
+        multiplier += 1
+
     for key in ("health", "mana", "stamina"):
         trait = chara.traits.get(key)
         if not trait:


### PR DESCRIPTION
## Summary
- enhance regeneration to check for a `rest_area` room flag and boost healing
- document rest area in the regeneration help entry
- allow state manager tests to run without DEFAULT_HOME and add a rest area test

## Testing
- `pytest typeclasses/tests/test_state_manager.py::TestStateManager::test_apply_regen_scales_with_status -q`
- `pytest typeclasses/tests/test_state_manager.py::TestStateManager::test_apply_regen_rest_area_bonus -q`

------
https://chatgpt.com/codex/tasks/task_e_68452de6c590832caef179a16514d541