### PR TITLE
Add balance and transfer to banker role

### DIFF
--- a/typeclasses/tests/test_npc_roles_behavior.py
+++ b/typeclasses/tests/test_npc_roles_behavior.py
@@ -19,6 +19,7 @@ class TestNPCRoleBehaviors(EvenniaTest):
     def setUp(self):
         super().setUp()
         self.char1.msg = MagicMock()
+        self.char2.msg = MagicMock()
 
     def test_merchant_sell_transfers_item_and_coins(self):
         merchant = create.create_object(MerchantNPC, key="shopkeep", location=self.room1)
@@ -43,6 +44,25 @@ class TestNPCRoleBehaviors(EvenniaTest):
         banker.withdraw(self.char1, 5)
         self.assertEqual(to_copper(self.char1.db.coins), 15)
         self.assertEqual(self.char1.db.bank, 15)
+
+    def test_banker_balance_reports_funds(self):
+        banker = create.create_object(BankerNPC, key="teller", location=self.room1)
+        self.char1.db.coins = from_copper(50)
+        self.char1.db.bank = 25
+
+        banker.balance(self.char1)
+
+        self.char1.msg.assert_called_with("You have 50 Copper on hand and 25 coins in the bank.")
+
+    def test_banker_transfer_moves_funds(self):
+        banker = create.create_object(BankerNPC, key="clerk", location=self.room1)
+        self.char1.db.bank = 30
+        self.char2.db.bank = 10
+
+        banker.transfer(self.char1, self.char2, 20)
+
+        self.assertEqual(self.char1.db.bank, 10)
+        self.assertEqual(self.char2.db.bank, 30)
 
     def test_trainer_trains_skill_and_consumes_xp(self):
         trainer = create.create_object(TrainerNPC, key="trainer", location=self.room1)

--- a/world/npc_roles/banker.py
+++ b/world/npc_roles/banker.py
@@ -35,3 +35,37 @@ class BankerRole:
         wallet = withdrawer.db.coins or {}
         withdrawer.db.coins = from_copper(to_copper(wallet) + amount)
         withdrawer.msg(f"{self.key} gives you {amount} coins from your account.")
+
+    def balance(self, player) -> None:
+        """Report ``player``'s wallet and bank balance."""
+        if not player:
+            return
+
+        from utils.currency import format_wallet
+
+        wallet = player.db.coins or {}
+        bank = int(player.db.bank or 0)
+        player.msg(
+            f"You have {format_wallet(wallet)} on hand and {bank} coins in the bank."
+        )
+
+    def transfer(self, sender, receiver, amount: int) -> None:
+        """Move ``amount`` coins from ``sender`` to ``receiver``'s bank accounts."""
+        if not sender or not receiver or amount <= 0:
+            return
+
+        balance = int(sender.db.bank or 0)
+        if balance < amount:
+            sender.msg("You do not have that much saved.")
+            return
+
+        sender.db.bank = balance - amount
+        receiver.db.bank = int(receiver.db.bank or 0) + amount
+
+        sender.msg(
+            f"You transfer {amount} coins to {receiver.get_display_name(sender)} through {self.key}."
+        )
+        if receiver != sender:
+            receiver.msg(
+                f"{self.key} transfers {amount} coins to your account from {sender.get_display_name(receiver)}."
+            )


### PR DESCRIPTION
## Summary
- expand banker role with balance and transfer helpers
- verify new banker logic in tests

## Testing
- `pytest -q` *(fails: django.db.utils.OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68466b069d88832cbd0b12260660727e