### PR TITLE
Add basic NPC prototypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,10 @@ There are also helper commands for managing NPCs after creation:
 duplicates one, `@deletenpc <npc>` removes it (with confirmation) and
 `@spawnnpc <proto>` spawns a saved prototype from `world/prototypes/npcs.json`.
 
+Several basic NPC prototypes are included out of the box. Try `cnpc dev_spawn basic_merchant`
+or `@spawnnpc basic_merchant` to quickly create a merchant, or `basic_questgiver` for a quest
+giver.
+
 ## Weapon Creation and Inspection
 
 Builders can quickly create melee weapons with the `cweapon` command.

--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -718,8 +718,14 @@ class CmdCNPC(Command):
                 self.msg("Usage: cnpc dev_spawn <proto>")
                 return
             proto = rest
+            from world import prototypes
+
+            proto_dict = prototypes.get_npc_prototypes().get(proto)
             try:
-                obj = spawner.spawn(proto)[0]
+                if proto_dict:
+                    obj = spawner.spawn(proto_dict)[0]
+                else:
+                    obj = spawner.spawn(proto)[0]
             except KeyError:
                 self.msg(f"Unknown prototype: {proto}")
                 return

--- a/typeclasses/tests/test_spawnnpc.py
+++ b/typeclasses/tests/test_spawnnpc.py
@@ -1,0 +1,25 @@
+from unittest.mock import MagicMock
+from evennia.utils.test_resources import EvenniaTest
+from commands.admin import BuilderCmdSet
+from typeclasses.npcs import MerchantNPC
+
+
+class TestSpawnNPCPrototype(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.char1.msg = MagicMock()
+        self.char1.cmdset.add_default(BuilderCmdSet)
+
+    def _find(self, key):
+        for obj in self.char1.location.contents:
+            if obj.key == key:
+                return obj
+        return None
+
+    def test_spawn_basic_merchant(self):
+        self.char1.execute_cmd("@spawnnpc basic_merchant")
+        npc = self._find("merchant")
+        self.assertIsNotNone(npc)
+        self.assertTrue(npc.is_typeclass(MerchantNPC, exact=False))
+        self.assertTrue(npc.tags.has("merchant", category="npc_type"))
+        self.assertEqual(npc.db.ai_type, "passive")

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -2471,7 +2471,7 @@ Arguments:
 Examples:
     cnpc start guard_01
     cnpc edit Bob
-    cnpc dev_spawn test_blacksmith
+    cnpc dev_spawn basic_merchant
 
 Notes:
     - Aliases:
@@ -2499,7 +2499,7 @@ Notes:
       Choosing Add prompts for the event type, match text and reaction
       command.
     - |wcnpc dev_spawn|n quickly spawns prototype NPCs for testing (Developer only).
-    - Example: |wcnpc dev_spawn test_blacksmith|n
+    - Example: |wcnpc dev_spawn basic_merchant|n
     - See |whelp triggers|n for available events and reactions.
     - ANSI color codes are supported in names and descriptions.
 
@@ -2649,7 +2649,7 @@ Arguments:
     <prototype> - key in world/prototypes/npcs.json
 
 Examples:
-    @spawnnpc test_blacksmith
+    @spawnnpc basic_merchant
 
 Notes:
     - Prototypes are saved with the cnpc builder.

--- a/world/prototypes/npcs.json
+++ b/world/prototypes/npcs.json
@@ -1,1 +1,26 @@
-{}
+{
+    "basic_merchant": {
+        "key": "merchant",
+        "desc": "A traveling merchant ready to trade goods.",
+        "npc_class": "merchant",
+        "npc_type": "merchant",
+        "ai_type": "passive",
+        "level": 1
+    },
+    "basic_questgiver": {
+        "key": "quest giver",
+        "desc": "A local seeking brave adventurers for help.",
+        "npc_class": "questgiver",
+        "npc_type": "questgiver",
+        "ai_type": "passive",
+        "level": 1
+    },
+    "basic_guard": {
+        "key": "town guard",
+        "desc": "A vigilant guard keeping watch over the streets.",
+        "npc_class": "base",
+        "npc_type": "guard",
+        "ai_type": "defensive",
+        "level": 1
+    }
+}


### PR DESCRIPTION
## Summary
- provide default NPC prototypes in `world/prototypes/npcs.json`
- allow `cnpc dev_spawn` to also read prototype registry
- document usage of these prototypes
- update help files with new prototype names
- test spawning a prototype NPC

## Testing
- `pytest -k spawnnpc -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684574e046fc832c9e050d2f52509ef0