### PR TITLE
Add stackable combat states with callbacks

### DIFF
--- a/combat/combat_states.py
+++ b/combat/combat_states.py
@@ -1,16 +1,22 @@
 """Status and combat state utilities."""
 
 from dataclasses import dataclass
-from typing import Dict
+from typing import Callable, Dict, Optional
 
 
 @dataclass
 class CombatState:
-    """Simple state effect."""
+    """Simple state effect that can stack."""
 
     key: str
     duration: int
     desc: str = ""
+    max_stacks: int = 1
+    diminish: float = 1.0
+    stacks: int = 1
+    on_apply: Optional[Callable[[object, "CombatState"], None]] = None
+    on_expire: Optional[Callable[[object, "CombatState"], None]] = None
+    on_tick: Optional[Callable[[object, "CombatState"], None]] = None
 
 
 class StateManager:
@@ -20,17 +26,42 @@ class StateManager:
         self.states: Dict[object, Dict[str, CombatState]] = {}
 
     def add_state(self, obj: object, state: CombatState) -> None:
-        self.states.setdefault(obj, {})[state.key] = state
+        """Add ``state`` to ``obj``.
+
+        If the state already exists on the object it will stack and add
+        duration using the state's ``diminish`` factor, up to ``max_stacks``.
+        ``on_apply`` is only triggered the first time the state is added.
+        """
+
+        obj_states = self.states.setdefault(obj, {})
+        current = obj_states.get(state.key)
+        if current:
+            if current.max_stacks is None or current.stacks < current.max_stacks:
+                current.stacks += 1
+            added = int(state.duration * (current.diminish ** (current.stacks - 1)))
+            current.duration += added
+        else:
+            obj_states[state.key] = state
+            if state.on_apply:
+                state.on_apply(obj, state)
 
     def remove_state(self, obj: object, key: str) -> None:
         if obj in self.states and key in self.states[obj]:
+            state = self.states[obj][key]
+            if state.on_expire:
+                state.on_expire(obj, state)
             del self.states[obj][key]
 
     def tick(self) -> None:
+        """Advance all state timers and fire callbacks."""
         for obj, sts in list(self.states.items()):
             for key, state in list(sts.items()):
+                if state.on_tick:
+                    state.on_tick(obj, state)
                 state.duration -= 1
                 if state.duration <= 0:
+                    if state.on_expire:
+                        state.on_expire(obj, state)
                     del sts[key]
             if not sts:
                 del self.states[obj]

--- a/typeclasses/tests/test_combat_states.py
+++ b/typeclasses/tests/test_combat_states.py
@@ -1,0 +1,55 @@
+import unittest
+from combat.combat_states import CombatState, StateManager
+
+
+class Dummy:
+    pass
+
+
+class TestCombatStates(unittest.TestCase):
+    def test_stacking_and_diminish(self):
+        mgr = StateManager()
+        obj = Dummy()
+        base = CombatState(key="bleeding", duration=4, max_stacks=3, diminish=0.5)
+        mgr.add_state(obj, base)
+        self.assertEqual(mgr.states[obj]["bleeding"].duration, 4)
+        self.assertEqual(mgr.states[obj]["bleeding"].stacks, 1)
+
+        mgr.add_state(obj, CombatState(key="bleeding", duration=4, max_stacks=3, diminish=0.5))
+        self.assertEqual(mgr.states[obj]["bleeding"].stacks, 2)
+        self.assertEqual(mgr.states[obj]["bleeding"].duration, 6)
+
+        mgr.add_state(obj, CombatState(key="bleeding", duration=4, max_stacks=3, diminish=0.5))
+        self.assertEqual(mgr.states[obj]["bleeding"].stacks, 3)
+        self.assertEqual(mgr.states[obj]["bleeding"].duration, 7)
+
+        mgr.add_state(obj, CombatState(key="bleeding", duration=4, max_stacks=3, diminish=0.5))
+        self.assertEqual(mgr.states[obj]["bleeding"].stacks, 3)
+        self.assertEqual(mgr.states[obj]["bleeding"].duration, 8)
+
+    def test_callbacks(self):
+        events = []
+
+        def on_apply(o, s):
+            events.append("apply")
+
+        def on_tick(o, s):
+            events.append("tick")
+
+        def on_expire(o, s):
+            events.append("expire")
+
+        mgr = StateManager()
+        obj = Dummy()
+        state = CombatState(
+            key="bleeding",
+            duration=1,
+            on_apply=on_apply,
+            on_tick=on_tick,
+            on_expire=on_expire,
+        )
+        mgr.add_state(obj, state)
+        mgr.tick()
+
+        self.assertEqual(events, ["apply", "tick", "expire"])
+

--- a/world/effects.py
+++ b/world/effects.py
@@ -72,4 +72,16 @@ EFFECTS: Dict[str, Effect] = {
         type="buff",
         mods={"STR": 3, "armor": -2},
     ),
+    "defending": Effect(
+        key="defending",
+        name="Defending",
+        desc="You brace yourself against incoming attacks.",
+        type="status",
+    ),
+    "bleeding": Effect(
+        key="bleeding",
+        name="Bleeding",
+        desc="You are slowly losing health.",
+        type="status",
+    ),
 }


### PR DESCRIPTION
## Summary
- support stackable combat `CombatState`s with diminishing returns
- call optional `on_apply`, `on_tick`, `on_expire` callbacks
- add new statuses (defending, bleeding)
- document/implement tests for new state manager features

## Testing
- `pytest -q` *(fails: OperationalError - no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6846db74a618832caea75787540ff825