### PR TITLE
Enable guard type for NPC builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ mixins found under `world.npc_roles`:
 - **guildmaster** – manages guild business.
 - **guild_receptionist** – greets visitors for a guild.
 - **questgiver** – offers quests to players.
+- **guard** – protects areas or important figures.
 - **combat_trainer** – spars to improve combat ability.
 - **event_npc** – starts or manages special events.
 

--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -16,6 +16,7 @@ ALLOWED_NPC_TYPES = (
     "banker",
     "guild_receptionist",
     "trainer",
+    "guard",
     "wanderer",
 )
 


### PR DESCRIPTION
## Summary
- support `guard` in the NPC builder menu
- document the new `guard` role in the README

## Testing
- `pytest -q` *(fails: OperationalError - no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684648cad69c832c822bf46e2d12e6ac