### PR TITLE
Add medit command

### DIFF
--- a/commands/admin.py
+++ b/commands/admin.py
@@ -38,7 +38,7 @@ from .mob_builder_commands import (
     CmdRepairSet,
     CmdRepairStat,
 )
-from .mob_builder import CmdMobBuilder, CmdMSpawn, CmdMStat, CmdMList
+from .mob_builder import CmdMobBuilder, CmdMSpawn, CmdMStat, CmdMList, CmdMedit
 
 
 def _safe_split(text):
@@ -1381,6 +1381,7 @@ class BuilderCmdSet(CmdSet):
         self.add(CmdRemoveFlag)
         self.add(CmdCNPC)
         self.add(CmdEditNPC)
+        self.add(CmdMedit)
         self.add(CmdDeleteNPC)
         self.add(CmdCloneNPC)
         self.add(CmdSpawnNPC)

--- a/commands/mob_builder.py
+++ b/commands/mob_builder.py
@@ -3,6 +3,8 @@
 from evennia.utils.evmenu import EvMenu
 from evennia.prototypes import spawner
 from world import prototypes
+from typeclasses.characters import NPC
+from . import npc_builder
 
 from .command import Command
 from .mob_builder_commands import CmdMStat as _OldMStat, CmdMList as _OldMList
@@ -54,3 +56,23 @@ class CmdMStat(_OldMStat):
 
 class CmdMList(_OldMList):
     pass
+
+
+class CmdMedit(Command):
+    """Edit an NPC and optionally update its prototype."""
+
+    key = "@medit"
+    locks = "cmd:perm(Builder)"
+    help_category = "Building"
+
+    def func(self):
+        if not self.args:
+            self.msg("Usage: @medit <npc>")
+            return
+        npc = self.caller.search(self.args.strip(), global_search=True)
+        if not npc or not npc.is_typeclass(NPC, exact=False):
+            self.msg("Invalid NPC.")
+            return
+        data = npc_builder._gather_npc_data(npc)
+        self.caller.ndb.buildnpc = data
+        EvMenu(self.caller, "commands.npc_builder", startnode="menunode_desc")

--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -3,6 +3,7 @@ from evennia.utils import make_iter, dedent
 from evennia import create_object
 from evennia.objects.models import ObjectDB
 from evennia.prototypes import spawner
+from evennia.prototypes.prototypes import PROTOTYPE_TAG_CATEGORY
 from typeclasses.characters import NPC
 from utils.slots import SLOT_ORDER
 from utils.menu_utils import add_back_skip
@@ -920,8 +921,9 @@ def _create_npc(caller, raw_string, register=False, **kwargs):
     if register:
         from world import prototypes
 
-        proto = {k: v for k, v in data.items() if k != "edit_obj"}
-        prototypes.register_npc_prototype(data.get("key"), proto)
+        proto_key = data.get("proto_key", data.get("key"))
+        proto = {k: v for k, v in data.items() if k not in ("edit_obj", "proto_key")}
+        prototypes.register_npc_prototype(proto_key, proto)
         caller.msg(f"NPC {npc.key} created and prototype saved.")
     else:
         caller.msg(f"NPC {npc.key} created.")
@@ -938,6 +940,7 @@ def _gather_npc_data(npc):
     """Return a dict of editable NPC attributes."""
     return {
         "edit_obj": npc,
+        "proto_key": npc.tags.get(category=PROTOTYPE_TAG_CATEGORY),
         "key": npc.key,
         "desc": npc.db.desc,
         "npc_type": npc.tags.get(category="npc_type") or "",


### PR DESCRIPTION
## Summary
- add `CmdMedit` for editing NPCs via the builder
- include proto_key support in `_gather_npc_data`
- save to the original prototype when registering changes
- register `CmdMedit` in the admin cmdset

## Testing
- `python -m py_compile commands/npc_builder.py commands/mob_builder.py commands/admin.py`
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6846a000f8a0832c96f36a0b6c7b61f4