### PR TITLE
Fix mob builder confirm back handling

### DIFF
--- a/commands/mob_builder.py
+++ b/commands/mob_builder.py
@@ -531,7 +531,11 @@ def menunode_confirm(caller, raw_string="", **kwargs):
 def _do_confirm(caller, raw_string, **kwargs):
     string = raw_string.strip().lower()
     if string == "back":
-        if caller.ndb.mob_build.get("role") in ("merchant", "shop", "repair"):
+        if caller.ndb.mob_build and caller.ndb.mob_build.get("role") in (
+            "merchant",
+            "shop",
+            "repair",
+        ):
             return "menunode_shop"
         return "menunode_role"
     if string not in ("yes", "y", "done", ""):

--- a/typeclasses/tests/test_mob_builder.py
+++ b/typeclasses/tests/test_mob_builder.py
@@ -67,3 +67,9 @@ class TestMobBuilder(EvenniaTest):
         self.char1.execute_cmd("@mstat mob_goblin")
         out = self.char1.msg.call_args[0][0]
         assert "goblin" in out
+
+    def test_cancel_then_back(self):
+        """Cancelling confirm and then going back should not error."""
+        mob_builder._do_confirm(self.char1, "no")
+        result = mob_builder._do_confirm(self.char1, "back")
+        assert result == "menunode_role"


### PR DESCRIPTION
## Summary
- guard mob builder confirm logic for missing `mob_build`
- test cancel then back scenario

## Testing
- `pytest -q` *(fails: django.db.utils.OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6846876f8220832cab2243af496df5d1