### PR TITLE
Add test setup documentation and requirements

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install -r requirements-test.txt
           pip install -e .
-          pip install pytest
       - name: Run tests
         run: pytest -q

--- a/README.md
+++ b/README.md
@@ -216,3 +216,19 @@ Add `/unidentified` before the name to create the weapon unidentified.
 When a weapon is identified, `inspect` shows its damage, slot, any bonuses and
 effects, so `inspect epee-2` will display the full details of the second
 "Epee" you created.
+
+## Running the Tests
+
+To run the automated test suite you need Evennia, Django and pytest installed. You can install these dependencies using the provided requirements file:
+
+```bash
+python -m pip install --upgrade pip
+pip install -r requirements-test.txt
+```
+
+Once installed, execute the tests with:
+
+```bash
+pytest -q
+```
+

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,5 @@
+# Packages required to run the test suite
+# Evennia brings in Django but we list it explicitly to avoid missing deps
+"evennia[extra] >= 4.2, <5.0"
+Django>=4.2,<5.0
+pytest


### PR DESCRIPTION
## Summary
- include instructions for running tests in README
- add `requirements-test.txt` for test dependencies
- install dependencies from the requirements file in CI

## Testing
- `pytest -q` *(fails: 234 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68465462ab7c832c92b7b0a6b89cb4bb