### PR TITLE
Add missing guest typeclass

### DIFF
--- a/typeclasses/accounts.py
+++ b/typeclasses/accounts.py
@@ -101,3 +101,8 @@ class Account(ContribChargenAccount):
         self.db.settings = {"auto attack": True, "auto prompt": False}
 
 
+class Guest(DefaultGuest):
+    """Guest account typeclass."""
+    pass
+
+


### PR DESCRIPTION
## Summary
- implement `Guest` account typeclass

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6845867a1308832c8d10d5b74557a129