### PR TITLE
Add NPC loot table system

### DIFF
--- a/commands/mob_builder_commands.py
+++ b/commands/mob_builder_commands.py
@@ -1,4 +1,5 @@
 import shlex
+import json
 
 from typeclasses.npcs import BaseNPC
 from evennia.utils import evtable
@@ -156,6 +157,7 @@ class CmdMSet(Command):
         "attack_types": lambda s: [f.value for f in parse_flag_list(s, ATTACK_TYPES)],
         "defense_types": lambda s: [f.value for f in parse_flag_list(s, DEFENSE_TYPES)],
         "special_funcs": lambda s: [f.value for f in parse_flag_list(s, SPECIAL_FUNCS)],
+        "loot_table": json.loads,
     }
 
     def parse(self):

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -872,8 +872,15 @@ class NPC(Character):
 
         if self.traits.health.value <= 0:
             # we've been defeated!
-            # create loot drops
-            objs = spawn(*list(self.db.drops))
+            drops = list(self.db.drops)
+            if loot_table := self.db.loot_table:
+                for entry in loot_table:
+                    proto = entry.get("proto")
+                    chance = int(entry.get("chance", 100))
+                    if proto and randint(1, 100) <= chance:
+                        drops.append(proto)
+
+            objs = spawn(*drops)
             for obj in objs:
                 obj.location = self.location
             # delete ourself

--- a/typeclasses/tests/test_loot_table.py
+++ b/typeclasses/tests/test_loot_table.py
@@ -1,0 +1,16 @@
+from unittest.mock import patch, MagicMock
+from evennia.utils import create
+from evennia.utils.test_resources import EvenniaTest
+
+class TestNPCLootTable(EvenniaTest):
+    def test_loot_table_spawn(self):
+        from typeclasses.characters import NPC
+
+        npc = create.create_object(NPC, key="mob", location=self.room1)
+        npc.db.drops = []
+        npc.db.loot_table = [{"proto": "RAW_MEAT", "chance": 100}]
+        npc.traits.health.current = 1
+        with patch("evennia.prototypes.spawner.spawn", return_value=[MagicMock()]) as mock_spawn:
+            npc.at_damage(self.char1, 2)
+            mock_spawn.assert_called_with("RAW_MEAT")
+

--- a/typeclasses/tests/test_mset_command.py
+++ b/typeclasses/tests/test_mset_command.py
@@ -32,3 +32,11 @@ class TestMSetCommand(EvenniaTest):
         self.char1.execute_cmd('@mset orc desc "Fierce orc"')
         reg = prototypes.get_npc_prototypes()
         assert reg["orc"]["desc"] == "Fierce orc"
+
+    def test_mset_loot_table(self):
+        prototypes.register_npc_prototype("wolf", {"key": "wolf"})
+        self.char1.execute_cmd('@mset wolf loot_table "[{\\"proto\\": \\"RAW_MEAT\\", \\"chance\\": 80}]"')
+        reg = prototypes.get_npc_prototypes()
+        table = reg["wolf"]["loot_table"]
+        assert table[0]["proto"] == "RAW_MEAT"
+        assert table[0]["chance"] == 80

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -3010,4 +3010,32 @@ Usage:
     learn
 """,
     },
+    {
+        "key": "loot tables",
+        "aliases": ["loottable", "loot"],
+        "category": "Building",
+        "text": """Help for loot tables
+
+Loot tables control random item drops from NPCs. Each entry is a mapping with
+the prototype key and drop chance::
+
+    [{"proto": "RAW_MEAT", "chance": 50}]
+
+Set ``loot_table`` on an NPC prototype with |w@mset|n using JSON syntax.
+
+Usage:
+    @mset <proto> loot_table <json>
+
+Examples:
+    @mset wolf loot_table "[{\"proto\": \"RAW_MEAT\", \"chance\": 75}]"
+    @mset bandit loot_table "[{\"proto\": \"IRON_SWORD\", \"chance\": 25}]"
+
+Notes:
+    - ``chance`` is a percent from 1-100.
+    - Items with 100% chance always drop.
+
+Related:
+    help cnpc
+""",
+    },
 ]

--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -485,6 +485,15 @@ DEER_ANTLER = {
     ],
 }
 
+# Example loot table entry structure. A loot table is stored on
+# ``npc.db.loot_table`` as a list of mappings with the prototype key and the
+# percent chance to drop that prototype when the NPC dies.
+# Example::
+#
+#     [{"proto": "RAW_MEAT", "chance": 50}, {"proto": "ANIMAL_HIDE", "chance": 25}]
+
+EXAMPLE_LOOT_TABLE = [{"proto": "RAW_MEAT", "chance": 50}]
+
 # ------------------------------------------------------------
 # NPC prototype registry utilities
 # ------------------------------------------------------------


### PR DESCRIPTION
## Summary
- support JSON loot tables for NPC prototypes
- roll on loot tables when NPCs die
- document loot table usage in help
- test loot table editing and spawning

## Testing
- `pytest -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6846a3483e40832ca8ff5f7e2bcfda47