### PR TITLE
Extend trigger events and docs

### DIFF
--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -2730,6 +2730,8 @@ Events:
     on_look    - someone looks at the NPC
     on_attack  - combat starts or damage occurs
     on_timer   - once every game tick
+    hour       - fires at a specific game hour
+    time       - fires at an exact HH:MM time
 
 Reactions:
     say <text>         - speak
@@ -2738,6 +2740,12 @@ Reactions:
     attack [target]    - attack a character
     script <module.fn> - call a Python function
     <command>          - run any other command string
+
+Conditions:
+    percent <pct>   - only run if a random roll succeeds
+    combat <0|1>    - requires the NPC be in or out of combat
+    bribe <amount>  - minimum coin value given
+    hp_pct <pct>    - fires below this health percent
 
 The match text only applies to some events like |won_speak|n and |won_look|n.
 Multiple triggers may be defined for the same event and each trigger can have
@@ -2751,6 +2759,9 @@ Examples:
         4) Finish
     Adding a trigger asks for event type, optional match text and the
     command that should run when the event occurs.
+
+Example:
+    {"on_attack": [{"hp_pct": 50, "response": "say I'm badly hurt!"}]}
 
 Related:
     help cnpc

--- a/world/tests/__init__.py
+++ b/world/tests/__init__.py
@@ -1,0 +1,7 @@
+import os
+import django
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "server.conf.settings")
+django.setup()
+import evennia
+if getattr(evennia, "SESSION_HANDLER", None) is None:
+    evennia._init()

--- a/world/tests/test_trigger_manager.py
+++ b/world/tests/test_trigger_manager.py
@@ -1,0 +1,55 @@
+from unittest.mock import MagicMock, patch
+import unittest
+from world.triggers import TriggerManager
+
+
+class Dummy:
+    def __init__(self):
+        self.db = type("DB", (), {})()
+        self.db.triggers = {}
+        self.execute_cmd = MagicMock()
+        self.traits = type("Traits", (), {})()
+        self.traits.health = type("Hp", (), {"value": 100, "max": 100})()
+        self.in_combat = False
+
+
+class TestTriggerManager(unittest.TestCase):
+    def setUp(self):
+        self.obj = Dummy()
+
+    @patch("world.triggers.randint", return_value=1)
+    def test_percent_condition(self, mock_rand):
+        self.obj.db.triggers["on_timer"] = [{"percent": 50, "response": "say hi"}]
+        TriggerManager(self.obj).check("on_timer")
+        self.obj.execute_cmd.assert_called_with("say hi")
+
+    def test_combat_condition(self):
+        self.obj.db.triggers["on_attack"] = [{"combat": True, "response": "say fight"}]
+        TriggerManager(self.obj).check("on_attack")
+        self.obj.execute_cmd.assert_not_called()
+        self.obj.execute_cmd.reset_mock()
+        self.obj.in_combat = True
+        TriggerManager(self.obj).check("on_attack")
+        self.obj.execute_cmd.assert_called_with("say fight")
+
+    def test_bribe_condition(self):
+        self.obj.db.triggers["on_bribe"] = [{"bribe": 10, "response": "say thanks"}]
+        TriggerManager(self.obj).check("on_bribe", amount=5)
+        self.obj.execute_cmd.assert_not_called()
+        self.obj.execute_cmd.reset_mock()
+        TriggerManager(self.obj).check("on_bribe", amount=15)
+        self.obj.execute_cmd.assert_called_with("say thanks")
+
+    def test_hp_pct_condition(self):
+        self.obj.db.triggers["on_attack"] = [{"hp_pct": 50, "response": "say hurt"}]
+        self.obj.traits.health.value = 60
+        TriggerManager(self.obj).check("on_attack")
+        self.obj.execute_cmd.assert_not_called()
+        self.obj.execute_cmd.reset_mock()
+        self.obj.traits.health.value = 40
+        TriggerManager(self.obj).check("on_attack")
+        self.obj.execute_cmd.assert_called_with("say hurt")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/world/triggers.py
+++ b/world/triggers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from importlib import import_module
 from typing import Any
+from random import randint
 
 from evennia.utils import make_iter, logger
 
@@ -93,6 +94,37 @@ class TriggerManager:
                         continue
                 elif str(match).lower() not in text.lower():
                     continue
+
+            # additional conditional checks
+            percent = trig.get("percent")
+            if percent is not None and randint(1, 100) > int(percent):
+                continue
+
+            combat = trig.get("combat")
+            if combat is not None and bool(getattr(self.obj, "in_combat", False)) != bool(combat):
+                continue
+
+            bribe = trig.get("bribe")
+            if bribe is not None and kwargs.get("amount", kwargs.get("bribe_amount", 0)) < bribe:
+                continue
+
+            hp_pct = trig.get("hp_pct")
+            if hp_pct is not None:
+                try:
+                    cur = self.obj.traits.health.value
+                    maxhp = self.obj.traits.health.max or 1
+                    if (cur / maxhp) * 100 > float(hp_pct):
+                        continue
+                except Exception:
+                    continue
+
+            hour = trig.get("hour")
+            if hour is not None and kwargs.get("hour") != hour:
+                continue
+
+            time_val = trig.get("time")
+            if time_val is not None and kwargs.get("time") != time_val:
+                continue
 
             responses = (
                 trig.get("responses")


### PR DESCRIPTION
## Summary
- add more trigger condition checks like percent chance, combat state, bribes, hp percent, hour and time
- document new trigger options
- test TriggerManager behaviour with new conditions

## Testing
- `pytest world/tests/test_trigger_manager.py -q`
- `pytest -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684665127af0832ca30896c837fd52ee