### PR TITLE
Add achievement system

### DIFF
--- a/commands/achievements.py
+++ b/commands/achievements.py
@@ -1,0 +1,84 @@
+from evennia import CmdSet
+from .command import Command
+from world.achievements import (
+    AchievementManager,
+    normalize_achievement_key,
+)
+
+
+class CmdAchievements(Command):
+    """View your earned achievements.
+
+    Usage:
+        achievements
+    """
+
+    key = "achievements"
+    aliases = ("achvs", "achv")
+    help_category = "General"
+
+    def func(self):
+        caller = self.caller
+        earned = caller.db.achievements or []
+        if not earned:
+            self.msg("You have not earned any achievements.")
+            return
+        lines = []
+        for ach_key in earned:
+            _, ach = AchievementManager.find(ach_key)
+            if ach:
+                title = ach.title or ach_key
+                lines.append(f"{title} (+{ach.points})")
+        if lines:
+            self.msg("\n".join(lines))
+        else:
+            self.msg("You have not earned any achievements.")
+
+
+class CmdAwardAchievement(Command):
+    """Award an achievement to a player.
+
+    Usage:
+        awardach <player> <achievement>
+    """
+
+    key = "awardach"
+    locks = "cmd:perm(Builder)"
+    help_category = "Building"
+
+    def func(self):
+        if not self.args:
+            self.msg("Usage: awardach <player> <achievement>")
+            return
+        parts = self.args.split(None, 1)
+        if len(parts) < 2:
+            self.msg("Usage: awardach <player> <achievement>")
+            return
+        player_name, ach_key = parts
+        ach_key = normalize_achievement_key(ach_key)
+        idx, ach = AchievementManager.find(ach_key)
+        if not ach:
+            self.msg("Unknown achievement.")
+            return
+        target = self.caller.search(player_name, global_search=True)
+        if not target:
+            return
+        earned = target.db.achievements or []
+        if ach_key in earned:
+            self.msg(f"{target.key} already has that achievement.")
+            return
+        earned.append(ach_key)
+        target.db.achievements = earned
+        title = ach.title or ach_key
+        announce = ach.award_msg or f"You have earned the achievement '{title}'!"
+        target.msg(announce)
+        self.msg(f"{target.key} awarded '{title}'.")
+
+
+class AchievementCmdSet(CmdSet):
+    key = "Achievement CmdSet"
+
+    def at_cmdset_creation(self):
+        super().at_cmdset_creation()
+        self.add(CmdAchievements)
+        self.add(CmdAwardAchievement)

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -40,6 +40,7 @@ from commands.areas import AreaCmdSet
 from commands.room_flags import RoomFlagCmdSet
 from commands.admin import AdminCmdSet, BuilderCmdSet
 from commands.quests import QuestCmdSet
+from commands.achievements import AchievementCmdSet
 
 
 class CharacterCmdSet(default_cmds.CharacterCmdSet):
@@ -80,6 +81,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(AdminCmdSet)
         self.add(BuilderCmdSet)
         self.add(QuestCmdSet)
+        self.add(AchievementCmdSet)
 
 
 class AccountCmdSet(default_cmds.AccountCmdSet):

--- a/world/achievements.py
+++ b/world/achievements.py
@@ -1,0 +1,98 @@
+"""Achievement definitions and utilities."""
+
+from dataclasses import dataclass, asdict
+from typing import Dict, List, Optional
+
+from evennia.server.models import ServerConfig
+
+
+def normalize_achievement_key(key: str) -> str:
+    """Return the canonical achievement key."""
+    return str(key).lower().strip()
+
+
+@dataclass
+class Achievement:
+    """Simple data container for an achievement."""
+
+    ach_key: str
+    title: str = ""
+    desc: str = ""
+    points: int = 0
+    award_msg: str = ""
+
+    @classmethod
+    def from_dict(cls, data: Dict) -> "Achievement":
+        return cls(
+            ach_key=data.get("ach_key", ""),
+            title=data.get("title", ""),
+            desc=data.get("desc", ""),
+            points=int(data.get("points", 0)),
+            award_msg=data.get("award_msg", ""),
+        )
+
+    def to_dict(self) -> Dict:
+        return asdict(self)
+
+
+_REGISTRY_KEY = "achievement_registry"
+
+
+def _load_registry() -> List[Dict]:
+    return ServerConfig.objects.conf(_REGISTRY_KEY, default=list)
+
+
+def _save_registry(registry: List[Dict]):
+    ServerConfig.objects.conf(_REGISTRY_KEY, value=registry)
+
+
+def get_achievements() -> List[Achievement]:
+    """Return all stored achievements."""
+    return [Achievement.from_dict(data) for data in _load_registry()]
+
+
+def save_achievement(ach: Achievement):
+    """Add a new achievement to the registry."""
+    registry = _load_registry()
+    ach.ach_key = normalize_achievement_key(ach.ach_key)
+    registry.append(ach.to_dict())
+    _save_registry(registry)
+
+
+def update_achievement(index: int, ach: Achievement):
+    """Update achievement at index."""
+    registry = _load_registry()
+    ach.ach_key = normalize_achievement_key(ach.ach_key)
+    registry[index] = ach.to_dict()
+    _save_registry(registry)
+
+
+def find_achievement(key: str) -> tuple[int, Optional[Achievement]]:
+    """Return index and achievement matching key (case-insensitive)."""
+    key = normalize_achievement_key(key)
+    registry = _load_registry()
+    for i, data in enumerate(registry):
+        ach = Achievement.from_dict(data)
+        if normalize_achievement_key(ach.ach_key) == key:
+            return i, ach
+    return -1, None
+
+
+class AchievementManager:
+    """Helper class for managing achievements."""
+
+    @staticmethod
+    def all() -> List[Achievement]:
+        return get_achievements()
+
+    @staticmethod
+    def save(achievement: Achievement):
+        save_achievement(achievement)
+
+    @staticmethod
+    def update(index: int, achievement: Achievement):
+        update_achievement(index, achievement)
+
+    @staticmethod
+    def find(key: str) -> tuple[int, Optional[Achievement]]:
+        return find_achievement(key)


### PR DESCRIPTION
## Summary
- add Achievement dataclass and registry utilities
- implement commands to view and award achievements
- register commands in default cmdset

## Testing
- `pytest -q` *(fails: OperationalError - no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68458042fae0832c90125011475b0d17