### PR TITLE
Add NPC role mixins

### DIFF
--- a/typeclasses/npcs/banker.py
+++ b/typeclasses/npcs/banker.py
@@ -1,7 +1,8 @@
 from . import BaseNPC
+from world.npc_roles import BankerRole
 
 
-class BankerNPC(BaseNPC):
+class BankerNPC(BankerRole, BaseNPC):
     """NPC that handles currency transactions or storage."""
 
     pass

--- a/typeclasses/npcs/merchant.py
+++ b/typeclasses/npcs/merchant.py
@@ -1,7 +1,8 @@
 from . import BaseNPC
+from world.npc_roles import MerchantRole
 
 
-class MerchantNPC(BaseNPC):
+class MerchantNPC(MerchantRole, BaseNPC):
     """NPC that buys and sells items."""
 
     pass

--- a/typeclasses/npcs/trainer.py
+++ b/typeclasses/npcs/trainer.py
@@ -1,7 +1,8 @@
 from . import BaseNPC
+from world.npc_roles import TrainerRole
 
 
-class TrainerNPC(BaseNPC):
+class TrainerNPC(TrainerRole, BaseNPC):
     """NPC that teaches skills or abilities."""
 
     pass

--- a/world/npc_roles/__init__.py
+++ b/world/npc_roles/__init__.py
@@ -1,0 +1,7 @@
+"""Mixin classes for specialized NPC behaviors."""
+
+from .merchant import MerchantRole
+from .banker import BankerRole
+from .trainer import TrainerRole
+
+__all__ = ["MerchantRole", "BankerRole", "TrainerRole"]

--- a/world/npc_roles/banker.py
+++ b/world/npc_roles/banker.py
@@ -1,0 +1,16 @@
+"""Banker role mixin."""
+
+class BankerRole:
+    """Mixin providing simple banker behavior."""
+
+    def deposit(self, depositor, amount: int) -> None:
+        """Handle depositing currency from `depositor`."""
+        if not depositor:
+            return
+        depositor.msg(f"You deposit {amount} coins with {self.key}.")
+
+    def withdraw(self, withdrawer, amount: int) -> None:
+        """Handle withdrawing currency for `withdrawer`."""
+        if not withdrawer:
+            return
+        withdrawer.msg(f"{self.key} gives you {amount} coins from your account.")

--- a/world/npc_roles/merchant.py
+++ b/world/npc_roles/merchant.py
@@ -1,0 +1,10 @@
+"""Merchant role mixin."""
+
+class MerchantRole:
+    """Mixin providing simple merchant behavior."""
+
+    def sell(self, buyer, item, price: int) -> None:
+        """Handle selling `item` to `buyer`."""
+        if not buyer or not item:
+            return
+        buyer.msg(f"{self.key} sells {item} to you for {price} coins.")

--- a/world/npc_roles/trainer.py
+++ b/world/npc_roles/trainer.py
@@ -1,0 +1,10 @@
+"""Trainer role mixin."""
+
+class TrainerRole:
+    """Mixin providing simple trainer behavior."""
+
+    def train(self, trainee, skill: str) -> None:
+        """Handle training `trainee` in a `skill`."""
+        if not trainee:
+            return
+        trainee.msg(f"{self.key} trains you in {skill}.")


### PR DESCRIPTION
## Summary
- add `world/npc_roles` package
- implement simple merchant/banker/trainer role mixins
- hook mixins into NPC subclasses

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6845425b3290832cb84184ddf7a3e199