### PR TITLE
Allow configuration of NPC prototype file

### DIFF
--- a/server/conf/settings.py
+++ b/server/conf/settings.py
@@ -21,6 +21,7 @@ put secret game- or server-specific settings in secret_settings.py.
 
 # Use the defaults from Evennia unless explicitly overridden
 from evennia.settings_default import *
+from pathlib import Path
 
 ######################################################################
 # Evennia base server config
@@ -47,6 +48,9 @@ EXTRA_LAUNCHER_COMMANDS["xyzgrid"] = "evennia.contrib.grid.xyzgrid.launchcmd.xyz
 PROTOTYPE_MODULES += ["evennia.contrib.grid.xyzgrid.prototypes"]
 XYZROOM_PROTOTYPE_OVERRIDE = {"typeclass": "typeclasses.rooms.XYGridRoom"}
 # exits are stored as room.db.exits mappings
+
+# File used for storing NPC prototypes
+PROTOTYPE_NPC_FILE = Path(GAME_DIR) / "world" / "prototypes" / "npcs.json"
 
 
 # Clothing - https://www.evennia.com/docs/latest/Contribs/Contrib-Clothing.html#configuration

--- a/typeclasses/tests/test_mcreate_command.py
+++ b/typeclasses/tests/test_mcreate_command.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from unittest import mock
 
 from django.test import override_settings
+from django.conf import settings
 from evennia.utils.test_resources import EvenniaTest
 
 from commands.admin import BuilderCmdSet
@@ -18,8 +19,8 @@ class TestMCreateCommand(EvenniaTest):
         self.char1.cmdset.add_default(BuilderCmdSet)
         self.tmp = TemporaryDirectory()
         patcher = mock.patch.object(
-            prototypes,
-            "_NPC_PROTO_FILE",
+            settings,
+            "PROTOTYPE_NPC_FILE",
             Path(self.tmp.name) / "npcs.json",
         )
         self.addCleanup(self.tmp.cleanup)

--- a/typeclasses/tests/test_mlist_command.py
+++ b/typeclasses/tests/test_mlist_command.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from unittest import mock
 
 from django.test import override_settings
+from django.conf import settings
 from evennia.utils.test_resources import EvenniaTest
 
 from commands.admin import BuilderCmdSet
@@ -18,8 +19,8 @@ class TestMListCommand(EvenniaTest):
         self.char1.cmdset.add_default(BuilderCmdSet)
         self.tmp = TemporaryDirectory()
         patcher = mock.patch.object(
-            prototypes,
-            "_NPC_PROTO_FILE",
+            settings,
+            "PROTOTYPE_NPC_FILE",
             Path(self.tmp.name) / "npcs.json",
         )
         self.addCleanup(self.tmp.cleanup)

--- a/typeclasses/tests/test_mob_proto_commands.py
+++ b/typeclasses/tests/test_mob_proto_commands.py
@@ -3,6 +3,7 @@ from tempfile import TemporaryDirectory
 from pathlib import Path
 from evennia.utils.test_resources import EvenniaTest
 from django.test import override_settings
+from django.conf import settings
 from unittest import mock
 
 from commands.admin import BuilderCmdSet
@@ -17,8 +18,8 @@ class TestMobPrototypeCommands(EvenniaTest):
         self.char1.cmdset.add_default(BuilderCmdSet)
         self.tmp = TemporaryDirectory()
         patcher = mock.patch.object(
-            prototypes,
-            "_NPC_PROTO_FILE",
+            settings,
+            "PROTOTYPE_NPC_FILE",
             Path(self.tmp.name) / "npcs.json",
         )
         self.addCleanup(self.tmp.cleanup)

--- a/typeclasses/tests/test_mset_command.py
+++ b/typeclasses/tests/test_mset_command.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from unittest import mock
 
 from django.test import override_settings
+from django.conf import settings
 from evennia.utils.test_resources import EvenniaTest
 
 from commands.admin import BuilderCmdSet
@@ -18,8 +19,8 @@ class TestMSetCommand(EvenniaTest):
         self.char1.cmdset.add_default(BuilderCmdSet)
         self.tmp = TemporaryDirectory()
         patcher = mock.patch.object(
-            prototypes,
-            "_NPC_PROTO_FILE",
+            settings,
+            "PROTOTYPE_NPC_FILE",
             Path(self.tmp.name) / "npcs.json",
         )
         self.addCleanup(self.tmp.cleanup)

--- a/typeclasses/tests/test_mstat_command.py
+++ b/typeclasses/tests/test_mstat_command.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from unittest import mock
 
 from django.test import override_settings
+from django.conf import settings
 from evennia.utils.test_resources import EvenniaTest
 
 from commands.admin import BuilderCmdSet
@@ -18,8 +19,8 @@ class TestMStatCommand(EvenniaTest):
         self.char1.cmdset.add_default(BuilderCmdSet)
         self.tmp = TemporaryDirectory()
         patcher = mock.patch.object(
-            prototypes,
-            "_NPC_PROTO_FILE",
+            settings,
+            "PROTOTYPE_NPC_FILE",
             Path(self.tmp.name) / "npcs.json",
         )
         self.addCleanup(self.tmp.cleanup)

--- a/typeclasses/tests/test_shop_repair_commands.py
+++ b/typeclasses/tests/test_shop_repair_commands.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from unittest import mock
 
 from django.test import override_settings
+from django.conf import settings
 from evennia.utils.test_resources import EvenniaTest
 
 from commands.admin import BuilderCmdSet
@@ -18,8 +19,8 @@ class TestShopRepairCommands(EvenniaTest):
         self.char1.cmdset.add_default(BuilderCmdSet)
         self.tmp = TemporaryDirectory()
         patcher = mock.patch.object(
-            prototypes,
-            "_NPC_PROTO_FILE",
+            settings,
+            "PROTOTYPE_NPC_FILE",
             Path(self.tmp.name) / "npcs.json",
         )
         self.addCleanup(self.tmp.cleanup)

--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -492,14 +492,18 @@ DEER_ANTLER = {
 from typing import Dict
 import json
 from pathlib import Path
+from django.conf import settings
 
-_NPC_PROTO_FILE = Path(__file__).resolve().parent / "prototypes" / "npcs.json"
+
+def _npc_proto_file() -> Path:
+    """Return the path to the NPC prototype JSON file."""
+    return Path(settings.PROTOTYPE_NPC_FILE)
 
 
 def _load_npc_registry() -> Dict[str, dict]:
     """Return the stored NPC prototypes from the JSON file."""
     try:
-        with _NPC_PROTO_FILE.open("r") as f:
+        with _npc_proto_file().open("r") as f:
             return json.load(f)
     except FileNotFoundError:
         return {}
@@ -508,8 +512,9 @@ def _load_npc_registry() -> Dict[str, dict]:
 
 
 def _save_npc_registry(registry: Dict[str, dict]):
-    _NPC_PROTO_FILE.parent.mkdir(parents=True, exist_ok=True)
-    with _NPC_PROTO_FILE.open("w") as f:
+    path = _npc_proto_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w") as f:
         json.dump(registry, f, indent=4)
 
 


### PR DESCRIPTION
## Summary
- add `PROTOTYPE_NPC_FILE` setting to configure prototype storage location
- use `settings.PROTOTYPE_NPC_FILE` in `world/prototypes` functions
- adjust tests to patch the new setting

## Testing
- `pytest -q` *(fails: OperationalError - no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68465c2d85f4832cb492198e9e392703