### PR TITLE
Fix README NPC builder commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,10 +116,10 @@ If you wind up having any issues or questions working with Evennia, [the Discord
 
 ### NPC Creation Menu
 
-You can quickly set up non-player characters using `@cnpc start <key>` (alias
-`@createnpc`). This opens an interactive menu where you enter the description,
+You can quickly set up non-player characters using `cnpc start <key>` (alias
+`createnpc`). This opens an interactive menu where you enter the description,
 type, level and other details. Follow the prompts, review the summary at the end
-and confirm to create your NPC. You can later update them with `@cnpc edit
+and confirm to create your NPC. You can later update them with `cnpc edit
 <npc>`.
 
 See the `cnpc` help entry for a full breakdown of every menu option.


### PR DESCRIPTION
## Summary
- correct command names in the NPC creation section

## Testing
- `python -m pip install --upgrade pip` *(fails: cannot connect to proxy)*
- `pip install -r requirements-test.txt` *(fails: invalid requirement)*
- `pytest -q` *(fails: OperationalError, missing tables)*

------
https://chatgpt.com/codex/tasks/task_e_68469ccd9b84832c90686f27e2882198