### PR TITLE
Add assist/help flags and AI behavior

### DIFF
--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -507,7 +507,7 @@ def menunode_actflags(caller, raw_string="", **kwargs):
     if default:
         text += f" [default: {' '.join(default)}]"
     text += f"\nAvailable: {flags}"
-    text += "\nExample: |wsentinel aggressive|n"
+    text += "\nExample: |wsentinel aggressive assist call_for_help|n"
     text += "\n(back to go back, skip for default)"
     options = add_back_skip({"key": "_default", "goto": _set_actflags}, _set_actflags)
     return text, options

--- a/world/mob_constants.py
+++ b/world/mob_constants.py
@@ -59,6 +59,8 @@ class ACTFLAGS(_StrEnum):
     AGGRESSIVE = "aggressive"
     STAY_AREA = "stay_area"
     WIMPY = "wimpy"
+    ASSIST = "assist"
+    CALL_FOR_HELP = "call_for_help"
 
 
 class AFFECTED_BY(_StrEnum):

--- a/world/prototypes/npcs.json
+++ b/world/prototypes/npcs.json
@@ -5,7 +5,8 @@
         "npc_class": "merchant",
         "npc_type": "merchant",
         "ai_type": "passive",
-        "level": 1
+        "level": 1,
+        "actflags": ["call_for_help"]
     },
     "basic_questgiver": {
         "key": "quest giver",
@@ -13,7 +14,8 @@
         "npc_class": "questgiver",
         "npc_type": "questgiver",
         "ai_type": "passive",
-        "level": 1
+        "level": 1,
+        "actflags": ["call_for_help"]
     },
     "basic_guard": {
         "key": "town guard",
@@ -21,6 +23,7 @@
         "npc_class": "base",
         "npc_type": "guard",
         "ai_type": "defensive",
-        "level": 1
+        "level": 1,
+        "actflags": ["assist", "call_for_help"]
     }
 }


### PR DESCRIPTION
## Summary
- expand ACTFLAGS with assist & call_for_help
- allow specifying these flags via NPC builder
- make AI react to assist/call_for_help flags
- store flags in default NPC prototypes
- test AI helper behaviour

## Testing
- `evennia migrate`
- `pytest typeclasses/tests/test_npc_ai.py::TestAIBehaviors::test_assist_flag_attacks_leader_target typeclasses/tests/test_npc_ai.py::TestAIBehaviors::test_call_for_help_summons_allies -q` *(fails: expected call not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846a76dd914832ca1c25a963778ba08