### PR TITLE
Fix npc builder back nav and add test

### DIFF
--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -97,7 +97,7 @@ def menunode_desc(caller, raw_string="", **kwargs):
     text = (
         "|wEnter a short description for the NPC|n "
         "(e.g. 'A grumpy orc')\n"
-        "Type |wback|n to return or |wskip|n to keep the current value."
+        "Type |wback|n to edit the key or |wskip|n to keep the current value."
     )
     if default:
         text += f" [default: {default}]"
@@ -108,7 +108,7 @@ def menunode_desc(caller, raw_string="", **kwargs):
 def _set_desc(caller, raw_string, **kwargs):
     string = raw_string.strip()
     if string.lower() == "back":
-        return "menunode_desc"
+        return "menunode_key"
     if not string or string.lower() == "skip":
         string = caller.ndb.buildnpc.get("desc", "")
     caller.ndb.buildnpc["desc"] = string

--- a/typeclasses/tests/test_cnpc.py
+++ b/typeclasses/tests/test_cnpc.py
@@ -176,3 +176,8 @@ class TestCNPC(EvenniaTest):
         self.char1.msg.assert_called()
         msg = self.char1.msg.call_args[0][0]
         self.assertIn("Error", msg)
+
+    def test_set_desc_back_returns_key(self):
+        """Entering 'back' at description should return to key prompt."""
+        result = npc_builder._set_desc(self.char1, "back")
+        self.assertEqual(result, "menunode_key")


### PR DESCRIPTION
## Summary
- fix npc description menu to go back to key prompt
- clarify help text when editing description
- test that `back` from description node returns to key entry

## Testing
- `pytest typeclasses/tests/test_cnpc.py::TestCNPC::test_set_desc_back_returns_key -q` *(fails: OperationalError - no such table)*

------
https://chatgpt.com/codex/tasks/task_e_684691d5c670832c8e5c362634f9a350