### PR TITLE
Add shop/repair prototype commands

### DIFF
--- a/commands/admin.py
+++ b/commands/admin.py
@@ -28,7 +28,18 @@ from .npc_builder import (
     CmdListNPCs,
     CmdDupNPC,
 )
-from .mob_builder_commands import CmdMStat, CmdMList, CmdMCreate, CmdMSet
+from .mob_builder_commands import (
+    CmdMStat,
+    CmdMList,
+    CmdMCreate,
+    CmdMSet,
+    CmdMakeShop,
+    CmdShopSet,
+    CmdShopStat,
+    CmdMakeRepair,
+    CmdRepairSet,
+    CmdRepairStat,
+)
 
 
 def _safe_split(text):
@@ -40,7 +51,9 @@ def _safe_split(text):
     try:
         return shlex.split(text)
     except ValueError:
-        raise ValueError("No closing quotation found; enclose multiword names in quotes.")
+        raise ValueError(
+            "No closing quotation found; enclose multiword names in quotes."
+        )
 
 
 # Valid stats that can be modified by gear bonuses
@@ -506,7 +519,9 @@ class CmdCGear(Command):
         try:
             bonuses, desc = parse_stat_mods(rest)
         except ValueError as err:
-            self.msg(f"Invalid stat modifier: {err}. See 'help statmods' for valid stats.")
+            self.msg(
+                f"Invalid stat modifier: {err}. See 'help statmods' for valid stats."
+            )
             return
         if slot and slot not in VALID_SLOTS:
             self.msg("Invalid slot name.")
@@ -914,7 +929,9 @@ class CmdCArmor(Command):
         try:
             bonuses, desc = parse_stat_mods(rest)
         except ValueError as err:
-            self.msg(f"Invalid stat modifier: {err}. See 'help statmods' for valid stats.")
+            self.msg(
+                f"Invalid stat modifier: {err}. See 'help statmods' for valid stats."
+            )
             return
         slot = normalize_slot(slot)
         if slot not in VALID_SLOTS:
@@ -938,9 +955,7 @@ class CmdCArmor(Command):
         if bonuses:
             obj.db.stat_mods = bonuses
 
-        self.caller.msg(
-            f"Slot: {slot}\nWeight: {weight}\nDescription: {desc}"
-        )
+        self.caller.msg(f"Slot: {slot}\nWeight: {weight}\nDescription: {desc}")
 
 
 class CmdCTool(Command):
@@ -996,7 +1011,9 @@ class CmdCTool(Command):
         try:
             bonuses, desc = parse_stat_mods(rest)
         except ValueError as err:
-            self.msg(f"Invalid stat modifier: {err}. See 'help statmods' for valid stats.")
+            self.msg(
+                f"Invalid stat modifier: {err}. See 'help statmods' for valid stats."
+            )
             return
         obj = _create_gear(
             self.caller,
@@ -1077,7 +1094,9 @@ class CmdCRing(Command):
         try:
             bonuses, desc = parse_stat_mods(rest)
         except ValueError as err:
-            self.msg(f"Invalid stat modifier: {err}. See 'help statmods' for valid stats.")
+            self.msg(
+                f"Invalid stat modifier: {err}. See 'help statmods' for valid stats."
+            )
             return
 
         if slot not in VALID_SLOTS:
@@ -1155,7 +1174,9 @@ class CmdCTrinket(Command):
         try:
             bonuses, desc = parse_stat_mods(rest)
         except ValueError as err:
-            self.msg(f"Invalid stat modifier: {err}. See 'help statmods' for valid stats.")
+            self.msg(
+                f"Invalid stat modifier: {err}. See 'help statmods' for valid stats."
+            )
             return
 
         obj = _create_gear(
@@ -1294,7 +1315,9 @@ class CmdCPotion(Command):
         try:
             bonuses, desc = parse_stat_mods(rest)
         except ValueError as err:
-            self.msg(f"Invalid stat modifier: {err}. See 'help statmods' for valid stats.")
+            self.msg(
+                f"Invalid stat modifier: {err}. See 'help statmods' for valid stats."
+            )
             return
 
         obj = _create_gear(
@@ -1368,3 +1391,9 @@ class BuilderCmdSet(CmdSet):
         self.add(CmdMSet)
         self.add(CmdMStat)
         self.add(CmdMList)
+        self.add(CmdMakeShop)
+        self.add(CmdShopSet)
+        self.add(CmdShopStat)
+        self.add(CmdMakeRepair)
+        self.add(CmdRepairSet)
+        self.add(CmdRepairStat)

--- a/typeclasses/tests/test_mob_proto_commands.py
+++ b/typeclasses/tests/test_mob_proto_commands.py
@@ -53,3 +53,35 @@ class TestMobPrototypeCommands(EvenniaTest):
         self.assertIn("btwo", out)
         self.assertNotIn("cthree", out)
 
+    def test_shop_and_repair_commands(self):
+        self.char1.execute_cmd("@mcreate shopkeep")
+        self.char1.execute_cmd("@makeshop shopkeep")
+        reg = prototypes.get_npc_prototypes()
+        self.assertIn("shop", reg["shopkeep"])
+        self.char1.execute_cmd("@shopset shopkeep buy 150")
+        self.char1.execute_cmd("@shopset shopkeep sell 50")
+        self.char1.execute_cmd("@shopset shopkeep hours 9-17")
+        self.char1.execute_cmd("@shopset shopkeep types weapon,armor")
+        reg = prototypes.get_npc_prototypes()
+        shop = reg["shopkeep"]["shop"]
+        self.assertEqual(shop["buy_percent"], 150)
+        self.assertEqual(shop["sell_percent"], 50)
+        self.assertEqual(shop["hours"], "9-17")
+        self.assertEqual(shop["item_types"], ["weapon", "armor"])
+        self.char1.execute_cmd("@shopstat shopkeep")
+        out = self.char1.msg.call_args[0][0]
+        self.assertIn("Buy Percent", out)
+        self.char1.msg.reset_mock()
+
+        self.char1.execute_cmd("@makerepair shopkeep")
+        self.char1.execute_cmd("@repairset shopkeep cost 200")
+        self.char1.execute_cmd("@repairset shopkeep hours 10-20")
+        self.char1.execute_cmd("@repairset shopkeep types weapon")
+        reg = prototypes.get_npc_prototypes()
+        repair = reg["shopkeep"]["repair"]
+        self.assertEqual(repair["cost_percent"], 200)
+        self.assertEqual(repair["hours"], "10-20")
+        self.assertEqual(repair["item_types"], ["weapon"])
+        self.char1.execute_cmd("@repairstat shopkeep")
+        out = self.char1.msg.call_args[0][0]
+        self.assertIn("Cost Percent", out)


### PR DESCRIPTION
## Summary
- add commands to manage shop and repair data on NPC prototypes
- include commands in builder command set
- test shop/repair prototype editing

## Testing
- `pytest -q` *(fails: OperationalError no such table accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684652062b8c832c80372bf1a7f49283