### PR TITLE
Add NPC spawn metadata and search utils

### DIFF
--- a/typeclasses/tests/test_spawnnpc.py
+++ b/typeclasses/tests/test_spawnnpc.py
@@ -1,7 +1,10 @@
 from unittest.mock import MagicMock
 from evennia.utils.test_resources import EvenniaTest
 from commands.admin import BuilderCmdSet
-from typeclasses.npcs import MerchantNPC
+from unittest.mock import patch
+from typeclasses.npcs import MerchantNPC, BaseNPC
+from scripts.area_spawner import AreaSpawner
+from world import area_npcs
 
 
 class TestSpawnNPCPrototype(EvenniaTest):
@@ -9,6 +12,7 @@ class TestSpawnNPCPrototype(EvenniaTest):
         super().setUp()
         self.char1.msg = MagicMock()
         self.char1.cmdset.add_default(BuilderCmdSet)
+        self.char1.location.db.area = "testarea"
 
     def _find(self, key):
         for obj in self.char1.location.contents:
@@ -23,3 +27,20 @@ class TestSpawnNPCPrototype(EvenniaTest):
         self.assertTrue(npc.is_typeclass(MerchantNPC, exact=False))
         self.assertTrue(npc.tags.has("merchant", category="npc_type"))
         self.assertEqual(npc.db.ai_type, "passive")
+        self.assertEqual(npc.db.prototype_key, "basic_merchant")
+        self.assertIs(npc.db.spawn_room, self.char1.location)
+        self.assertEqual(npc.db.area_tag, "testarea")
+
+    @patch("scripts.area_spawner.choice", return_value="basic_merchant")
+    @patch("scripts.area_spawner.randint", return_value=1)
+    def test_area_spawner_sets_attributes(self, mock_randint, mock_choice):
+        area_npcs.add_area_npc("testarea", "basic_merchant")
+        script = self.char1.location.scripts.add(
+            AreaSpawner, key="area_spawner", autostart=False
+        )
+        script.db.spawn_chance = 100
+        script.at_repeat()
+        npc = [o for o in self.char1.location.contents if o.is_typeclass(BaseNPC, exact=False)][0]
+        self.assertEqual(npc.db.prototype_key, "basic_merchant")
+        self.assertIs(npc.db.spawn_room, self.char1.location)
+        self.assertEqual(npc.db.area_tag, "testarea")

--- a/world/area_npcs.py
+++ b/world/area_npcs.py
@@ -1,5 +1,7 @@
 from typing import Dict, List
 from evennia.server.models import ServerConfig
+from evennia.objects.models import ObjectDB
+from typeclasses.npcs import BaseNPC
 
 _REGISTRY_KEY = "area_npc_registry"
 
@@ -39,3 +41,15 @@ def remove_area_npc(area: str, proto_key: str):
         else:
             reg.pop(key, None)
         _save_registry(reg)
+
+
+def find_npcs_by_prototype(proto_key: str):
+    """Return live NPCs spawned from ``proto_key``."""
+    objs = ObjectDB.objects.get_by_attribute(key="prototype_key", value=proto_key)
+    return [obj for obj in objs if obj.is_typeclass(BaseNPC, exact=False)]
+
+
+def find_npcs_by_area(area_tag: str):
+    """Return live NPCs with ``db.area_tag`` matching ``area_tag``."""
+    objs = ObjectDB.objects.get_by_attribute(key="area_tag", value=area_tag)
+    return [obj for obj in objs if obj.is_typeclass(BaseNPC, exact=False)]

--- a/world/tests/test_npc_search.py
+++ b/world/tests/test_npc_search.py
@@ -1,0 +1,17 @@
+from evennia.utils import create
+from evennia.utils.test_resources import EvenniaTest
+from typeclasses.npcs import BaseNPC
+from world import area_npcs
+
+
+class TestNPCSearchUtilities(EvenniaTest):
+    def test_search_by_prototype_and_area(self):
+        npc = create.create_object(BaseNPC, key="mob", location=self.room1)
+        npc.db.prototype_key = "goblin"
+        npc.db.area_tag = "dungeon"
+
+        by_proto = area_npcs.find_npcs_by_prototype("goblin")
+        self.assertIn(npc, by_proto)
+
+        by_area = area_npcs.find_npcs_by_area("dungeon")
+        self.assertIn(npc, by_area)


### PR DESCRIPTION
## Summary
- store `prototype_key`, `spawn_room`, and `area_tag` on spawned NPCs
- search for NPCs by prototype or area
- test spawn attribute assignment and search helpers

## Testing
- `pytest -q` *(fails: OperationalError – no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6846c160d580832c9c2f8fc611fc4ae6