### PR TITLE
Add mob script attachment support

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,11 @@ either a Python import path or a direct function reference. Example::
 
     npc.db.ai_script = "scripts.example_ai.patrol_ai"
 
+You can also attach full Script typeclasses to mobs. After selecting languages in
+the mob builder you will be prompted for a script path such as
+``scripts.bandit_ai.BanditAI``. When saved as a prototype this is stored under
+``scripts`` and automatically started when the mob spawns.
+
 ### Trigger Syntax
 
 NPC triggers use a dictionary mapping events to one or more reaction entries. A

--- a/commands/mob_builder.py
+++ b/commands/mob_builder.py
@@ -23,6 +23,7 @@ class CmdMobBuilder(Command):
             "npc_class": "base",
             "roles": [],
             "merchant_markup": 1.0,
+            "script": "",
             "use_mob": True,
         }
         EvMenu(self.caller, "commands.npc_builder", startnode="menunode_key")

--- a/scripts/bandit_ai.py
+++ b/scripts/bandit_ai.py
@@ -1,0 +1,29 @@
+from random import choice
+from typeclasses.scripts import Script
+
+class BanditAI(Script):
+    """Roams around and attacks weaker players."""
+
+    def at_script_creation(self):
+        self.key = "bandit_ai"
+        self.desc = "Bandit combat behavior"
+        self.interval = 5
+        self.persistent = True
+
+    def at_repeat(self):
+        npc = self.obj
+        if not npc or not npc.location:
+            return
+        if npc.in_combat:
+            return
+        # look for an easy target
+        for obj in npc.location.contents:
+            if obj.has_account and obj.db.level and npc.db.level:
+                if obj.db.level < npc.db.level:
+                    npc.execute_cmd(f"kill {obj.key}")
+                    return
+        # wander if no target
+        exits = npc.location.contents_get(content_type="exit")
+        if exits:
+            exit_obj = choice(exits)
+            exit_obj.at_traverse(npc, exit_obj.destination)

--- a/scripts/guard_patrol.py
+++ b/scripts/guard_patrol.py
@@ -1,0 +1,33 @@
+from random import choice
+from typeclasses.scripts import Script
+
+class GuardPatrol(Script):
+    """Walk a patrol path and attack wanted players."""
+
+    def at_script_creation(self):
+        self.key = "guard_patrol"
+        self.desc = "Guard patrol behavior"
+        self.interval = 10
+        self.persistent = True
+        self.db.patrol = []
+        self.db.index = 0
+
+    def at_repeat(self):
+        npc = self.obj
+        if not npc or not npc.location:
+            return
+        for obj in npc.location.contents:
+            if obj.tags.get("wanted"):
+                npc.execute_cmd(f"kill {obj.key}")
+                return
+        path = self.db.patrol
+        if path:
+            exit_name = path[self.db.index % len(path)]
+            self.db.index = (self.db.index + 1) % len(path)
+            exit_obj = npc.search(exit_name, location=npc.location)
+            if exit_obj:
+                exit_obj.at_traverse(npc, exit_obj.destination)
+        else:
+            exits = npc.location.contents_get(content_type="exit")
+            if exits:
+                choice(exits).at_traverse(npc, exits[0].destination)

--- a/scripts/merchant_logic.py
+++ b/scripts/merchant_logic.py
@@ -1,0 +1,20 @@
+from datetime import datetime
+from typeclasses.scripts import Script
+
+class MerchantLogic(Script):
+    """Restock goods and refuse trade at night."""
+
+    def at_script_creation(self):
+        self.key = "merchant_logic"
+        self.desc = "Merchant restocking behavior"
+        self.interval = 60
+        self.persistent = True
+
+    def at_repeat(self):
+        npc = self.obj
+        if not npc:
+            return
+        hour = datetime.now().hour
+        npc.db.closed = hour < 6
+        if hasattr(npc, "restock"):
+            npc.restock()

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -2772,6 +2772,7 @@ Invokes the same menu-driven builder as |wcnpc|n but instead of creating the
 NPC immediately it stores the result as a prototype prefixed with ``mob_``.
 Additional mob-specific fields such as act flags and resistances may be set
 while stepping through the menu.
+You can also specify a Script typeclass to attach after the languages step.
 
 Usage:
     mobbuilder


### PR DESCRIPTION
## Summary
- extend mob builder to attach script path via new step
- save script in prototypes and add on creation
- gather existing script when editing NPCs
- add example scripts for bandit, merchant and guard
- document attaching scripts in README and help

## Testing
- `pytest -q` *(fails: OperationalError no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6846b6092e50832c8494298439e0f13f