### PR TITLE
Allow multiple trigger responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,8 @@ classes include `BaseNPC`, `MerchantNPC`, `BankerNPC`, `TrainerNPC`,
 
 While editing, there's a step to manage triggers using a numbered menu. Choose
 `Add trigger` to create a new reaction, `Delete trigger` to remove one, `List
-triggers` to review them and `Finish` when done.
+triggers` to review them and `Finish` when done. Multiple trigger entries can be
+added for the same event.
 See the `triggers` help entry for the list of events and possible reactions.
 
 There are also helper commands for managing NPCs after creation:

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -2619,8 +2619,11 @@ Related:
         "text": """
 Help for triggers
 
-NPCs may react automatically to events. Each trigger defines an event,
-an optional match text and one or more reactions to perform.
+NPCs may react automatically to events. Triggers are grouped by event and
+stored as lists of dictionaries with optional |wmatch|n text and one or more
+|wresponse|n commands to run. Example::
+
+    {"on_enter": [{"match": "", "response": "say Hello"}]}
 
 Events:
     on_speak   - someone speaks in the room
@@ -2639,8 +2642,8 @@ Reactions:
     <command>          - run any other command string
 
 The match text only applies to some events like |won_speak|n and |won_look|n.
-Multiple reactions can be listed separated by commas or by using multiple
-triggers.
+Multiple triggers may be defined for the same event and each trigger can have
+one or several responses.
 
 Examples:
     Trigger Menu


### PR DESCRIPTION
## Summary
- support lists of trigger dictionaries per event
- update NPC builder to handle multiple triggers
- clarify trigger help entry and docs

## Testing
- `pytest -q` *(fails: OperationalError no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684553f59e78832cb15a478a0b0ef0dd