### PR TITLE
Add extra NPC role mixins and typeclasses

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,10 @@ and confirm to create your NPC. You can later update them with `@cnpc edit
 See the `cnpc` help entry for a full breakdown of every menu option.
 
 The builder also lets you choose which NPC class to use. Available
-classes include `BaseNPC`, `MerchantNPC`, `BankerNPC`, `TrainerNPC`
-and `WandererNPC` defined under `typeclasses.npcs`.
+classes include `BaseNPC`, `MerchantNPC`, `BankerNPC`, `TrainerNPC`,
+`WandererNPC`, `GuildmasterNPC`, `GuildReceptionistNPC`,
+`QuestGiverNPC`, `CombatTrainerNPC` and `EventNPC` defined under
+`typeclasses.npcs`.
 
 While editing, there's a step to manage triggers using a numbered menu. Choose
 `Add trigger` to create a new reaction, `Delete trigger` to remove one, `List

--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -28,6 +28,11 @@ NPC_CLASS_MAP = {
     "banker": "typeclasses.npcs.banker.BankerNPC",
     "trainer": "typeclasses.npcs.trainer.TrainerNPC",
     "wanderer": "typeclasses.npcs.wanderer.WandererNPC",
+    "guildmaster": "typeclasses.npcs.guildmaster.GuildmasterNPC",
+    "guild_receptionist": "typeclasses.npcs.guild_receptionist.GuildReceptionistNPC",
+    "questgiver": "typeclasses.npcs.questgiver.QuestGiverNPC",
+    "combat_trainer": "typeclasses.npcs.combat_trainer.CombatTrainerNPC",
+    "event_npc": "typeclasses.npcs.event_npc.EventNPC",
 }
 
 

--- a/typeclasses/npcs/__init__.py
+++ b/typeclasses/npcs/__init__.py
@@ -9,6 +9,11 @@ from .merchant import MerchantNPC  # noqa: E402
 from .banker import BankerNPC  # noqa: E402
 from .trainer import TrainerNPC  # noqa: E402
 from .wanderer import WandererNPC  # noqa: E402
+from .guildmaster import GuildmasterNPC  # noqa: E402
+from .guild_receptionist import GuildReceptionistNPC  # noqa: E402
+from .questgiver import QuestGiverNPC  # noqa: E402
+from .combat_trainer import CombatTrainerNPC  # noqa: E402
+from .event_npc import EventNPC  # noqa: E402
 
 __all__ = [
     "BaseNPC",
@@ -16,4 +21,9 @@ __all__ = [
     "BankerNPC",
     "TrainerNPC",
     "WandererNPC",
+    "GuildmasterNPC",
+    "GuildReceptionistNPC",
+    "QuestGiverNPC",
+    "CombatTrainerNPC",
+    "EventNPC",
 ]

--- a/typeclasses/npcs/combat_trainer.py
+++ b/typeclasses/npcs/combat_trainer.py
@@ -1,0 +1,8 @@
+from . import BaseNPC
+from world.npc_roles import CombatTrainerRole
+
+
+class CombatTrainerNPC(CombatTrainerRole, BaseNPC):
+    """NPC that trains players in combat."""
+
+    pass

--- a/typeclasses/npcs/event_npc.py
+++ b/typeclasses/npcs/event_npc.py
@@ -1,0 +1,8 @@
+from . import BaseNPC
+from world.npc_roles import EventNPCRole
+
+
+class EventNPC(EventNPCRole, BaseNPC):
+    """NPC tied to special events."""
+
+    pass

--- a/typeclasses/npcs/guild_receptionist.py
+++ b/typeclasses/npcs/guild_receptionist.py
@@ -1,0 +1,8 @@
+from . import BaseNPC
+from world.npc_roles import GuildReceptionistRole
+
+
+class GuildReceptionistNPC(GuildReceptionistRole, BaseNPC):
+    """NPC that greets visitors for a guild."""
+
+    pass

--- a/typeclasses/npcs/guildmaster.py
+++ b/typeclasses/npcs/guildmaster.py
@@ -1,0 +1,8 @@
+from . import BaseNPC
+from world.npc_roles import GuildmasterRole
+
+
+class GuildmasterNPC(GuildmasterRole, BaseNPC):
+    """NPC that oversees guild management."""
+
+    pass

--- a/typeclasses/npcs/questgiver.py
+++ b/typeclasses/npcs/questgiver.py
@@ -1,0 +1,8 @@
+from . import BaseNPC
+from world.npc_roles import QuestGiverRole
+
+
+class QuestGiverNPC(QuestGiverRole, BaseNPC):
+    """NPC that offers quests."""
+
+    pass

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -2479,7 +2479,9 @@ Notes:
     - createnpc
     - NPC types include merchant, guard, questgiver, guildmaster,
       guild_receptionist, banker, craftsman, trainer and wanderer.
-    - NPC classes include base, merchant, banker, trainer and wanderer.
+    - NPC classes include base, merchant, banker, trainer, wanderer,
+      guildmaster, guild_receptionist, questgiver, combat_trainer and
+      event_npc.
     - The builder prompts for description, NPC type, creature type, level,
       HP MP SP, primary stats, behavior, skills and AI type.
     - Humanoid body type grants the standard equipment slots automatically.

--- a/world/npc_roles/__init__.py
+++ b/world/npc_roles/__init__.py
@@ -3,5 +3,19 @@
 from .merchant import MerchantRole
 from .banker import BankerRole
 from .trainer import TrainerRole
+from .guildmaster import GuildmasterRole
+from .guild_receptionist import GuildReceptionistRole
+from .questgiver import QuestGiverRole
+from .combat_trainer import CombatTrainerRole
+from .event_npc import EventNPCRole
 
-__all__ = ["MerchantRole", "BankerRole", "TrainerRole"]
+__all__ = [
+    "MerchantRole",
+    "BankerRole",
+    "TrainerRole",
+    "GuildmasterRole",
+    "GuildReceptionistRole",
+    "QuestGiverRole",
+    "CombatTrainerRole",
+    "EventNPCRole",
+]

--- a/world/npc_roles/combat_trainer.py
+++ b/world/npc_roles/combat_trainer.py
@@ -1,0 +1,10 @@
+"""Combat trainer role mixin."""
+
+class CombatTrainerRole:
+    """Mixin for training combat techniques."""
+
+    def spar(self, trainee) -> None:
+        """Spar with `trainee` to improve their skills."""
+        if not trainee:
+            return
+        trainee.msg(f"{self.key} spars with you, honing your abilities.")

--- a/world/npc_roles/event_npc.py
+++ b/world/npc_roles/event_npc.py
@@ -1,0 +1,10 @@
+"""Event NPC role mixin."""
+
+class EventNPCRole:
+    """Mixin for starting or interacting with special events."""
+
+    def start_event(self, caller, event_key: str) -> None:
+        """Initiate an event identified by `event_key`."""
+        if not caller or not event_key:
+            return
+        caller.msg(f"{self.key} begins the event '{event_key}'.")

--- a/world/npc_roles/guild_receptionist.py
+++ b/world/npc_roles/guild_receptionist.py
@@ -1,0 +1,10 @@
+"""Guild receptionist role mixin."""
+
+class GuildReceptionistRole:
+    """Mixin for greeting and assisting guild members."""
+
+    def greet_visitor(self, visitor) -> None:
+        """Greet `visitor` on behalf of the guild."""
+        if not visitor:
+            return
+        visitor.msg(f"{self.key} welcomes you to the guild hall.")

--- a/world/npc_roles/guildmaster.py
+++ b/world/npc_roles/guildmaster.py
@@ -1,0 +1,10 @@
+"""Guildmaster role mixin."""
+
+class GuildmasterRole:
+    """Mixin for guild management behavior."""
+
+    def manage_guild(self, caller) -> None:
+        """Handle generic guild management interaction."""
+        if not caller:
+            return
+        caller.msg(f"{self.key} discusses guild matters with you.")

--- a/world/npc_roles/questgiver.py
+++ b/world/npc_roles/questgiver.py
@@ -1,0 +1,10 @@
+"""Quest giver role mixin."""
+
+class QuestGiverRole:
+    """Mixin for offering quests to players."""
+
+    def offer_quest(self, player, quest) -> None:
+        """Offer `quest` to `player`."""
+        if not player or not quest:
+            return
+        player.msg(f"{self.key} offers you the quest '{quest}'.")


### PR DESCRIPTION
## Summary
- add more npc role mixins
- implement matching typeclasses
- expose classes and role mixins
- extend the npc builder class map
- document new classes

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68454ef86d98832caa85d448c36ba947