### PR TITLE
Add resistance matrix and new damage types

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,21 @@ A modular combat engine is provided under the `combat/` package. It implements
 round-based processing, action queues and a sample `ShieldBash` skill. The
 system is designed to plug into Evennia characters and rooms for dynamic fights.
 
+### Damage Types and Resistances
+
+Damage dealt in combat is categorized by `DamageType`. Characters may hold
+resistance flags in their `db.ris` attribute. During damage resolution the
+engine consults a resistance matrix to modify incoming damage. For example:
+
+```python
+from combat.damage_types import DamageType, ResistanceType, get_damage_multiplier
+
+mult = get_damage_multiplier([ResistanceType.FIRE], DamageType.FIRE)
+print(mult)  # 0.5
+```
+
+Resistances can be assigned via the mob builder menu when creating NPCs.
+
 
 ## Running the Tests
 

--- a/combat/combat_actions.py
+++ b/combat/combat_actions.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Optional, Iterable
 
+from .damage_types import DamageType
+
 from evennia.utils import utils
 from world.system import state_manager
 
@@ -16,6 +18,8 @@ class CombatResult:
     actor: object
     target: object
     message: str
+    damage: int = 0
+    damage_type: object | None = None
 
 
 class Action:
@@ -91,13 +95,16 @@ class AttackAction(Action):
             weapon = self.actor.wielding[0] if self.actor.wielding else self.actor
             weapon.at_attack(self.actor, target)
         dmg = 0
+        dtype = DamageType.BLUDGEONING
         if hasattr(target, "hp"):
             dmg = getattr(weapon, "damage", 0)
-            target.hp = max(target.hp - dmg, 0)
+            dtype = getattr(weapon, "damage_type", DamageType.BLUDGEONING)
         return CombatResult(
             actor=self.actor,
             target=target,
             message=f"{self.actor.key} strikes {target.key} for {dmg} damage!",
+            damage=dmg,
+            damage_type=dtype,
         )
 
 

--- a/combat/damage_types.py
+++ b/combat/damage_types.py
@@ -12,3 +12,65 @@ class DamageType(str, Enum):
     ACID = "acid"
     HOLY = "holy"
     SHADOW = "shadow"
+    LIGHTNING = "lightning"
+    VOID = "void"
+
+
+class ResistanceType(str, Enum):
+    """Types of elemental or physical resistance."""
+
+    SLASHING = "slashing"
+    PIERCING = "piercing"
+    BLUDGEONING = "bludgeoning"
+    FIRE = "fire"
+    COLD = "cold"
+    ACID = "acid"
+    HOLY = "holy"
+    SHADOW = "shadow"
+    LIGHTNING = "lightning"
+    VOID = "void"
+
+
+RESISTANCE_MATRIX: dict[ResistanceType, dict[DamageType, float]] = {
+    ResistanceType.SLASHING: {DamageType.SLASHING: 0.5},
+    ResistanceType.PIERCING: {DamageType.PIERCING: 0.5},
+    ResistanceType.BLUDGEONING: {DamageType.BLUDGEONING: 0.5},
+    ResistanceType.FIRE: {
+        DamageType.FIRE: 0.5,
+        DamageType.COLD: 1.5,
+    },
+    ResistanceType.COLD: {
+        DamageType.COLD: 0.5,
+        DamageType.FIRE: 1.5,
+    },
+    ResistanceType.ACID: {DamageType.ACID: 0.5},
+    ResistanceType.HOLY: {
+        DamageType.HOLY: 0.5,
+        DamageType.SHADOW: 1.5,
+    },
+    ResistanceType.SHADOW: {
+        DamageType.SHADOW: 0.5,
+        DamageType.HOLY: 1.5,
+    },
+    ResistanceType.LIGHTNING: {
+        DamageType.LIGHTNING: 0.5,
+        DamageType.VOID: 1.5,
+    },
+    ResistanceType.VOID: {
+        DamageType.VOID: 0.5,
+        DamageType.LIGHTNING: 1.5,
+    },
+}
+
+
+def get_damage_multiplier(
+    resistances: list[ResistanceType] | None, damage_type: DamageType
+) -> float:
+    """Return the damage multiplier for given resistances and damage type."""
+
+    multiplier = 1.0
+    if not resistances:
+        return multiplier
+    for res in resistances:
+        multiplier *= RESISTANCE_MATRIX.get(res, {}).get(damage_type, 1.0)
+    return multiplier

--- a/utils/tests/test_resistances.py
+++ b/utils/tests/test_resistances.py
@@ -1,0 +1,12 @@
+from evennia.utils.test_resources import EvenniaTest
+
+class TestResistanceMatrix(EvenniaTest):
+    def test_fire_resistance(self):
+        from combat.damage_types import DamageType, ResistanceType, get_damage_multiplier
+        mult = get_damage_multiplier([ResistanceType.FIRE], DamageType.FIRE)
+        self.assertEqual(mult, 0.5)
+
+    def test_shadow_weak_to_holy(self):
+        from combat.damage_types import DamageType, ResistanceType, get_damage_multiplier
+        mult = get_damage_multiplier([ResistanceType.SHADOW], DamageType.HOLY)
+        self.assertEqual(mult, 1.5)


### PR DESCRIPTION
## Summary
- extend `damage_types` with Lightning and Void
- add `ResistanceType` and a damage resistance matrix
- use resistances in `Character.at_damage`
- calculate final damage in `CombatEngine`
- return damage from `at_damage` overrides
- document damage types and resistances
- test resistance helpers

## Testing
- `pytest -q` *(fails: django.db.utils.OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6846e39b2f8c832c8112e4dd0e4e442f