### PR TITLE
Fix README URL placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Evennia: The RPG
 
-**Play Here** https://example.com
 
 ### What is this?
 


### PR DESCRIPTION
## Summary
- remove placeholder game URL from README

## Testing
- `pytest -q` *(fails: OperationalError - no such table)*
- `pytest utils/tests/test_currency.py::TestCurrencyConversion::test_round_trip_values -q` *(fails: OperationalError - no such table)*

------
https://chatgpt.com/codex/tasks/task_e_684590fdc82c832c901d310e4b7e9932