### PR TITLE
Add banking help docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,17 @@ Typical uses for each coin are roughly:
 - **Gold** – quality equipment or costly services such as a house or mount.
 - **Platinum** – rare, high value purchases or very large transactions.
 
+Bankers can hold your coins for safekeeping. When near one, use the `bank`
+command to check your balance, deposit or withdraw funds, or transfer money to
+another player:
+
+```
+bank balance
+bank deposit <amount [coin]>
+bank withdraw <amount [coin]>
+bank transfer <amount [coin]> <player>
+```
+
 
 ## Installation and Setup
 

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -1831,6 +1831,41 @@ Related:
 """,
     },
     {
+        "key": "bank",
+        "category": "General",
+        "text": """Help for bank
+
+Handle your stored coins with a banker.
+
+Usage:
+    bank balance
+    bank deposit <amount [coin]>
+    bank withdraw <amount [coin]>
+    bank transfer <amount [coin]> <target>
+
+Switches:
+    None
+
+Arguments:
+    <amount> - number of coins
+    <coin> - copper, silver, gold or platinum
+    <target> - player to receive a transfer
+
+Examples:
+    bank deposit 50 silver
+    bank withdraw 10 gold
+    bank transfer 20 gold Bob
+
+Notes:
+    - Use while in the same room as a banker NPC.
+    - Deposits convert coins upward automatically.
+    - Withdrawals use higher denominations if necessary.
+
+Related:
+    help npc roles
+""",
+    },
+    {
         "key": "inventory",
         "category": "General",
         "text": """


### PR DESCRIPTION
## Summary
- add help entry for `bank` command
- document banking in README

## Testing
- `pytest -q` *(fails: no such table accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6846703b5598832cb09f9ef4034ea9e1