### PR TITLE
Improve combat engine handling

### DIFF
--- a/combat/combat_engine.py
+++ b/combat/combat_engine.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import List, Optional, Iterable
+from typing import List, Optional, Iterable, Dict
+import random
 from evennia.utils import delay
+from world.system import state_manager
 
 from .combat_actions import Action, AttackAction
 
@@ -21,16 +23,29 @@ class CombatParticipant:
 class CombatEngine:
     """Simple round-based combat engine."""
 
-    def __init__(self, participants: Iterable[object] | None = None, round_time: int = 2):
+    def __init__(self, participants: Iterable[object] | None = None, round_time: int = 2, use_initiative: bool = True):
         self.participants: List[CombatParticipant] = []
         self.round = 0
         self.round_time = round_time
+        self.use_initiative = use_initiative
+        self.queue: List[CombatParticipant] = []
+        self.aggro: Dict[object, Dict[object, int]] = {}
         if participants:
             for p in participants:
                 self.add_participant(p)
 
     def add_participant(self, actor: object) -> None:
+        """Add a combatant to this engine."""
         self.participants.append(CombatParticipant(actor=actor))
+        if hasattr(actor, "on_enter_combat"):
+            actor.on_enter_combat()
+
+    def remove_participant(self, actor: object) -> None:
+        """Remove ``actor`` from combat."""
+        self.participants = [p for p in self.participants if p.actor is not actor]
+        self.queue = [p for p in self.queue if p.actor is not actor]
+        if hasattr(actor, "on_exit_combat"):
+            actor.on_exit_combat()
 
     @property
     def turn_order(self) -> List[CombatParticipant]:
@@ -43,20 +58,59 @@ class CombatEngine:
                 participant.next_action = action
                 break
 
+    # -------------------------------------------------------------
+    # Round Processing
+    # -------------------------------------------------------------
+
+    def start_round(self) -> None:
+        """Prepare a new combat round."""
+        self.queue = []
+        for participant in self.participants:
+            actor = participant.actor
+            if hasattr(actor, "traits"):
+                state_manager.apply_regen(actor)
+                base = getattr(actor.traits.get("initiative"), "value", 0)
+            else:
+                base = getattr(actor, "initiative", 0)
+            participant.initiative = base + random.randint(1, 20)
+            self.queue.append(participant)
+        if self.use_initiative:
+            self.queue.sort(key=lambda p: p.initiative, reverse=True)
+
+    def track_aggro(self, target, attacker) -> None:
+        if not target or target is attacker:
+            return
+        data = self.aggro.setdefault(target, {})
+        data[attacker] = data.get(attacker, 0) + 1
+
+    def handle_defeat(self, target, attacker) -> None:
+        if hasattr(target, "on_exit_combat"):
+            target.on_exit_combat()
+        if hasattr(target, "at_defeat"):
+            target.at_defeat(attacker)
+        self.remove_participant(target)
+
+    def cleanup_environment(self) -> None:
+        for participant in list(self.participants):
+            actor = participant.actor
+            if getattr(actor, "location", None) is None or getattr(actor, "hp", 1) <= 0:
+                self.remove_participant(actor)
+
     def process_round(self) -> None:
         """Process a single combat round."""
-        for participant in self.turn_order:
-            if not hasattr(participant.actor, "hp"):
+        self.start_round()
+        for participant in list(self.queue):
+            actor = participant.actor
+            if not hasattr(actor, "hp") or actor.hp <= 0:
                 continue
-            if participant.actor.hp <= 0:
-                continue
-            action = participant.next_action or AttackAction(participant.actor, None)
+            action = participant.next_action or AttackAction(actor, None)
             result = action.resolve()
             participant.next_action = None
-            if participant.actor.location:
-                participant.actor.location.msg_contents(result.message)
+            if actor.location:
+                actor.location.msg_contents(result.message)
             if getattr(result.target, "hp", 1) <= 0:
-                if hasattr(result.target, "at_defeat"):
-                    result.target.at_defeat(participant.actor)
+                self.handle_defeat(result.target, actor)
+            self.track_aggro(result.target, actor)
+        self.cleanup_environment()
         self.round += 1
         delay(self.round_time, self.process_round)

--- a/typeclasses/tests/test_combat_engine.py
+++ b/typeclasses/tests/test_combat_engine.py
@@ -1,0 +1,54 @@
+from unittest.mock import MagicMock, patch
+import unittest
+
+from combat.combat_engine import CombatEngine
+from combat.combat_actions import Action, CombatResult
+
+
+class KillAction(Action):
+    def resolve(self):
+        self.target.hp = 0
+        return CombatResult(self.actor, self.target, "boom")
+
+
+class Dummy:
+    def __init__(self, hp=10, init=0):
+        self.hp = hp
+        self.location = MagicMock()
+        self.traits = MagicMock()
+        self.traits.get.return_value = MagicMock(value=init)
+        self.on_enter_combat = MagicMock()
+        self.on_exit_combat = MagicMock()
+
+
+class TestCombatEngine(unittest.TestCase):
+    def test_enter_and_exit_callbacks(self):
+        a = Dummy()
+        b = Dummy()
+        with patch('world.system.state_manager.apply_regen'):
+            engine = CombatEngine([a, b], round_time=0)
+            a.on_enter_combat.assert_called()
+            b.on_enter_combat.assert_called()
+            engine.queue_action(a, KillAction(a, b))
+            engine.start_round()
+            engine.process_round()
+            b.on_exit_combat.assert_called()
+
+    def test_initiative_and_regen(self):
+        a = Dummy(init=10)
+        b = Dummy(init=1)
+        engine = CombatEngine([a, b], round_time=0)
+        with patch('world.system.state_manager.apply_regen') as mock_regen, patch('random.randint', return_value=0):
+            engine.start_round()
+            self.assertEqual(engine.queue[0].actor, a)
+            self.assertEqual(mock_regen.call_count, 2)
+
+    def test_aggro_tracking(self):
+        a = Dummy()
+        b = Dummy()
+        with patch('world.system.state_manager.apply_regen'):
+            engine = CombatEngine([a, b], round_time=0)
+            engine.queue_action(a, KillAction(a, b))
+            engine.start_round()
+            engine.process_round()
+            self.assertIn(a, engine.aggro.get(b, {}))


### PR DESCRIPTION
## Summary
- enhance combat engine with callbacks, KO handling and initiative queue
- add aggro tracking and regeneration per round
- cover new engine logic with tests

## Testing
- `pytest typeclasses/tests/test_combat_engine.py -q`
- `pytest -q` *(fails: 268 failed)*

------
https://chatgpt.com/codex/tasks/task_e_6846d694e890832cadfedc145cb9565d