### PR TITLE
Add multiple reaction support for NPC triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,9 @@ classes include `BaseNPC`, `MerchantNPC`, `BankerNPC`, `TrainerNPC`,
 While editing, there's a step to manage triggers using a numbered menu. Choose
 `Add trigger` to create a new reaction, `Delete trigger` to remove one, `List
 triggers` to review them and `Finish` when done. Multiple trigger entries can be
-added for the same event. See the `triggers` help entry for the list of events
-and possible reactions.
+added for the same event. When entering a reaction you may separate several
+commands with commas or semicolons to store them as multiple responses. See the
+`triggers` help entry for the list of events and possible reactions.
 
 ### NPC Roles and AI
 
@@ -177,8 +178,8 @@ reaction may specify a `match` text and single or multiple `responses` to run::
     }
 
 During the builder you can add triggers one at a time. The example above shows
-how multiple responses can be combined in your prototype file if you edit it
-manually.
+how multiple responses can be combined in your prototype file or entered during
+the builder by separating commands with commas or semicolons.
 
 To spawn an NPC saved with an AI type and triggers, use:
 

--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -721,7 +721,7 @@ def menunode_trigger_list(caller, raw_string="", **kwargs):
                 if not isinstance(trig, dict):
                     continue
                 match = trig.get("match", "")
-                resp = trig.get("response", trig.get("reactions"))
+                resp = trig.get("responses", trig.get("response", trig.get("reactions")))
                 if isinstance(resp, list):
                     resp = ", ".join(resp)
                 text += f"{event}: \"{match}\" -> {resp}\n"
@@ -772,7 +772,7 @@ def _set_trigger_match(caller, raw_string, **kwargs):
     return "menunode_trigger_react"
 
 def menunode_trigger_react(caller, raw_string="", **kwargs):
-    text = "|wEnter reaction command|n"
+    text = "|wEnter reaction command(s) (comma or semicolon separated)|n"
     options = {"key": "_default", "goto": _save_trigger}
     return text, options
 
@@ -782,7 +782,9 @@ def _save_trigger(caller, raw_string, **kwargs):
     match = caller.ndb.trigger_match
     triggers = caller.ndb.buildnpc.setdefault("triggers", {})
     triglist = triggers.setdefault(event, [])
-    triglist.append({"match": match, "response": reaction})
+
+    responses = [part.strip() for part in re.split(r"[;,]", reaction) if part.strip()]
+    triglist.append({"match": match, "responses": responses})
     caller.ndb.trigger_event = None
     caller.ndb.trigger_match = None
     caller.msg("Trigger added.")
@@ -801,7 +803,7 @@ def menunode_trigger_delete(caller, raw_string="", **kwargs):
             if not isinstance(trig, dict):
                 continue
             match = trig.get("match", "")
-            resp = trig.get("response", trig.get("reactions"))
+            resp = trig.get("responses", trig.get("response", trig.get("reactions")))
             if isinstance(resp, list):
                 resp = ", ".join(resp)
             desc = f"{event}: \"{match}\" -> {resp}"
@@ -840,7 +842,7 @@ def menunode_confirm(caller, raw_string="", **kwargs):
                         if not isinstance(trig, dict):
                             continue
                         match = trig.get("match", "")
-                        resp = trig.get("response", trig.get("reactions"))
+                        resp = trig.get("responses", trig.get("response", trig.get("reactions")))
                         if isinstance(resp, list):
                             resp = ", ".join(resp)
                         text += f"trigger {event}: \"{match}\" -> {resp}\n"

--- a/typeclasses/tests/test_cnpc.py
+++ b/typeclasses/tests/test_cnpc.py
@@ -181,3 +181,16 @@ class TestCNPC(EvenniaTest):
         """Entering 'back' at description should return to key prompt."""
         result = npc_builder._set_desc(self.char1, "back")
         self.assertEqual(result, "menunode_key")
+
+    def test_save_trigger_multiple_responses(self):
+        self.char1.ndb.trigger_event = "on_test"
+        self.char1.ndb.trigger_match = "hello"
+        self.char1.ndb.buildnpc = {}
+
+        npc_builder._save_trigger(self.char1, "say hi, emote waves;jump")
+
+        triggers = self.char1.ndb.buildnpc.get("triggers")
+        self.assertIn("on_test", triggers)
+        trig = triggers["on_test"][0]
+        self.assertEqual(trig["match"], "hello")
+        self.assertEqual(trig["responses"], ["say hi", "emote waves", "jump"])


### PR DESCRIPTION
## Summary
- allow npc_builder to parse comma or semicolon separated reactions
- display reactions as lists and update builder instructions
- document new trigger syntax and builder usage
- test that `_save_trigger` stores multiple responses

## Testing
- `pytest -q` *(fails: various tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_684693fcf99c832c85660ddb62774da5