### PR TITLE
Implement NPC management commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,11 @@ While editing, there's a step to manage triggers using a numbered menu. Choose
 triggers` to review them and `Finish` when done.
 See the `triggers` help entry for the list of events and possible reactions.
 
+There are also helper commands for managing NPCs after creation:
+`@editnpc <npc>` reopens the builder on an existing NPC, `@clonenpc <npc> [= <new_name>]`
+duplicates one, `@deletenpc <npc>` removes it (with confirmation) and
+`@spawnnpc <proto>` spawns a saved prototype from `world/prototypes/npcs.json`.
+
 ## Weapon Creation and Inspection
 
 Builders can quickly create melee weapons with the `cweapon` command.

--- a/commands/admin.py
+++ b/commands/admin.py
@@ -19,7 +19,13 @@ from world.system import stat_manager
 from world.system.constants import MAX_LEVEL
 from utils.stats_utils import get_display_scroll, normalize_stat_key
 from utils import VALID_SLOTS, normalize_slot
-from .npc_builder import CmdCNPC
+from .npc_builder import (
+    CmdCNPC,
+    CmdEditNPC,
+    CmdDeleteNPC,
+    CmdCloneNPC,
+    CmdSpawnNPC,
+)
 
 
 def _safe_split(text):
@@ -1349,3 +1355,7 @@ class BuilderCmdSet(CmdSet):
         self.add(CmdSetFlag)
         self.add(CmdRemoveFlag)
         self.add(CmdCNPC)
+        self.add(CmdEditNPC)
+        self.add(CmdDeleteNPC)
+        self.add(CmdCloneNPC)
+        self.add(CmdSpawnNPC)

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -2507,6 +2507,111 @@ Related:
 """,
     },
     {
+        "key": '@editnpc',
+        "category": 'Building',
+        "text": """Help for @editnpc
+
+Open the NPC builder for an existing NPC.
+
+Usage:
+    @editnpc <npc>
+
+Switches:
+    None
+
+Arguments:
+    <npc> - the NPC to edit
+
+Examples:
+    @editnpc Bob
+
+Notes:
+    - Same as |wcnpc edit <npc>|n.
+
+Related:
+    help cnpc
+""",
+    },
+    {
+        "key": '@deletenpc',
+        "category": 'Building',
+        "text": """Help for @deletenpc
+
+Remove an NPC from the world.
+
+Usage:
+    @deletenpc <npc>
+
+Switches:
+    None
+
+Arguments:
+    <npc> - the NPC to delete
+
+Examples:
+    @deletenpc Bob
+
+Notes:
+    - Prompts for confirmation before deleting.
+
+Related:
+    help cnpc
+""",
+    },
+    {
+        "key": '@clonenpc',
+        "category": 'Building',
+        "text": """Help for @clonenpc
+
+Create a duplicate of an existing NPC.
+
+Usage:
+    @clonenpc <npc> [= <new_name>]
+
+Switches:
+    None
+
+Arguments:
+    <npc> - NPC to clone
+    <new_name> - optional new key
+
+Examples:
+    @clonenpc Bob = Bob2
+
+Notes:
+    - The copy is placed in your current room.
+
+Related:
+    help cnpc
+""",
+    },
+    {
+        "key": '@spawnnpc',
+        "category": 'Building',
+        "text": """Help for @spawnnpc
+
+Spawn a saved NPC prototype.
+
+Usage:
+    @spawnnpc <prototype>
+
+Switches:
+    None
+
+Arguments:
+    <prototype> - key in world/prototypes/npcs.json
+
+Examples:
+    @spawnnpc test_blacksmith
+
+Notes:
+    - Prototypes are saved with the cnpc builder.
+
+Related:
+    help cnpc
+""",
+    },
+    {
         "key": 'triggers',
         "category": 'Building',
         "text": """


### PR DESCRIPTION
## Summary
- add new NPC management commands (editnpc, deletenpc, clonenpc, spawnnpc)
- document commands in help entries and README
- hook commands into builder cmdset

## Testing
- `pytest -q` *(fails: OperationalError no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6845472132e4832cbe3812378e7a53ff