### PR TITLE
Add prototype filter helper

### DIFF
--- a/commands/mob_builder_commands.py
+++ b/commands/mob_builder_commands.py
@@ -249,7 +249,9 @@ class CmdMList(Command):
             if not area:
                 area = part
 
-        registry = prototypes.get_npc_prototypes(filter_by)
+        all_reg = prototypes.get_npc_prototypes()
+        registry_list = prototypes.filter_npc_prototypes(all_reg, filter_by)
+        registry = dict(registry_list)
 
         if show_room or show_area:
             if show_room:

--- a/typeclasses/tests/test_mlist_command.py
+++ b/typeclasses/tests/test_mlist_command.py
@@ -44,14 +44,23 @@ class TestMListCommand(EvenniaTest):
         )
         prototypes.register_npc_prototype(
             "elf_mage",
-            {"key": "elf mage", "npc_class": "mage", "race": "elf", "roles": ["questgiver"]},
+            {
+                "key": "elf mage",
+                "npc_class": "mage",
+                "race": "elf",
+                "roles": ["questgiver"],
+                "tags": ["caster"],
+            },
         )
-        res = prototypes.get_npc_prototypes({"class": "warrior"})
-        assert list(res.keys()) == ["orc_warrior"]
-        res = prototypes.get_npc_prototypes({"race": "elf"})
-        assert list(res.keys()) == ["elf_mage"]
-        res = prototypes.get_npc_prototypes({"role": "guard"})
-        assert list(res.keys()) == ["orc_warrior"]
+        reg = prototypes.get_npc_prototypes()
+        res = prototypes.filter_npc_prototypes(reg, {"class": "warrior"})
+        assert [k for k, _ in res] == ["orc_warrior"]
+        res = prototypes.filter_npc_prototypes(reg, {"race": "elf"})
+        assert [k for k, _ in res] == ["elf_mage"]
+        res = prototypes.filter_npc_prototypes(reg, {"role": "guard"})
+        assert [k for k, _ in res] == ["orc_warrior"]
+        res = prototypes.filter_npc_prototypes(reg, {"tag": "caster"})
+        assert [k for k, _ in res] == ["elf_mage"]
 
     def test_mlist_room_and_area(self):
         proto = {

--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -588,3 +588,47 @@ def register_npc_prototype(key: str, prototype: dict):
     registry = _load_npc_registry()
     registry[key] = prototype
     _save_npc_registry(registry)
+
+
+def filter_npc_prototypes(protos: dict, filters: dict) -> list[tuple[str, dict]]:
+    """Return ``protos`` entries matching ``filters``.
+
+    Args:
+        protos (dict): Mapping of key -> prototype data.
+        filters (dict): Filters to apply. Supported keys are ``"class"``,
+            ``"race"``, ``"role"`` and ``"tag"``.
+
+    Returns:
+        list[tuple[str, dict]]: Sequence of ``(key, prototype)`` pairs that
+        matched all filters.
+    """
+
+    if not filters:
+        return list(protos.items())
+
+    result: list[tuple[str, dict]] = []
+    for key, proto in protos.items():
+        if "class" in filters and proto.get("npc_class") != filters["class"]:
+            continue
+        if "race" in filters and proto.get("race") != filters["race"]:
+            continue
+        if "role" in filters:
+            roles = proto.get("roles") or []
+            if isinstance(roles, str):
+                roles = [roles]
+            if filters["role"] not in roles:
+                continue
+        if "tag" in filters:
+            tag = filters["tag"]
+            tags = proto.get("tags") or []
+
+            def _tag_match(entry):
+                if isinstance(entry, (list, tuple)):
+                    return entry and entry[0] == tag
+                return entry == tag
+
+            if not any(_tag_match(t) for t in tags):
+                continue
+        result.append((key, proto))
+
+    return result


### PR DESCRIPTION
## Summary
- add `filter_npc_prototypes` helper
- use it in `CmdMList`
- test filtering helpers

## Testing
- `pytest typeclasses/tests/test_mlist_command.py::TestMListCommand::test_prototype_filtering -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6846c35c294c832c9f5d90fce6227359