### PR TITLE
Add basic magic system

### DIFF
--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -41,6 +41,7 @@ from commands.room_flags import RoomFlagCmdSet
 from commands.admin import AdminCmdSet, BuilderCmdSet
 from commands.quests import QuestCmdSet
 from commands.achievements import AchievementCmdSet
+from commands.spells import SpellCmdSet
 
 
 class CharacterCmdSet(default_cmds.CharacterCmdSet):
@@ -69,6 +70,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(CmdCraft)
         self.add(CombatCmdSet)
         self.add(SkillCmdSet)
+        self.add(SpellCmdSet)
         self.add(InteractCmdSet)
         self.add(InfoCmdSet)
         self.add(RestCmdSet)

--- a/commands/spells.py
+++ b/commands/spells.py
@@ -1,0 +1,105 @@
+from evennia import CmdSet
+from evennia.utils.evtable import EvTable
+from .command import Command
+from world.spells import SPELLS
+
+
+class CmdSpellbook(Command):
+    """View known spells."""
+    key = "spells"
+    aliases = ("spellbook",)
+
+    def func(self):
+        known = self.caller.db.spells or []
+        if not known:
+            self.msg("You do not know any spells.")
+            return
+        table = EvTable("Spell", "Mana")
+        for skey in known:
+            spell = SPELLS.get(skey)
+            if spell:
+                table.add_row(spell.key, spell.mana_cost)
+        self.msg(str(table))
+
+
+class CmdCast(Command):
+    """Cast a learned spell."""
+    key = "cast"
+
+    def parse(self):
+        args = self.args.strip()
+        if " on " in args:
+            self.spellname, self.target = args.split(" on ", 1)
+        else:
+            self.spellname = args
+            self.target = None
+
+    def func(self):
+        if not self.spellname:
+            self.msg("Cast what?")
+            return
+        spell_key = self.spellname.lower()
+        spell = SPELLS.get(spell_key)
+        if not spell:
+            self.msg("No such spell.")
+            return
+        known = self.caller.db.spells or []
+        if spell_key not in known:
+            self.msg("You have not learned that spell.")
+            return
+        if self.caller.traits.mana.current < spell.mana_cost:
+            self.msg("You do not have enough mana.")
+            return
+        target = None
+        if self.target:
+            target = self.caller.search(self.target)
+            if not target:
+                return
+        self.caller.traits.mana.current -= spell.mana_cost
+        if target:
+            self.caller.location.msg_contents(
+                f"{self.caller.get_display_name(self.caller)} casts {spell.key} at {target.get_display_name(self.caller)}!"
+            )
+        else:
+            self.caller.location.msg_contents(
+                f"{self.caller.get_display_name(self.caller)} casts {spell.key}!"
+            )
+
+
+class CmdLearnSpell(Command):
+    """Learn a spell from a trainer."""
+    key = "learn"
+
+    def func(self):
+        if not self.obj or not (spell_key := self.obj.db.spell_training):
+            self.msg("You cannot learn spells here.")
+            return
+        spell = SPELLS.get(spell_key)
+        if not spell:
+            self.msg("You cannot learn spells here.")
+            return
+        known = self.caller.db.spells or []
+        if spell_key in known:
+            self.msg("You already know that spell.")
+            return
+        known.append(spell_key)
+        self.caller.db.spells = known
+        self.msg(f"You learn the {spell.key} spell.")
+
+
+class SpellTrainCmdSet(CmdSet):
+    key = "Spell Train CmdSet"
+
+    def at_cmdset_creation(self):
+        super().at_cmdset_creation()
+        self.add(CmdLearnSpell)
+
+
+class SpellCmdSet(CmdSet):
+    key = "Spell CmdSet"
+
+    def at_cmdset_creation(self):
+        super().at_cmdset_creation()
+        self.add(CmdSpellbook)
+        self.add(CmdCast)
+

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -2704,4 +2704,41 @@ Related:
     help cnpc
 """,
     },
+    {
+        "key": 'spells',
+        "category": 'General',
+        "text": """Help for spells
+
+Learn new spells from trainers with |wlearn|n. Once learned, cast a spell
+using |wcast <spell> [on <target>]|n. Casting costs mana according to the
+spell.
+""",
+    },
+    {
+        "key": 'cast',
+        "category": 'General',
+        "text": """Help for cast
+
+Cast a spell that you have learned.
+
+Usage:
+    cast <spell> [on <target>]
+
+Notes:
+    - Each spell consumes mana when cast.
+    - You must learn a spell before you can cast it.
+""",
+    },
+    {
+        "key": 'learn',
+        "aliases": ['trainspell'],
+        "category": 'General',
+        "text": """Help for learn
+
+Learn a spell from a trainer in your current location.
+
+Usage:
+    learn
+""",
+    },
 ]

--- a/world/spells.py
+++ b/world/spells.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass
+from typing import Dict
+
+@dataclass
+class Spell:
+    key: str
+    stat: str
+    mana_cost: int
+    desc: str = ""
+
+
+SPELLS: Dict[str, Spell] = {
+    "fireball": Spell("fireball", "INT", 10, "Hurl a ball of fire at your target."),
+    "heal": Spell("heal", "WIS", 8, "Restore a small amount of health."),
+}


### PR DESCRIPTION
## Summary
- implement `commands/spells.py` with casting and learning commands
- register default spells in `world/spells.py`
- track learned spells on characters and allow casting
- load `SpellCmdSet` in default commandset
- document how to learn and cast spells

## Testing
- `pytest -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684581dbb258832c9fd06f61e79ef032