### PR TITLE
Add area-based NPC registry and builder commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,9 @@ There are also helper commands for managing NPCs after creation:
 `@editnpc <npc>` reopens the builder on an existing NPC, `@clonenpc <npc> [= <new_name>]`
 duplicates one, `@deletenpc <npc>` removes it (with confirmation) and
 `@spawnnpc <proto>` spawns a saved prototype from `world/prototypes/npcs.json`.
+You can organize prototypes by area with `@listnpcs <area>`, spawn them with
+`@spawnnpc <area>/<proto>` and duplicate them using
+`@dupnpc <area>/<proto> [= <new_key>]`.
 
 Several basic NPC prototypes are included out of the box. Try `cnpc dev_spawn basic_merchant`
 or `@spawnnpc basic_merchant` to quickly create a merchant, or `basic_questgiver` for a quest

--- a/commands/admin.py
+++ b/commands/admin.py
@@ -25,6 +25,8 @@ from .npc_builder import (
     CmdDeleteNPC,
     CmdCloneNPC,
     CmdSpawnNPC,
+    CmdListNPCs,
+    CmdDupNPC,
 )
 
 
@@ -1359,3 +1361,5 @@ class BuilderCmdSet(CmdSet):
         self.add(CmdDeleteNPC)
         self.add(CmdCloneNPC)
         self.add(CmdSpawnNPC)
+        self.add(CmdListNPCs)
+        self.add(CmdDupNPC)

--- a/typeclasses/tests/test_area_npcs.py
+++ b/typeclasses/tests/test_area_npcs.py
@@ -1,0 +1,37 @@
+from unittest.mock import MagicMock
+from evennia.utils.test_resources import EvenniaTest
+from django.test import override_settings
+from commands.admin import BuilderCmdSet
+from world import area_npcs, prototypes
+
+@override_settings(DEFAULT_HOME=None)
+class TestAreaNPCRegistry(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.char1.msg = MagicMock()
+        self.char1.cmdset.add_default(BuilderCmdSet)
+        area_npcs.remove_area_npc("testarea", "basic_merchant")
+
+    def test_add_and_remove(self):
+        area_npcs.add_area_npc("testarea", "basic_merchant")
+        self.assertIn("basic_merchant", area_npcs.get_area_npc_list("testarea"))
+        area_npcs.remove_area_npc("testarea", "basic_merchant")
+        self.assertNotIn("basic_merchant", area_npcs.get_area_npc_list("testarea"))
+
+    def test_commands(self):
+        area_npcs.add_area_npc("testarea", "basic_merchant")
+        # listnpcs
+        self.char1.execute_cmd("@listnpcs testarea")
+        out = self.char1.msg.call_args[0][0]
+        self.assertIn("basic_merchant", out)
+        # spawnnpc
+        self.char1.msg.reset_mock()
+        self.char1.execute_cmd("@spawnnpc testarea/basic_merchant")
+        objs = [o for o in self.char1.location.contents if o.key == "merchant"]
+        self.assertTrue(objs)
+        # dupnpc
+        self.char1.msg.reset_mock()
+        self.char1.execute_cmd("@dupnpc testarea/basic_merchant = special_merchant")
+        reg = prototypes.get_npc_prototypes()
+        self.assertIn("special_merchant", reg)
+        self.assertIn("special_merchant", area_npcs.get_area_npc_list("testarea"))

--- a/world/area_npcs.py
+++ b/world/area_npcs.py
@@ -1,0 +1,41 @@
+from typing import Dict, List
+from evennia.server.models import ServerConfig
+
+_REGISTRY_KEY = "area_npc_registry"
+
+
+def _load_registry() -> Dict[str, List[str]]:
+    return ServerConfig.objects.conf(_REGISTRY_KEY, default={})
+
+
+def _save_registry(registry: Dict[str, List[str]]):
+    ServerConfig.objects.conf(_REGISTRY_KEY, value=registry)
+
+
+def get_area_npc_list(area: str) -> List[str]:
+    """Return list of prototype keys for ``area``."""
+    return _load_registry().get(area.lower(), [])
+
+
+def add_area_npc(area: str, proto_key: str):
+    """Add ``proto_key`` to ``area`` list."""
+    reg = _load_registry()
+    key = area.lower()
+    lst = reg.setdefault(key, [])
+    if proto_key not in lst:
+        lst.append(proto_key)
+        _save_registry(reg)
+
+
+def remove_area_npc(area: str, proto_key: str):
+    """Remove ``proto_key`` from ``area`` list."""
+    reg = _load_registry()
+    key = area.lower()
+    lst = reg.get(key, [])
+    if proto_key in lst:
+        lst.remove(proto_key)
+        if lst:
+            reg[key] = lst
+        else:
+            reg.pop(key, None)
+        _save_registry(reg)

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -2641,6 +2641,7 @@ Spawn a saved NPC prototype.
 
 Usage:
     @spawnnpc <prototype>
+    @spawnnpc <area>/<prototype>
 
 Switches:
     None
@@ -2650,9 +2651,58 @@ Arguments:
 
 Examples:
     @spawnnpc basic_merchant
+    @spawnnpc town/basic_merchant
 
 Notes:
     - Prototypes are saved with the cnpc builder.
+
+Related:
+    help cnpc
+""",
+    },
+    {
+        "key": "@listnpcs",
+        "category": "Building",
+        "text": """Help for @listnpcs
+
+List NPC prototypes assigned to an area.
+
+Usage:
+    @listnpcs <area>
+
+Switches:
+    None
+
+Arguments:
+    <area> - registered area name
+
+Examples:
+    @listnpcs town
+
+Related:
+    help cnpc
+""",
+    },
+    {
+        "key": "@dupnpc",
+        "category": "Building",
+        "text": """Help for @dupnpc
+
+Duplicate an NPC prototype from an area's list.
+
+Usage:
+    @dupnpc <area>/<proto> [= <new_name>]
+
+Switches:
+    None
+
+Arguments:
+    <area> - area containing the prototype
+    <proto> - prototype key to copy
+    <new_name> - optional new key for the copy
+
+Examples:
+    @dupnpc town/basic_merchant = special_merchant
 
 Related:
     help cnpc


### PR DESCRIPTION
## Summary
- add `world.area_npcs` module for area-to-prototype mapping
- extend NPC builder with list, spawn and duplicate commands
- register new commands in the builder cmdset
- update help entries and documentation
- add tests for area npc registry utilities and commands

## Testing
- `pytest -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6845949b5df4832c8354d8ff6d0a5e11