### PR TITLE
Add level up rewards

### DIFF
--- a/commands/quests.py
+++ b/commands/quests.py
@@ -397,6 +397,8 @@ class CmdCompleteQuest(Command):
         rewards = []
         if quest.xp_reward:
             caller.db.exp = (caller.db.exp or 0) + quest.xp_reward
+            from world.system import state_manager
+            state_manager.check_level_up(caller)
             rewards.append(f"{quest.xp_reward} XP")
 
         from utils.currency import to_copper, from_copper, format_wallet

--- a/commands/shops.py
+++ b/commands/shops.py
@@ -291,6 +291,8 @@ class CmdDonate(Command):
 
         exp = self.caller.db.exp or 0
         self.caller.db.exp = exp + total
+        from world.system import state_manager
+        state_manager.check_level_up(self.caller)
 
         self.msg(f"You exchange {obj_name} for {total} experience.")
 

--- a/typeclasses/scripts.py
+++ b/typeclasses/scripts.py
@@ -128,9 +128,12 @@ class CombatScript(Script):
 
         # grant exp to the other team, if relevant
         if exp := combatant.db.exp_reward:
+            from world.system import state_manager
+
             for obj in self.db.teams[team - 1]:
                 obj.msg(f"You gain {exp} experience.")
                 obj.db.exp = (obj.db.exp or 0) + exp
+                state_manager.check_level_up(obj)
         self.check_victory()
         # remove their combat target if they have one
         del combatant.db.combat_target

--- a/typeclasses/tests/test_leveling.py
+++ b/typeclasses/tests/test_leveling.py
@@ -1,0 +1,28 @@
+from unittest.mock import MagicMock
+from evennia.utils.test_resources import EvenniaTest
+from world.system import state_manager
+
+
+class TestLeveling(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.char1.db.exp = 0
+        self.char1.db.level = 1
+        self.char1.db.practice_sessions = 0
+        self.char1.db.training_points = 0
+        self.char1.msg = MagicMock()
+
+    def test_single_level_up_awards_resources(self):
+        self.char1.db.exp = 100
+        state_manager.check_level_up(self.char1)
+        self.assertEqual(self.char1.db.level, 2)
+        self.assertEqual(self.char1.db.practice_sessions, 3)
+        self.assertEqual(self.char1.db.training_points, 1)
+        self.char1.msg.assert_called()
+
+    def test_multiple_level_ups(self):
+        self.char1.db.exp = 210
+        state_manager.check_level_up(self.char1)
+        self.assertEqual(self.char1.db.level, 3)
+        self.assertEqual(self.char1.db.practice_sessions, 6)
+        self.assertEqual(self.char1.db.training_points, 2)

--- a/world/recipes/base.py
+++ b/world/recipes/base.py
@@ -50,6 +50,8 @@ class SkillRecipe(CraftingRecipe):
         if self.exp_gain:
             exp = crafter.attributes.get("exp", 0)
             crafter.db.exp = self.exp_gain + exp
+            from world.system import state_manager
+            state_manager.check_level_up(crafter)
         # implement some randomness - the higher the difference, the lower the chance of failure
         if not randint(0, success_rate):
             self.msg("It doesn't seem to work out. Maybe you should try again?")

--- a/world/system/state_manager.py
+++ b/world/system/state_manager.py
@@ -274,3 +274,36 @@ def tick_all():
 
     for chara in Character.objects.all():
         tick_character(chara)
+
+
+def check_level_up(chara) -> bool:
+    """Increase character level based on experience.
+
+    Grants +3 practice sessions and +1 training point per level gained and
+    notifies the character when a level up occurs.
+
+    Args:
+        chara: The character to check for leveling.
+
+    Returns:
+        bool: True if the character gained at least one level.
+    """
+
+    exp = int(chara.db.exp or 0)
+    level = int(chara.db.level or 1)
+    leveled = False
+
+    while level < MAX_LEVEL and exp >= level * 100:
+        level += 1
+        leveled = True
+        chara.db.practice_sessions = (chara.db.practice_sessions or 0) + 3
+        chara.db.training_points = (chara.db.training_points or 0) + 1
+
+    if leveled:
+        chara.db.level = level
+        chara.msg(
+            f"You advance to level {level}! +3 practice sessions and +1 training point awarded."
+        )
+        stat_manager.refresh_stats(chara)
+
+    return leveled


### PR DESCRIPTION
## Summary
- grant practice sessions and training points when levelling up
- call level check when awarding XP from combat, quests, donations and crafting
- test level-up reward logic

## Testing
- `pytest typeclasses/tests/test_leveling.py -q` *(fails: OperationalError no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68458df4bc34832cae289d5daa2127ed