### PR TITLE
Add mlist filtering and live NPC listing

### DIFF
--- a/commands/README.md
+++ b/commands/README.md
@@ -72,8 +72,9 @@ spawned later with `@spawnnpc`. These commands help you manage the prototypes:
 * `@mset <key> <field> <value>` – update a field on a prototype. Valid races,
   classes and flag names can be found in `world/mob_constants.py`.
 * `@mstat <key>` – view the details of a prototype or an existing NPC.
-* `@mlist [area] [range]` – list prototype keys, optionally limited to an area
-  or a numeric/letter range.
+* `@mlist [/room|/area] [filters]` – list prototypes or spawned NPCs. Filters can
+  include `class=<val>`, `race=<val>`, `role=<val>`, `tag=<val>`, `zone=<name>`,
+  an area name or a numeric/letter range.
 
 Example:
 

--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -1165,12 +1165,16 @@ class CmdSpawnNPC(Command):
                 return
             proto = prototypes.get_npc_prototypes().get(key)
         else:
+            key = arg
             proto = prototypes.get_npc_prototypes().get(arg)
         if not proto:
             self.msg("Unknown NPC prototype.")
             return
         obj = spawner.spawn(proto)[0]
         obj.move_to(self.caller.location, quiet=True)
+        obj.db.prototype_key = key
+        obj.db.area_tag = self.caller.location.db.area
+        obj.db.spawn_room = self.caller.location
         self.msg(f"Spawned {obj.get_display_name(self.caller)}.")
 
 

--- a/scripts/area_spawner.py
+++ b/scripts/area_spawner.py
@@ -43,3 +43,6 @@ class AreaSpawner(Script):
             return
         npc = spawner.spawn(proto)[0]
         npc.location = room
+        npc.db.prototype_key = proto_key
+        npc.db.area_tag = area
+        npc.db.spawn_room = room

--- a/typeclasses/tests/test_mlist_command.py
+++ b/typeclasses/tests/test_mlist_command.py
@@ -36,3 +36,41 @@ class TestMListCommand(EvenniaTest):
         assert "alpha" in out
         assert "bravo" in out
         assert "charlie" not in out
+
+    def test_prototype_filtering(self):
+        prototypes.register_npc_prototype(
+            "orc_warrior",
+            {"key": "orc warrior", "npc_class": "warrior", "race": "orc", "roles": ["guard"]},
+        )
+        prototypes.register_npc_prototype(
+            "elf_mage",
+            {"key": "elf mage", "npc_class": "mage", "race": "elf", "roles": ["questgiver"]},
+        )
+        res = prototypes.get_npc_prototypes({"class": "warrior"})
+        assert list(res.keys()) == ["orc_warrior"]
+        res = prototypes.get_npc_prototypes({"race": "elf"})
+        assert list(res.keys()) == ["elf_mage"]
+        res = prototypes.get_npc_prototypes({"role": "guard"})
+        assert list(res.keys()) == ["orc_warrior"]
+
+    def test_mlist_room_and_area(self):
+        proto = {
+            "key": "goblin",
+            "npc_class": "warrior",
+            "level": 1,
+            "typeclass": "typeclasses.npcs.BaseNPC",
+        }
+        prototypes.register_npc_prototype("gob", proto)
+        self.char1.execute_cmd("@spawnnpc gob")
+        self.char1.execute_cmd("@mlist /room")
+        out = self.char1.msg.call_args[0][0]
+        assert "gob" in out
+        self.char1.location.set_area("test", 1)
+        self.char1.execute_cmd("dig north test 2")
+        self.char1.location.db.exits.get("north")
+        self.char1.execute_cmd("north")
+        self.char1.execute_cmd("@spawnnpc gob")
+        self.char1.execute_cmd("south")
+        self.char1.execute_cmd("@mlist /area")
+        out = self.char1.msg.call_args[0][0]
+        assert "gob" in out

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -2779,7 +2779,7 @@ Usage:
 
 Notes:
     - Edit saved prototypes with |w@mcreate|n or |w@mset|n and review them
-      using |w@mlist|n.
+      using |w@mlist|n. See |whelp @mlist|n for filtering options.
     - Spawn a stored prototype with |w@mspawn <prototype>|n.
     - Inspect prototypes or NPCs with |w@mstat <key>|n.
 


### PR DESCRIPTION
## Summary
- support filtering npc prototypes and listing live spawns
- tag spawned NPCs with prototype information
- implement helper `get_npc_prototypes(filter_by)`
- document new `@mlist` options
- test filtering and live list functionality

## Testing
- `pytest -q typeclasses/tests/test_mlist_command.py::TestMListCommand::test_mlist_room_and_area -q`
- `pytest -q typeclasses/tests/test_mlist_command.py::TestMListCommand::test_prototype_filtering -q`


------
https://chatgpt.com/codex/tasks/task_e_6846bce26438832c9fb727adfe4b5f4a