### PR TITLE
Enhance spellbook command

### DIFF
--- a/commands/spells.py
+++ b/commands/spells.py
@@ -5,7 +5,8 @@ from world.spells import SPELLS, Spell
 
 
 class CmdSpellbook(Command):
-    """View known spells."""
+    """View known spells or details about one spell."""
+
     key = "spells"
     aliases = ("spellbook",)
 
@@ -14,6 +15,30 @@ class CmdSpellbook(Command):
         if not known:
             self.msg("You do not know any spells.")
             return
+
+        # if an argument was given, try to show details about that spell
+        if self.args:
+            spell_key = self.args.strip().lower()
+            for entry in known:
+                if (isinstance(entry, str) and entry == spell_key) or (
+                    not isinstance(entry, str) and entry.key == spell_key
+                ):
+                    spell = SPELLS.get(spell_key)
+                    if not spell:
+                        continue
+                    prof = 0 if isinstance(entry, str) else getattr(entry, "proficiency", 0)
+                    msg = (
+                        f"|w{spell.key.capitalize()}|n\n"
+                        f"  Mana Cost: |w{spell.mana_cost}|n\n"
+                        f"  Proficiency: |w{prof}%|n"
+                    )
+                    if spell.desc:
+                        msg += f"\n  {spell.desc}"
+                    self.msg(msg)
+                    return
+            self.msg("You have not learned that spell.")
+            return
+
         table = EvTable("Spell", "Mana", "Proficiency")
         for entry in known:
             if isinstance(entry, str):

--- a/typeclasses/tests/test_spellbook_command.py
+++ b/typeclasses/tests/test_spellbook_command.py
@@ -1,0 +1,31 @@
+from unittest.mock import MagicMock
+from evennia.utils.test_resources import EvenniaTest
+from commands.spells import CmdSpellbook
+from world.spells import Spell
+
+class TestSpellbook(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        # give char1 a known spell
+        self.char1.db.spells = [Spell("fireball", "INT", 10, "A fiery blast.", 50)]
+        self.char1.msg = MagicMock()
+
+    def test_spellbook_lists_spells(self):
+        self.char1.execute_cmd("spells")
+        out = self.char1.msg.call_args[0][0]
+        self.assertIn("fireball", out)
+
+    def test_spellbook_specific_spell(self):
+        self.char1.msg = MagicMock()
+        self.char1.execute_cmd("spells fireball")
+        out = self.char1.msg.call_args[0][0]
+        self.assertIn("Fireball", out)
+        self.assertIn("Mana Cost", out)
+        self.assertIn("Proficiency", out)
+        self.assertIn("A fiery blast.", out)
+
+    def test_spellbook_unknown_spell(self):
+        self.char1.msg = MagicMock()
+        self.char1.execute_cmd("spells unknown")
+        out = self.char1.msg.call_args[0][0]
+        self.assertIn("not learned", out.lower())


### PR DESCRIPTION
## Summary
- expand `CmdSpellbook` to show details for a single spell
- add tests for the spellbook command

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68466850bb30832cac145f559313bb95