### PR TITLE
Implement arrival/departure hooks

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -585,13 +585,27 @@ class Character(ObjectParent, ClothedCharacter):
         """
         Respond to the arrival of a character
         """
-        pass
+        if chara == self:
+            return
+
+        if self.sessions.count():
+            self.refresh_prompt()
+
+        if hasattr(self, "check_triggers"):
+            self.check_triggers("on_enter", chara=chara)
 
     def at_character_depart(self, chara, destination, **kwargs):
         """
         Respond to the departure of a character
         """
-        pass
+        if chara == self:
+            return
+
+        if self.sessions.count():
+            self.refresh_prompt()
+
+        if hasattr(self, "check_triggers"):
+            self.check_triggers("on_leave", chara=chara, destination=destination)
 
     def at_tick(self):
         """Called by the global ticker.
@@ -772,14 +786,15 @@ class NPC(Character):
         """
         Respond to the arrival of a character
         """
+        super().at_character_arrive(chara, **kwargs)
         if "aggressive" in self.attributes.get("react_as", ""):
             delay(0.1, self.enter_combat, chara)
-        self.check_triggers("on_enter", chara=chara)
 
     def at_character_depart(self, chara, destination, **kwargs):
         """
         Respond to the departure of a character
         """
+        super().at_character_depart(chara, destination, **kwargs)
         if chara == self.db.following:
             # find an exit that goes the same way
             exits = [

--- a/typeclasses/tests/test_characters.py
+++ b/typeclasses/tests/test_characters.py
@@ -112,6 +112,28 @@ class TestCharacterHooks(EvenniaTest):
         shield.wear(self.char1, True)
         self.assertFalse(shield.db.worn)
 
+    def test_arrive_depart_hooks(self):
+        npc = create.create_object("typeclasses.characters.NPC", key="mob", location=self.room1)
+
+        self.char1.refresh_prompt = MagicMock()
+        npc.check_triggers = MagicMock()
+
+        # character enters the room
+        self.char2.location = self.room2
+        self.char2.move_to(self.room1)
+
+        self.char1.refresh_prompt.assert_called()
+        npc.check_triggers.assert_called_with("on_enter", chara=self.char2)
+
+        self.char1.refresh_prompt.reset_mock()
+        npc.check_triggers.reset_mock()
+
+        # character leaves the room
+        self.char2.move_to(self.room2)
+
+        self.char1.refresh_prompt.assert_called()
+        npc.check_triggers.assert_called_with("on_leave", chara=self.char2, destination=self.room2)
+
 
 class TestCharacterDisplays(EvenniaTest):
     def test_get_display_status(self):

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -2671,6 +2671,7 @@ stored as lists of dictionaries with optional |wmatch|n text and one or more
 Events:
     on_speak   - someone speaks in the room
     on_enter   - someone enters the room
+    on_leave   - someone leaves the room
     on_give_item - the NPC receives an item
     on_look    - someone looks at the NPC
     on_attack  - combat starts or damage occurs


### PR DESCRIPTION
## Summary
- trigger prompt refresh and NPC reactions when characters enter/leave
- ensure NPC hooks delegate to base behavior
- document `on_leave` trigger event
- test that arrival and departure fire hooks

## Testing
- `pytest -q` *(fails: no such table accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684566beb70c832c9ea2c62c2442bc36