### PR TITLE
Add docs for NPC roles and AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,52 @@ classes include `BaseNPC`, `MerchantNPC`, `BankerNPC`, `TrainerNPC`,
 While editing, there's a step to manage triggers using a numbered menu. Choose
 `Add trigger` to create a new reaction, `Delete trigger` to remove one, `List
 triggers` to review them and `Finish` when done. Multiple trigger entries can be
-added for the same event.
-See the `triggers` help entry for the list of events and possible reactions.
+added for the same event. See the `triggers` help entry for the list of events
+and possible reactions.
+
+### NPC Roles and AI
+
+The builder now supports assigning extra roles and basic AI scripts. Roles are
+mixins found under `world.npc_roles`:
+
+- **merchant** – sells items to players.
+- **banker** – handles deposits and withdrawals.
+- **trainer** – teaches skills.
+- **guildmaster** – manages guild business.
+- **guild_receptionist** – greets visitors for a guild.
+- **questgiver** – offers quests to players.
+- **combat_trainer** – spars to improve combat ability.
+- **event_npc** – starts or manages special events.
+
+AI behaviors come from `world.npc_handlers.ai` and can be selected in the
+builder:
+
+- **passive** – take no automatic actions.
+- **aggressive** – attack the first player seen.
+- **defensive** – fight back only when in combat.
+- **wander** – roam randomly through available exits.
+- **scripted** – placeholder hook for custom Python code.
+
+### Trigger Syntax
+
+NPC triggers use a dictionary mapping events to one or more reaction entries. A
+reaction may specify a `match` text and single or multiple `responses` to run::
+
+    {
+        "on_enter": [
+            {"match": "", "responses": ["say Hello", "emote waves"]}
+        ]
+    }
+
+During the builder you can add triggers one at a time. The example above shows
+how multiple responses can be combined in your prototype file if you edit it
+manually.
+
+To spawn an NPC saved with an AI type and triggers, use:
+
+```text
+@spawnnpc my_npc_proto
+```
 
 There are also helper commands for managing NPCs after creation:
 `@editnpc <npc>` reopens the builder on an existing NPC, `@clonenpc <npc> [= <new_name>]`

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -2535,6 +2535,49 @@ Related:
 """,
     },
     {
+        "key": 'npc roles',
+        "aliases": ['roles'],
+        "category": 'Building',
+        "text": """Help for npc roles
+
+NPC roles grant extra behavior to an NPC. They are selected during the
+`cnpc` builder at the roles step. Available roles are:
+    merchant - sells items to players
+    banker - stores currency for players
+    trainer - teaches skills
+    guildmaster - manages a guild
+    guild_receptionist - greets guild visitors
+    questgiver - offers quests
+    combat_trainer - spars to improve combat ability
+    event_npc - starts special events
+
+Multiple roles may be assigned to the same NPC.
+
+Related:
+    help cnpc
+""",
+    },
+    {
+        "key": 'npc ai',
+        "aliases": ['ai'],
+        "category": 'Building',
+        "text": """Help for npc ai
+
+The `cnpc` builder lets you choose an AI type controlling basic behavior.
+The available AI types are stored in `world.npc_handlers.ai`:
+    passive - no automatic actions
+    aggressive - attack the first player seen
+    defensive - only fight when attacked
+    wander - move through random exits
+    scripted - custom Python hook
+
+Set the type when prompted in the builder or edit the prototype data.
+
+Related:
+    help cnpc
+""",
+    },
+    {
         "key": '@deletenpc',
         "category": 'Building',
         "text": """Help for @deletenpc


### PR DESCRIPTION
## Summary
- document NPC roles and AI options
- explain trigger syntax and give example
- add help entries for NPC roles and AI

## Testing
- `pytest -q` *(fails: no such table `accounts_accountdb`)*

------
https://chatgpt.com/codex/tasks/task_e_6845586366e4832cbc338c3f9e4a41c5