### PR TITLE
Add visibility helper and room filtering

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -159,6 +159,38 @@ class Character(ObjectParent, ClothedCharacter):
             return "Encumbered (Moderate)"
         return "Encumbered (Severe)"
 
+    # -------------------------------------------------------------
+    # Visibility helpers
+    # -------------------------------------------------------------
+
+    def can_see(self, target) -> bool:
+        """Return ``True`` if ``self`` can see ``target``."""
+
+        if target == self:
+            return True
+
+        # blindness overrides everything
+        if self.tags.get("blind", category="status"):
+            return False
+
+        # check room darkness
+        location = getattr(self, "location", None)
+        if location and location.tags.get("dark", category="status"):
+            if not self.tags.get("infrared", category="status"):
+                return False
+
+        # invisible targets require detect_invis
+        if target.tags.get("invisible", category="status"):
+            if not self.tags.get("detect_invis", category="status"):
+                return False
+
+        # hidden targets require detect_hidden
+        if target.tags.get("hidden", category="status"):
+            if not self.tags.get("detect_hidden", category="status"):
+                return False
+
+        return True
+
     def defense(self, damage_type=None):
         """
         Get the total armor defense from equipped items and natural defenses

--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -134,7 +134,14 @@ class RoomParent(ObjectParent):
             text += f"\n{exits}"
 
         visible = (
-            obj for obj in self.contents if obj != looker and obj.access(looker, "view")
+            obj
+            for obj in self.contents
+            if obj != looker
+            and obj.access(looker, "view")
+            and (
+                not hasattr(looker, "can_see")
+                or looker.can_see(obj)
+            )
         )
 
         env_objects, npcs, items, players = [], [], [], []

--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -502,6 +502,19 @@ class TestReturnAppearance(EvenniaTest):
         self.assertIn("|wExits:|n", output)
         self.assertIn(self.room1.key, output)
 
+    def test_invisible_objects_hidden(self):
+        from evennia.utils import create
+
+        obj = create.create_object("typeclasses.objects.Object", key="ghost", location=self.room1)
+        obj.tags.add("invisible", category="status")
+
+        out = self.room1.return_appearance(self.char1)
+        self.assertNotIn("ghost", out)
+
+        self.char1.tags.add("detect_invis", category="status")
+        out = self.room1.return_appearance(self.char1)
+        self.assertIn("ghost", out)
+
 
 class TestRestCommands(EvenniaTest):
     def setUp(self):


### PR DESCRIPTION
## Summary
- add `can_see` helper on Character for visibility checks
- filter Room return_appearance using new visibility logic
- test that invisible objects remain hidden until `detect_invis`

## Testing
- `pytest -q` *(fails: ImportError: No module named 'evennia')*

------
https://chatgpt.com/codex/tasks/task_e_6846ba360330832c8c96687270141dcf