### PR TITLE
Enable scripted NPC AI callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,12 @@ builder:
 - **aggressive** – attack the first player seen.
 - **defensive** – fight back only when in combat.
 - **wander** – roam randomly through available exits.
-- **scripted** – placeholder hook for custom Python code.
+- **scripted** – runs the callback stored in ``npc.db.ai_script``.
+
+For scripted AI you must assign a callable to ``npc.db.ai_script``. This can be
+either a Python import path or a direct function reference. Example::
+
+    npc.db.ai_script = "scripts.example_ai.patrol_ai"
 
 ### Trigger Syntax
 

--- a/scripts/example_ai.py
+++ b/scripts/example_ai.py
@@ -1,0 +1,13 @@
+"""Example scripted AI callbacks."""
+
+from random import choice
+
+
+def patrol_ai(npc):
+    """Simple patrol behavior that moves randomly."""
+    if not npc.location:
+        return
+    exits = npc.location.contents_get(content_type="exit")
+    if exits:
+        exit_obj = choice(exits)
+        exit_obj.at_traverse(npc, exit_obj.destination)

--- a/typeclasses/tests/test_npc_ai.py
+++ b/typeclasses/tests/test_npc_ai.py
@@ -26,4 +26,32 @@ class TestNPCAIScript(EvenniaTest):
         npc.at_object_creation()
         self.assertTrue(npc.scripts.get("npc_ai"))
 
+    def test_scripted_ai_string_callback(self):
+        from world.npc_handlers import ai
+        from typeclasses.npcs import BaseNPC
+
+        npc = create.create_object(BaseNPC, key="mob3", location=self.room1)
+        npc.db.ai_type = "scripted"
+        npc.db.ai_script = "scripts.example_ai.patrol_ai"
+
+        with patch("scripts.example_ai.patrol_ai") as mock_call:
+            ai.process_ai(npc)
+            mock_call.assert_called_with(npc)
+
+    def test_scripted_ai_direct_callable(self):
+        from world.npc_handlers import ai
+        from typeclasses.npcs import BaseNPC
+
+        called = {}
+
+        def callback(obj):
+            called["ran"] = obj
+
+        npc = create.create_object(BaseNPC, key="mob4", location=self.room1)
+        npc.db.ai_type = "scripted"
+        npc.db.ai_script = callback
+
+        ai.process_ai(npc)
+        self.assertIs(called.get("ran"), npc)
+
 

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -2569,9 +2569,11 @@ The available AI types are stored in `world.npc_handlers.ai`:
     aggressive - attack the first player seen
     defensive - only fight when attacked
     wander - move through random exits
-    scripted - custom Python hook
+    scripted - run npc.db.ai_script callback
 
 Set the type when prompted in the builder or edit the prototype data.
+For scripted AI, store a callable path on ``npc.db.ai_script`` such as
+``scripts.example_ai.patrol_ai``.
 
 Related:
     help cnpc

--- a/world/npc_handlers/ai.py
+++ b/world/npc_handlers/ai.py
@@ -34,8 +34,21 @@ def _ai_defensive(npc: DefaultObject) -> None:
 
 
 def _ai_scripted(npc: DefaultObject) -> None:
-    """Placeholder scripted behavior hook."""
-    pass
+    """Run a custom callback stored on the NPC."""
+    callback = npc.db.ai_script
+    if not callback:
+        return
+    try:
+        if callable(callback):
+            callback(npc)
+        elif isinstance(callback, str):
+            module, func = callback.rsplit(".", 1)
+            mod = __import__(module, fromlist=[func])
+            getattr(mod, func)(npc)
+    except Exception as err:  # pragma: no cover - log errors
+        from evennia.utils import logger
+
+        logger.log_err(f"Scripted AI error on {npc}: {err}")
 
 
 def _ai_passive(npc: DefaultObject) -> None:


### PR DESCRIPTION
## Summary
- allow NPCs to run a callable stored in `npc.db.ai_script`
- add example script and update AI docs
- explain how to assign scripted AI in help and README
- add tests for scripted callbacks

## Testing
- `pytest -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68456cb6fea4832cb09daf807c1d3474