### PR TITLE
Add tests for mob prototype commands

### DIFF
--- a/typeclasses/tests/test_mcreate_command.py
+++ b/typeclasses/tests/test_mcreate_command.py
@@ -1,0 +1,32 @@
+from unittest.mock import MagicMock
+from tempfile import TemporaryDirectory
+from pathlib import Path
+from unittest import mock
+
+from django.test import override_settings
+from evennia.utils.test_resources import EvenniaTest
+
+from commands.admin import BuilderCmdSet
+from world import prototypes
+
+
+@override_settings(DEFAULT_HOME=None)
+class TestMCreateCommand(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.char1.msg = MagicMock()
+        self.char1.cmdset.add_default(BuilderCmdSet)
+        self.tmp = TemporaryDirectory()
+        patcher = mock.patch.object(
+            prototypes,
+            "_NPC_PROTO_FILE",
+            Path(self.tmp.name) / "npcs.json",
+        )
+        self.addCleanup(self.tmp.cleanup)
+        self.addCleanup(patcher.stop)
+        patcher.start()
+
+    def test_mcreate_creates_prototype(self):
+        self.char1.execute_cmd("@mcreate orc")
+        reg = prototypes.get_npc_prototypes()
+        assert "orc" in reg

--- a/typeclasses/tests/test_mlist_command.py
+++ b/typeclasses/tests/test_mlist_command.py
@@ -1,0 +1,37 @@
+from unittest.mock import MagicMock
+from tempfile import TemporaryDirectory
+from pathlib import Path
+from unittest import mock
+
+from django.test import override_settings
+from evennia.utils.test_resources import EvenniaTest
+
+from commands.admin import BuilderCmdSet
+from world import prototypes, area_npcs
+
+
+@override_settings(DEFAULT_HOME=None)
+class TestMListCommand(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.char1.msg = MagicMock()
+        self.char1.cmdset.add_default(BuilderCmdSet)
+        self.tmp = TemporaryDirectory()
+        patcher = mock.patch.object(
+            prototypes,
+            "_NPC_PROTO_FILE",
+            Path(self.tmp.name) / "npcs.json",
+        )
+        self.addCleanup(self.tmp.cleanup)
+        self.addCleanup(patcher.stop)
+        patcher.start()
+
+    def test_mlist_range(self):
+        prototypes.register_npc_prototype("alpha", {"key": "alpha"})
+        prototypes.register_npc_prototype("bravo", {"key": "bravo"})
+        prototypes.register_npc_prototype("charlie", {"key": "charlie"})
+        self.char1.execute_cmd("@mlist a-b")
+        out = self.char1.msg.call_args[0][0]
+        assert "alpha" in out
+        assert "bravo" in out
+        assert "charlie" not in out

--- a/typeclasses/tests/test_mset_command.py
+++ b/typeclasses/tests/test_mset_command.py
@@ -1,0 +1,33 @@
+from unittest.mock import MagicMock
+from tempfile import TemporaryDirectory
+from pathlib import Path
+from unittest import mock
+
+from django.test import override_settings
+from evennia.utils.test_resources import EvenniaTest
+
+from commands.admin import BuilderCmdSet
+from world import prototypes
+
+
+@override_settings(DEFAULT_HOME=None)
+class TestMSetCommand(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.char1.msg = MagicMock()
+        self.char1.cmdset.add_default(BuilderCmdSet)
+        self.tmp = TemporaryDirectory()
+        patcher = mock.patch.object(
+            prototypes,
+            "_NPC_PROTO_FILE",
+            Path(self.tmp.name) / "npcs.json",
+        )
+        self.addCleanup(self.tmp.cleanup)
+        self.addCleanup(patcher.stop)
+        patcher.start()
+
+    def test_mset_edits_field(self):
+        prototypes.register_npc_prototype("orc", {"key": "orc"})
+        self.char1.execute_cmd('@mset orc desc "Fierce orc"')
+        reg = prototypes.get_npc_prototypes()
+        assert reg["orc"]["desc"] == "Fierce orc"

--- a/typeclasses/tests/test_mstat_command.py
+++ b/typeclasses/tests/test_mstat_command.py
@@ -1,0 +1,34 @@
+from unittest.mock import MagicMock
+from tempfile import TemporaryDirectory
+from pathlib import Path
+from unittest import mock
+
+from django.test import override_settings
+from evennia.utils.test_resources import EvenniaTest
+
+from commands.admin import BuilderCmdSet
+from world import prototypes
+
+
+@override_settings(DEFAULT_HOME=None)
+class TestMStatCommand(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.char1.msg = MagicMock()
+        self.char1.cmdset.add_default(BuilderCmdSet)
+        self.tmp = TemporaryDirectory()
+        patcher = mock.patch.object(
+            prototypes,
+            "_NPC_PROTO_FILE",
+            Path(self.tmp.name) / "npcs.json",
+        )
+        self.addCleanup(self.tmp.cleanup)
+        self.addCleanup(patcher.stop)
+        patcher.start()
+
+    def test_mstat_displays_stats(self):
+        prototypes.register_npc_prototype("orc", {"key": "orc", "desc": "mean"})
+        self.char1.execute_cmd("@mstat orc")
+        out = self.char1.msg.call_args[0][0]
+        assert "orc" in out
+        assert "mean" in out

--- a/typeclasses/tests/test_shop_repair_commands.py
+++ b/typeclasses/tests/test_shop_repair_commands.py
@@ -1,0 +1,39 @@
+from unittest.mock import MagicMock
+from tempfile import TemporaryDirectory
+from pathlib import Path
+from unittest import mock
+
+from django.test import override_settings
+from evennia.utils.test_resources import EvenniaTest
+
+from commands.admin import BuilderCmdSet
+from world import prototypes
+
+
+@override_settings(DEFAULT_HOME=None)
+class TestShopRepairCommands(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.char1.msg = MagicMock()
+        self.char1.cmdset.add_default(BuilderCmdSet)
+        self.tmp = TemporaryDirectory()
+        patcher = mock.patch.object(
+            prototypes,
+            "_NPC_PROTO_FILE",
+            Path(self.tmp.name) / "npcs.json",
+        )
+        self.addCleanup(self.tmp.cleanup)
+        self.addCleanup(patcher.stop)
+        patcher.start()
+
+    def test_shop_and_repair_setup(self):
+        self.char1.execute_cmd("@mcreate merchant")
+        self.char1.execute_cmd("@makeshop merchant")
+        self.char1.execute_cmd("@shopset merchant buy 120")
+        self.char1.execute_cmd("@makerepair merchant")
+        self.char1.execute_cmd("@repairset merchant cost 200")
+        reg = prototypes.get_npc_prototypes()
+        shop = reg["merchant"]["shop"]
+        repair = reg["merchant"]["repair"]
+        assert shop["buy_percent"] == 120
+        assert repair["cost_percent"] == 200


### PR DESCRIPTION
## Summary
- add tests for `@mcreate`
- add tests for `@mset`
- add tests for `@mstat`
- add tests for `@mlist`
- add tests for shop and repair shop creation

## Testing
- `evennia migrate`
- `pytest -q` *(fails: TestAdminCommands.test_carmor_tags_and_wear, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684656959f10832c9f9255465bff8f78