### PR TITLE
Implement skill categories and example abilities

### DIFF
--- a/combat/__init__.py
+++ b/combat/__init__.py
@@ -10,7 +10,7 @@ from .combat_actions import (
     CombatResult,
 )
 from .combat_states import CombatState, StateManager
-from .combat_skills import Skill, ShieldBash
+from .combat_skills import Skill, ShieldBash, Cleave, SKILL_CLASSES
 from .damage_types import DamageType
 
 __all__ = [
@@ -25,5 +25,7 @@ __all__ = [
     "StateManager",
     "Skill",
     "ShieldBash",
+    "Cleave",
+    "SKILL_CLASSES",
     "DamageType",
 ]

--- a/typeclasses/tests/test_skill_spell_usage.py
+++ b/typeclasses/tests/test_skill_spell_usage.py
@@ -1,0 +1,24 @@
+from evennia.utils.test_resources import EvenniaTest
+from combat.combat_skills import SKILL_CLASSES
+from world.spells import SPELLS
+
+class TestSkillAndSpellUsage(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        # ensure characters have sample spell known
+        self.char1.db.spells = [SPELLS["fireball"]]
+
+    def test_cast_spell_applies_cost_and_cooldown(self):
+        mana_before = self.char1.traits.mana.current
+        result = self.char1.cast_spell("fireball", target=self.char2)
+        self.assertTrue(result)
+        self.assertEqual(self.char1.traits.mana.current, mana_before - SPELLS["fireball"].mana_cost)
+        self.assertTrue(self.char1.cooldowns.time_left("fireball", use_int=True))
+
+    def test_use_skill_applies_cost_and_cooldown(self):
+        skill_cls = SKILL_CLASSES["cleave"]
+        stamina_before = self.char1.traits.stamina.current
+        result = self.char1.use_skill("cleave", target=self.char2)
+        self.assertEqual(self.char1.traits.stamina.current, stamina_before - skill_cls().stamina_cost)
+        self.assertTrue(self.char1.cooldowns.time_left("cleave", use_int=True))
+

--- a/world/spells.py
+++ b/world/spells.py
@@ -7,10 +7,11 @@ class Spell:
     stat: str
     mana_cost: int
     desc: str = ""
+    cooldown: int = 0
     proficiency: int = 0
 
 
 SPELLS: Dict[str, Spell] = {
-    "fireball": Spell("fireball", "INT", 10, "Hurl a ball of fire at your target."),
-    "heal": Spell("heal", "WIS", 8, "Restore a small amount of health."),
+    "fireball": Spell("fireball", "INT", 10, "Hurl a ball of fire at your target.", cooldown=5),
+    "heal": Spell("heal", "WIS", 8, "Restore a small amount of health.", cooldown=3),
 }


### PR DESCRIPTION
## Summary
- add `SkillCategory` enum and new `Cleave` skill
- track cooldowns and stamina when using combat skills
- extend `Spell` with a cooldown and update `fireball`
- hook character methods into new skill and spell logic
- add tests for cooldown and resource costs

## Testing
- `pytest typeclasses/tests/test_skill_spell_usage.py::TestSkillAndSpellUsage::test_cast_spell_applies_cost_and_cooldown -vv -s` *(fails: Database not available)*

------
https://chatgpt.com/codex/tasks/task_e_6846dd824b68832ca621a0c521aed2a1