### PR TITLE
Add 'createnpc' alias for cnpc command

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,10 +106,11 @@ If you wind up having any issues or questions working with Evennia, [the Discord
 
 ### NPC Creation Menu
 
-You can quickly set up non-player characters using `@cnpc start <key>`. This
-opens an interactive menu where you enter the description, type, level and other
-details. Follow the prompts, review the summary at the end and confirm to create
-your NPC. You can later update them with `@cnpc edit <npc>`.
+You can quickly set up non-player characters using `@cnpc start <key>` (alias
+`@createnpc`). This opens an interactive menu where you enter the description,
+type, level and other details. Follow the prompts, review the summary at the end
+and confirm to create your NPC. You can later update them with `@cnpc edit
+<npc>`.
 
 See the `cnpc` help entry for a full breakdown of every menu option.
 

--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -484,6 +484,7 @@ class CmdCNPC(Command):
     """Create or edit an NPC using a guided menu."""
 
     key = "cnpc"
+    aliases = ["createnpc"]
     locks = "cmd:perm(Builder) or perm(Admin) or perm(Developer)"
     help_category = "Building"
 

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -2450,7 +2450,7 @@ Guild Honor Rank Modifiers.
     },
     {
         "key": 'cnpc',
-        "aliases": ['npc'],
+        "aliases": ['npc', 'createnpc'],
         "category": 'Building',
         "text": """
 Help for cnpc
@@ -2474,6 +2474,9 @@ Examples:
     cnpc dev_spawn test_blacksmith
 
 Notes:
+    - Aliases:
+    - npc
+    - createnpc
     - NPC types include merchant, guard, questgiver, guildmaster,
       guild_receptionist, banker and craftsman.
     - The builder prompts for description, NPC type, creature type, level,


### PR DESCRIPTION
## Summary
- add an alias to call `cnpc` via `createnpc`
- document the new alias in the NPC help entry
- mention `@createnpc` in the README

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68453f2b7274832ca8b5581aa7f382b0