### PR TITLE
Implement NPC role behaviors

### DIFF
--- a/typeclasses/tests/test_npc_roles_behavior.py
+++ b/typeclasses/tests/test_npc_roles_behavior.py
@@ -1,0 +1,91 @@
+from unittest.mock import MagicMock
+from evennia.utils import create
+from evennia.utils.test_resources import EvenniaTest
+from world.guilds import Guild, save_guild, find_guild
+from world.quests import Quest, save_quest
+from utils.currency import from_copper, to_copper
+from typeclasses.npcs import (
+    MerchantNPC,
+    BankerNPC,
+    TrainerNPC,
+    GuildmasterNPC,
+    GuildReceptionistNPC,
+    QuestGiverNPC,
+    EventNPC,
+)
+
+
+class TestNPCRoleBehaviors(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.char1.msg = MagicMock()
+
+    def test_merchant_sell_transfers_item_and_coins(self):
+        merchant = create.create_object(MerchantNPC, key="shopkeep", location=self.room1)
+        item = create.create_object("typeclasses.objects.Object", key="apple", location=merchant)
+        self.char1.db.coins = from_copper(20)
+        merchant.db.coins = from_copper(0)
+
+        merchant.sell(self.char1, item, 10)
+
+        self.assertEqual(item.location, self.char1)
+        self.assertEqual(to_copper(self.char1.db.coins), 10)
+        self.assertEqual(to_copper(merchant.db.coins), 10)
+
+    def test_banker_deposit_and_withdraw(self):
+        banker = create.create_object(BankerNPC, key="banker", location=self.room1)
+        self.char1.db.coins = from_copper(30)
+
+        banker.deposit(self.char1, 20)
+        self.assertEqual(to_copper(self.char1.db.coins), 10)
+        self.assertEqual(self.char1.db.bank, 20)
+
+        banker.withdraw(self.char1, 5)
+        self.assertEqual(to_copper(self.char1.db.coins), 15)
+        self.assertEqual(self.char1.db.bank, 15)
+
+    def test_trainer_trains_skill_and_consumes_xp(self):
+        trainer = create.create_object(TrainerNPC, key="trainer", location=self.room1)
+        self.char1.db.exp = 5
+
+        trainer.train(self.char1, "smithing")
+
+        self.assertIsNotNone(self.char1.traits.get("smithing"))
+        self.assertEqual(self.char1.traits.smithing.base, 1)
+        self.assertEqual(self.char1.db.exp, 4)
+
+    def test_guildmaster_manages_membership(self):
+        guild = Guild(name="Testers", ranks=[(0, "Member")], rank_thresholds={"Member": 0})
+        save_guild(guild)
+        gm = create.create_object(GuildmasterNPC, key="master", location=self.room1)
+        gm.db.guild = "Testers"
+
+        gm.manage_guild(self.char1)
+        _, saved = find_guild("Testers")
+        self.assertEqual(self.char1.db.guild, "Testers")
+        self.assertIn(str(self.char1.id), saved.members)
+
+        gm.manage_guild(self.char1)
+        _, saved = find_guild("Testers")
+        self.assertEqual(saved.members[str(self.char1.id)], 1)
+
+    def test_receptionist_greets_visitor(self):
+        rec = create.create_object(GuildReceptionistNPC, key="rec", location=self.room1)
+        rec.db.guild = "Adventurers Guild"
+        self.char1.db.guild = ""
+
+        rec.greet_visitor(self.char1)
+        self.char1.msg.assert_called()
+
+    def test_questgiver_offers_quest(self):
+        quest = Quest(quest_key="testquest", title="A Test")
+        save_quest(quest)
+        giver = create.create_object(QuestGiverNPC, key="giver", location=self.room1)
+
+        giver.offer_quest(self.char1, "testquest")
+        self.assertIn("testquest", self.char1.db.active_quests)
+
+    def test_eventnpc_starts_event(self):
+        npc = create.create_object(EventNPC, key="eventer", location=self.room1)
+        npc.start_event(self.char1, "party")
+        self.assertEqual(npc.db.active_event, "party")

--- a/world/npc_roles/banker.py
+++ b/world/npc_roles/banker.py
@@ -4,13 +4,34 @@ class BankerRole:
     """Mixin providing simple banker behavior."""
 
     def deposit(self, depositor, amount: int) -> None:
-        """Handle depositing currency from `depositor`."""
-        if not depositor:
+        """Deposit ``amount`` of coins from ``depositor`` into their bank."""
+        if not depositor or amount <= 0:
             return
+
+        from utils.currency import to_copper, from_copper
+
+        wallet = depositor.db.coins or {}
+        if to_copper(wallet) < amount:
+            depositor.msg("You don't have that much coin.")
+            return
+
+        depositor.db.coins = from_copper(to_copper(wallet) - amount)
+        depositor.db.bank = int(depositor.db.bank or 0) + amount
         depositor.msg(f"You deposit {amount} coins with {self.key}.")
 
     def withdraw(self, withdrawer, amount: int) -> None:
-        """Handle withdrawing currency for `withdrawer`."""
-        if not withdrawer:
+        """Withdraw ``amount`` of coins for ``withdrawer`` from their bank."""
+        if not withdrawer or amount <= 0:
             return
+
+        from utils.currency import to_copper, from_copper
+
+        balance = int(withdrawer.db.bank or 0)
+        if balance < amount:
+            withdrawer.msg("You do not have that much saved.")
+            return
+
+        withdrawer.db.bank = balance - amount
+        wallet = withdrawer.db.coins or {}
+        withdrawer.db.coins = from_copper(to_copper(wallet) + amount)
         withdrawer.msg(f"{self.key} gives you {amount} coins from your account.")

--- a/world/npc_roles/event_npc.py
+++ b/world/npc_roles/event_npc.py
@@ -4,7 +4,9 @@ class EventNPCRole:
     """Mixin for starting or interacting with special events."""
 
     def start_event(self, caller, event_key: str) -> None:
-        """Initiate an event identified by `event_key`."""
+        """Trigger an in-game event using ``event_key``."""
         if not caller or not event_key:
             return
+
+        self.db.active_event = event_key
         caller.msg(f"{self.key} begins the event '{event_key}'.")

--- a/world/npc_roles/guild_receptionist.py
+++ b/world/npc_roles/guild_receptionist.py
@@ -4,7 +4,14 @@ class GuildReceptionistRole:
     """Mixin for greeting and assisting guild members."""
 
     def greet_visitor(self, visitor) -> None:
-        """Greet `visitor` on behalf of the guild."""
+        """Provide a greeting or directions to ``visitor``."""
         if not visitor:
             return
-        visitor.msg(f"{self.key} welcomes you to the guild hall.")
+
+        guild = self.db.guild
+        if guild and visitor.db.guild == guild:
+            visitor.msg(f"{self.key} says, 'Welcome back to {guild}, {visitor.key}.'")
+        elif guild:
+            visitor.msg(f"{self.key} says, 'Greetings traveler. The {guild} hall is this way.'")
+        else:
+            visitor.msg(f"{self.key} welcomes you to the guild hall.")

--- a/world/npc_roles/guildmaster.py
+++ b/world/npc_roles/guildmaster.py
@@ -4,7 +4,35 @@ class GuildmasterRole:
     """Mixin for guild management behavior."""
 
     def manage_guild(self, caller) -> None:
-        """Handle generic guild management interaction."""
+        """Add ``caller`` to this guild or update their rank."""
         if not caller:
             return
-        caller.msg(f"{self.key} discusses guild matters with you.")
+
+        from world.guilds import find_guild, update_guild, auto_promote
+
+        guild_name = self.db.guild
+        if not guild_name:
+            caller.msg("This guildmaster has no guild.")
+            return
+
+        idx, guild = find_guild(guild_name)
+        if guild is None:
+            caller.msg("The guild is not recognized.")
+            return
+
+        charid = str(caller.id)
+        gp_map = caller.db.guild_points or {}
+        if charid not in guild.members:
+            guild.members[charid] = 0
+            caller.db.guild = guild_name
+            gp_map[guild_name] = 0
+            caller.db.guild_points = gp_map
+            update_guild(idx, guild)
+            caller.msg(f"{self.key} inducts you into {guild_name}.")
+        else:
+            guild.members[charid] = guild.members.get(charid, 0) + 1
+            gp_map[guild_name] = guild.members[charid]
+            caller.db.guild_points = gp_map
+            update_guild(idx, guild)
+            auto_promote(caller, guild)
+            caller.msg(f"{self.key} recognizes your service to {guild_name}.")

--- a/world/npc_roles/merchant.py
+++ b/world/npc_roles/merchant.py
@@ -4,7 +4,21 @@ class MerchantRole:
     """Mixin providing simple merchant behavior."""
 
     def sell(self, buyer, item, price: int) -> None:
-        """Handle selling `item` to `buyer`."""
+        """Sell ``item`` to ``buyer`` and exchange coins."""
         if not buyer or not item:
             return
-        buyer.msg(f"{self.key} sells {item} to you for {price} coins.")
+
+        from utils.currency import to_copper, from_copper
+
+        wallet = buyer.db.coins or {}
+        if to_copper(wallet) < price:
+            buyer.msg("You cannot afford that.")
+            return
+
+        item.move_to(buyer, quiet=True, move_type="get")
+
+        buyer.db.coins = from_copper(to_copper(wallet) - price)
+        my_wallet = self.db.coins or {}
+        self.db.coins = from_copper(to_copper(my_wallet) + price)
+
+        buyer.msg(f"{self.key} sells {item.get_display_name(buyer)} to you for {price} coins.")

--- a/world/npc_roles/questgiver.py
+++ b/world/npc_roles/questgiver.py
@@ -4,7 +4,24 @@ class QuestGiverRole:
     """Mixin for offering quests to players."""
 
     def offer_quest(self, player, quest) -> None:
-        """Offer `quest` to `player`."""
+        """Grant ``quest`` to ``player`` if possible."""
         if not player or not quest:
             return
-        player.msg(f"{self.key} offers you the quest '{quest}'.")
+
+        from world.quests import QuestManager, normalize_quest_key
+
+        quest_key = normalize_quest_key(quest)
+        _, qobj = QuestManager.find(quest_key)
+        if not qobj:
+            return
+
+        active = player.db.active_quests or {}
+        completed = player.db.completed_quests or []
+        if quest_key in active or (not qobj.repeatable and quest_key in completed):
+            player.msg(f"{self.key} has no new quests for you.")
+            return
+
+        active[quest_key] = {"progress": 0}
+        player.db.active_quests = active
+        title = qobj.title or quest_key
+        player.msg(f"{self.key} offers you the quest '{title}'.")

--- a/world/npc_roles/trainer.py
+++ b/world/npc_roles/trainer.py
@@ -4,7 +4,30 @@ class TrainerRole:
     """Mixin providing simple trainer behavior."""
 
     def train(self, trainee, skill: str) -> None:
-        """Handle training `trainee` in a `skill`."""
-        if not trainee:
+        """Improve ``trainee``'s ``skill`` in exchange for experience."""
+        if not trainee or not skill:
             return
+
+        from commands.skills import SKILL_DICT
+        from world.system import stat_manager
+
+        xp = int(trainee.db.exp or 0)
+        if xp <= 0:
+            trainee.msg("You lack the experience to train right now.")
+            return
+
+        trait = trainee.traits.get(skill)
+        if not trait:
+            trait = trainee.traits.add(
+                skill,
+                trait_type="counter",
+                min=0,
+                max=100,
+                base=0,
+                stat=SKILL_DICT.get(skill),
+            )
+
+        trainee.db.exp = xp - 1
+        trait.base += 1
+        stat_manager.refresh_stats(trainee)
         trainee.msg(f"{self.key} trains you in {skill}.")


### PR DESCRIPTION
## Summary
- flesh out specialized NPC role mixins
- add new tests for NPC role behaviours

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6845643bb7b4832c935c4d2212fb82f4