### PR TITLE
Remove guard/craftsman types from NPC builder

### DIFF
--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -11,12 +11,10 @@ import re
 # NPC types that can be selected in the builder
 ALLOWED_NPC_TYPES = (
     "merchant",
-    "guard",
     "questgiver",
     "guildmaster",
     "banker",
     "guild_receptionist",
-    "craftsman",
     "trainer",
     "wanderer",
 )

--- a/typeclasses/tests/test_cnpc.py
+++ b/typeclasses/tests/test_cnpc.py
@@ -72,7 +72,7 @@ class TestCNPC(EvenniaTest):
 
         npc_builder._set_desc(self.char1, "A big ogre")
         npc_builder._set_creature_type(self.char1, "humanoid")
-        npc_builder._set_npc_type(self.char1, "guard")
+        npc_builder._set_npc_type(self.char1, "questgiver")
         npc_builder._set_level(self.char1, "1")
         npc_builder._set_resources(self.char1, "20 5 5")
         npc_builder._set_stats(self.char1, "5 5 5 5 5 5")
@@ -93,7 +93,7 @@ class TestCNPC(EvenniaTest):
 
         npc_builder._set_desc(self.char1, "A colorful parrot")
         npc_builder._set_creature_type(self.char1, "humanoid")
-        npc_builder._set_npc_type(self.char1, "craftsman")
+        npc_builder._set_npc_type(self.char1, "trainer")
         npc_builder._set_level(self.char1, "1")
         npc_builder._set_resources(self.char1, "10 0 0")
         npc_builder._set_stats(self.char1, "1 1 1 1 1 1")
@@ -132,7 +132,7 @@ class TestCNPC(EvenniaTest):
         npc_builder._edit_custom_slots(self.char1, "remove offhand")
         npc_builder._edit_custom_slots(self.char1, "add tail")
         npc_builder._edit_custom_slots(self.char1, "done")
-        npc_builder._set_npc_type(self.char1, "guard")
+        npc_builder._set_npc_type(self.char1, "questgiver")
         npc_builder._set_level(self.char1, "1")
         npc_builder._set_resources(self.char1, "5 0 0")
         npc_builder._set_stats(self.char1, "1 1 1 1 1 1")

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -2469,7 +2469,7 @@ Arguments:
     None
 
 Examples:
-    cnpc start guard_01
+    cnpc start merchant_01
     cnpc edit Bob
     cnpc dev_spawn basic_merchant
 
@@ -2477,8 +2477,8 @@ Notes:
     - Aliases:
     - npc
     - createnpc
-    - NPC types include merchant, guard, questgiver, guildmaster,
-      guild_receptionist, banker, craftsman, trainer and wanderer.
+    - NPC types include merchant, questgiver, guildmaster,
+      guild_receptionist, banker, trainer and wanderer.
     - NPC classes include base, merchant, banker, trainer, wanderer,
       guildmaster, guild_receptionist, questgiver, combat_trainer and
       event_npc.


### PR DESCRIPTION
## Summary
- trim unavailable NPC types from `ALLOWED_NPC_TYPES`
- update builder help entry examples
- adjust tests expecting `guard` or `craftsman` types

## Testing
- `pytest -q` *(fails: stats, combat calculations, smithing recipes, currency)*

------
https://chatgpt.com/codex/tasks/task_e_68458f75cb24832cabf40ab0d9ea5d35