### PR TITLE
Add mob prototype management commands

### DIFF
--- a/commands/admin.py
+++ b/commands/admin.py
@@ -28,7 +28,7 @@ from .npc_builder import (
     CmdListNPCs,
     CmdDupNPC,
 )
-from .mob_builder_commands import CmdMStat, CmdMList
+from .mob_builder_commands import CmdMStat, CmdMList, CmdMCreate, CmdMSet
 
 
 def _safe_split(text):
@@ -1364,5 +1364,7 @@ class BuilderCmdSet(CmdSet):
         self.add(CmdSpawnNPC)
         self.add(CmdListNPCs)
         self.add(CmdDupNPC)
+        self.add(CmdMCreate)
+        self.add(CmdMSet)
         self.add(CmdMStat)
         self.add(CmdMList)

--- a/commands/mob_builder_commands.py
+++ b/commands/mob_builder_commands.py
@@ -1,13 +1,14 @@
-from evennia import create_object
-from evennia.utils.search import search_object
+import shlex
+
 from typeclasses.npcs import BaseNPC
 from evennia.utils import evtable
+
 from .command import Command
 from . import npc_builder
 from world import prototypes, area_npcs
 
 class CmdMStat(Command):
-    """Inspect an NPC's stats."""
+    """Inspect an NPC or prototype."""
 
     key = "@mstat"
     locks = "cmd:perm(Builder) or perm(Admin) or perm(Developer)"
@@ -15,39 +16,139 @@ class CmdMStat(Command):
 
     def func(self):
         if not self.args:
-            self.msg("Usage: @mstat <npc>")
+            self.msg("Usage: @mstat <npc or proto>")
             return
-        target = self.caller.search(self.args.strip(), global_search=True)
-        if not target or not target.is_typeclass(BaseNPC, exact=False):
-            self.msg("NPC not found.")
-            return
-        data = npc_builder._gather_npc_data(target)
+        arg = self.args.strip()
+        registry = prototypes.get_npc_prototypes()
+        proto = registry.get(arg)
+        if proto:
+            data = proto
+        else:
+            target = self.caller.search(arg, global_search=True)
+            if not target or not target.is_typeclass(BaseNPC, exact=False):
+                self.msg("NPC or prototype not found.")
+                return
+            data = npc_builder._gather_npc_data(target)
         table = evtable.EvTable("Attribute", "Value")
-        table.add_row("Key", target.key)
-        table.add_row("Typeclass", target.typeclass_path)
-        table.add_row("Level", data.get("level", 1))
-        table.add_row("AI", data.get("ai_type", ""))
-        hp = data.get("hp")
-        if hp:
-            table.add_row("HP", hp)
-        stats = data.get("primary_stats") or {}
-        if stats:
-            statline = ", ".join(f"{k}:{v}" for k, v in stats.items())
-            table.add_row("Stats", statline)
-        roles = target.tags.get(category="npc_role", return_list=True) or []
-        if roles:
-            table.add_row("Roles", ", ".join(roles))
+        for field, value in data.items():
+            if field == "edit_obj":
+                continue
+            if isinstance(value, list):
+                valstr = ", ".join(str(v) for v in value)
+            else:
+                valstr = str(value)
+            table.add_row(field, valstr)
         self.msg(str(table))
 
+
+class CmdMCreate(Command):
+    """Create a new NPC prototype."""
+
+    key = "@mcreate"
+    locks = "cmd:perm(Builder) or perm(Admin) or perm(Developer)"
+    help_category = "Building"
+
+    def parse(self):
+        parts = self.args.split(None, 1)
+        self.new_key = parts[0].strip() if parts else ""
+        self.copy_key = parts[1].strip() if len(parts) > 1 else ""
+
+    def func(self):
+        if not self.new_key:
+            self.msg("Usage: @mcreate <key> [copy_key]")
+            return
+        registry = prototypes.get_npc_prototypes()
+        if self.new_key in registry:
+            self.msg("Prototype with that key already exists.")
+            return
+        proto = {}
+        if self.copy_key:
+            proto = registry.get(self.copy_key)
+            if not proto:
+                self.msg("Copy prototype not found.")
+                return
+            proto = dict(proto)
+        proto["key"] = self.new_key
+        prototypes.register_npc_prototype(self.new_key, proto)
+        self.msg(f"Prototype {self.new_key} created.")
+
+
+class CmdMSet(Command):
+    """Edit a field on an NPC prototype."""
+
+    key = "@mset"
+    locks = "cmd:perm(Builder) or perm(Admin) or perm(Developer)"
+    help_category = "Building"
+
+    _FIELD_CASTS = {
+        "level": int,
+    }
+
+    def parse(self):
+        try:
+            parts = shlex.split(self.args)
+        except ValueError:
+            parts = []
+        if len(parts) >= 3:
+            self.proto_key = parts[0]
+            self.field = parts[1]
+            self.value = " ".join(parts[2:])
+        else:
+            self.proto_key = self.field = self.value = None
+
+    def func(self):
+        if not self.proto_key:
+            self.msg("Usage: @mset <key> <field> <value>")
+            return
+        registry = prototypes.get_npc_prototypes()
+        proto = registry.get(self.proto_key)
+        if not proto:
+            self.msg("Prototype not found.")
+            return
+        cast = self._FIELD_CASTS.get(self.field, str)
+        if cast is int:
+            try:
+                val = int(self.value)
+            except (TypeError, ValueError):
+                self.msg("Value must be an integer.")
+                return
+        else:
+            val = self.value
+        proto = dict(proto)
+        proto[self.field] = val
+        prototypes.register_npc_prototype(self.proto_key, proto)
+        self.msg(f"{self.field} updated on {self.proto_key}.")
+
 class CmdMList(Command):
-    """List NPC prototypes optionally filtered by area."""
+    """List NPC prototypes optionally filtered by area and range."""
 
     key = "@mlist"
     locks = "cmd:perm(Builder) or perm(Admin) or perm(Developer)"
     help_category = "Building"
 
+    def _parse_range(self, spec):
+        if "-" not in spec:
+            return None
+        start, end = spec.split("-", 1)
+        if start.isdigit() and end.isdigit():
+            return ("num", int(start), int(end))
+        if len(start) == 1 and len(end) == 1 and start.isalpha() and end.isalpha():
+            return ("alpha", start.lower(), end.lower())
+        return None
+
     def func(self):
-        area = self.args.strip()
+        area = None
+        rangestr = None
+        parts = self.args.strip().split()
+        if parts:
+            if len(parts) == 2:
+                area, rangestr = parts
+            else:
+                part = parts[0]
+                if "-" in part:
+                    rangestr = part
+                else:
+                    area = part
         registry = prototypes.get_npc_prototypes()
         if area:
             keys = area_npcs.get_area_npc_list(area)
@@ -55,7 +156,20 @@ class CmdMList(Command):
                 self.msg("No prototypes registered for that area.")
                 return
         else:
-            keys = registry.keys()
+            keys = list(registry.keys())
+        keys = sorted(keys)
+        if rangestr:
+            rdata = self._parse_range(rangestr)
+            if not rdata:
+                self.msg("Invalid range specification.")
+                return
+            rtype, a, b = rdata
+            if rtype == "num":
+                a = max(1, a)
+                b = min(len(keys), b)
+                keys = keys[a - 1 : b]
+            else:
+                keys = [k for k in keys if a <= k[0].lower() <= b]
         lines = []
         for key in keys:
             desc = registry.get(key, {}).get("desc", "")

--- a/typeclasses/tests/test_mob_proto_commands.py
+++ b/typeclasses/tests/test_mob_proto_commands.py
@@ -1,0 +1,55 @@
+from unittest.mock import MagicMock
+from tempfile import TemporaryDirectory
+from pathlib import Path
+from evennia.utils.test_resources import EvenniaTest
+from django.test import override_settings
+from unittest import mock
+
+from commands.admin import BuilderCmdSet
+from world import prototypes
+
+
+@override_settings(DEFAULT_HOME=None)
+class TestMobPrototypeCommands(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.char1.msg = MagicMock()
+        self.char1.cmdset.add_default(BuilderCmdSet)
+        self.tmp = TemporaryDirectory()
+        patcher = mock.patch.object(
+            prototypes,
+            "_NPC_PROTO_FILE",
+            Path(self.tmp.name) / "npcs.json",
+        )
+        self.addCleanup(self.tmp.cleanup)
+        self.addCleanup(patcher.stop)
+        patcher.start()
+
+    def test_mcreate_and_mset(self):
+        self.char1.execute_cmd("@mcreate goblin")
+        reg = prototypes.get_npc_prototypes()
+        self.assertIn("goblin", reg)
+        self.char1.execute_cmd('@mset goblin desc "A small goblin"')
+        reg = prototypes.get_npc_prototypes()
+        self.assertEqual(reg["goblin"]["desc"], "A small goblin")
+
+    def test_mcreate_copy(self):
+        prototypes.register_npc_prototype("base", {"key": "base", "desc": "base"})
+        self.char1.execute_cmd("@mcreate gob base")
+        reg = prototypes.get_npc_prototypes()
+        self.assertEqual(reg["gob"]["desc"], "base")
+
+    def test_mstat_and_mlist_range(self):
+        prototypes.register_npc_prototype("aone", {"key": "aone"})
+        prototypes.register_npc_prototype("btwo", {"key": "btwo"})
+        prototypes.register_npc_prototype("cthree", {"key": "cthree"})
+        self.char1.execute_cmd("@mstat aone")
+        out = self.char1.msg.call_args[0][0]
+        self.assertIn("aone", out)
+        self.char1.msg.reset_mock()
+        self.char1.execute_cmd("@mlist a-c")
+        out = self.char1.msg.call_args[0][0]
+        self.assertIn("aone", out)
+        self.assertIn("btwo", out)
+        self.assertNotIn("cthree", out)
+


### PR DESCRIPTION
## Summary
- extend mob builder commands with `@mcreate`, `@mset`
- enhance `@mstat` to inspect prototypes
- allow ranges when listing prototypes via `@mlist`
- add new tests for mob prototype commands
- register the new commands in `BuilderCmdSet`

## Testing
- `pytest -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68464da5b090832cba0808692b6a856c