### PR TITLE
Add passive AI behavior

### DIFF
--- a/world/npc_handlers/ai.py
+++ b/world/npc_handlers/ai.py
@@ -38,11 +38,17 @@ def _ai_scripted(npc: DefaultObject) -> None:
     pass
 
 
+def _ai_passive(npc: DefaultObject) -> None:
+    """Non-responsive AI that takes no actions."""
+    return
+
+
 _AI_MAP = {
     "aggressive": _ai_aggressive,
     "wander": _ai_wander,
     "defensive": _ai_defensive,
     "scripted": _ai_scripted,
+    "passive": _ai_passive,
 }
 
 


### PR DESCRIPTION
## Summary
- add `_ai_passive` helper
- map "passive" AI to `_ai_passive`

## Testing
- `pytest -q` *(fails: django.db.utils.OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68455b6a553c832c921eb9957827f803