### PR TITLE
Document mob builder usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,15 @@ Several basic NPC prototypes are included out of the box. Try `cnpc dev_spawn ba
 or `@spawnnpc basic_merchant` to quickly create a merchant, or `basic_questgiver` for a quest
 giver.
 
+### Mob Builder
+
+Run `mobbuilder` to launch a simplified prototype builder. The prompt walks
+through entering a key, description and stats. When confirmed, the data is
+saved to `world/prototypes/npcs.json` with `mob_` prefixed to the key.
+Use `@mspawn <prototype>` to create the NPC from the stored prototype and
+`@mstat <key>` to inspect the result or any existing NPC. Prototype entries can
+be adjusted with `@mcreate`, `@mset` and viewed with `@mlist`.
+
 ## Weapon Creation and Inspection
 
 Builders can quickly create melee weapons with the `cweapon` command.

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -2760,6 +2760,38 @@ Related:
 """,
     },
     {
+        "key": "mobbuilder",
+        "category": "Building",
+        "text": """Help for mobbuilder
+
+Start the basic NPC prototype builder. The menu asks for a key,
+description and stats and saves the prototype to
+`world/prototypes/npcs.json` with a `mob_` prefix.
+
+Usage:
+    mobbuilder
+
+Switches:
+    None
+
+Arguments:
+    None
+
+Examples:
+    mobbuilder
+
+Notes:
+    - Spawn a saved prototype with |w@mspawn <prototype>|n.
+    - Inspect prototypes or NPCs with |w@mstat <key>|n.
+    - Edit entries using |w@mcreate|n, |w@mset|n, |w@mlist|n and the
+      shop/repair helpers.
+
+Related:
+    help @mspawn
+    help @mstat
+""",
+    },
+    {
         "key": "triggers",
         "category": "Building",
         "text": """


### PR DESCRIPTION
## Summary
- add help entry for `mobbuilder`
- explain mobbuilder workflow in README

## Testing
- `pytest -q` *(fails: OperationalError no such table)*

------
https://chatgpt.com/codex/tasks/task_e_6846895f2dc0832c86ae53c98562be01