### PR TITLE
Improve NPC combat AI

### DIFF
--- a/combat/ai_combat.py
+++ b/combat/ai_combat.py
@@ -1,13 +1,99 @@
-"""Basic combat AI utilities."""
+"""Combat AI utilities using a simple priority system."""
 
-import random
+from __future__ import annotations
 
-from .combat_actions import AttackAction
+from dataclasses import dataclass, field
+from typing import Callable, Iterable
+
+from .combat_actions import AttackAction, SkillAction, SpellAction
 from .combat_engine import CombatEngine
+from .combat_skills import SKILL_CLASSES
+from world.spells import SPELLS
 
 
-def npc_take_turn(engine: CombatEngine, npc, target):
-    """Very simple AI to attack target each round."""
+@dataclass(order=True)
+class Behavior:
+    """A prioritized behavior condition/action pair."""
+
+    priority: int
+    check: Callable[[CombatEngine | None, object, object], bool] = field(compare=False)
+    act: Callable[[CombatEngine | None, object, object], None] = field(compare=False)
+
+
+def _default_behaviors(npc) -> Iterable[Behavior]:
+    """Yield behaviors for any skills or spells the NPC knows."""
+
+    # Spells are highest priority if the NPC has mana for them.
+    for sp in getattr(npc.db, "spells", []):
+        spell_key = sp.key if hasattr(sp, "key") else sp
+        spell = SPELLS.get(spell_key)
+        if not spell:
+            continue
+
+        def check(engine, n, t, sk=spell):
+            mana = getattr(n.traits, "mana", None)
+            return mana and mana.current >= sk.mana_cost and n.cooldowns.ready(sk.key)
+
+        def act(engine, n, t, sk=spell_key):
+            if engine:
+                engine.queue_action(n, SpellAction(n, sk, t))
+            else:
+                n.cast_spell(sk, target=t)
+
+        yield Behavior(30, check, act)
+
+    # Skills next.
+    for sk in getattr(npc.db, "skills", []):
+        skill_cls = SKILL_CLASSES.get(sk)
+        if not skill_cls:
+            continue
+        skill = skill_cls()
+
+        def check(engine, n, t, s=skill):
+            stam = getattr(n.traits, "stamina", None)
+            return stam and stam.current >= s.stamina_cost and n.cooldowns.ready(s.name)
+
+        def act(engine, n, t, s=skill):
+            if engine:
+                engine.queue_action(n, SkillAction(n, s, t))
+            else:
+                n.use_skill(s.name, target=t)
+
+        yield Behavior(20, check, act)
+
+    # Fallback to a normal attack.
+    def atk_check(engine, n, t):
+        return bool(t and getattr(t, "hp", 0) > 0)
+
+    def atk_act(engine, n, t):
+        if engine:
+            engine.queue_action(n, AttackAction(n, t))
+        else:
+            weapon = n.wielding[0] if getattr(n, "wielding", None) else n
+            n.attack(t, weapon)
+
+    yield Behavior(0, atk_check, atk_act)
+
+
+def npc_take_turn(engine: CombatEngine | None, npc, target) -> None:
+    """Select and queue a combat action for ``npc``."""
+
+    if hasattr(npc, "on_environment"):
+        npc.on_environment(engine)
+
     if not target or getattr(target, "hp", 0) <= 0:
         return
-    engine.queue_action(npc, AttackAction(npc, target))
+
+    # check for low health hook
+    if hasattr(npc, "on_low_hp"):
+        cur = getattr(getattr(npc.traits, "health", None), "value", getattr(npc, "hp", 0))
+        max_hp = getattr(getattr(npc.traits, "health", None), "max", getattr(npc, "max_hp", cur))
+        if max_hp and cur / max_hp <= 0.3:
+            npc.on_low_hp(engine)
+
+    behaviors = sorted(list(_default_behaviors(npc)), reverse=True)
+    for beh in behaviors:
+        if beh.check(engine, npc, target):
+            beh.act(engine, npc, target)
+            break
+

--- a/combat/combat_engine.py
+++ b/combat/combat_engine.py
@@ -90,6 +90,14 @@ class CombatEngine:
         if hasattr(target, "at_defeat"):
             target.at_defeat(attacker)
         self.remove_participant(target)
+        for participant in list(self.participants):
+            ally = participant.actor
+            if ally is target:
+                continue
+            if ally.location == getattr(target, "location", None):
+                hook = getattr(ally, "on_ally_down", None)
+                if callable(hook):
+                    hook(target, attacker)
 
     def apply_damage(self, attacker, target, amount: int, damage_type: DamageType | None) -> int:
         """Apply ``amount`` of damage to ``target`` using its hooks."""

--- a/typeclasses/tests/test_ai_combat.py
+++ b/typeclasses/tests/test_ai_combat.py
@@ -1,0 +1,40 @@
+import unittest
+from unittest.mock import MagicMock
+
+from combat.ai_combat import npc_take_turn
+from combat.combat_actions import SpellAction, SkillAction
+
+class DummyNPC:
+    def __init__(self):
+        self.location = MagicMock()
+        self.traits = MagicMock()
+        self.traits.health = MagicMock(value=20, max=20)
+        self.traits.mana = MagicMock(current=20)
+        self.traits.stamina = MagicMock(current=20)
+        self.cooldowns = MagicMock()
+        self.cooldowns.ready.return_value = True
+        self.db = MagicMock()
+        self.db.spells = ["fireball"]
+        self.db.skills = ["cleave"]
+        self.wielding = []
+        self.attack = MagicMock()
+        self.cast_spell = MagicMock()
+        self.use_skill = MagicMock()
+
+class TestAICombat(unittest.TestCase):
+    def setUp(self):
+        self.npc = DummyNPC()
+        self.target = DummyNPC()
+        self.engine = MagicMock()
+
+    def test_prefers_spell_over_skill(self):
+        npc_take_turn(self.engine, self.npc, self.target)
+        action = self.engine.queue_action.call_args[0][1]
+        self.assertIsInstance(action, SpellAction)
+
+    def test_uses_skill_when_no_mana(self):
+        self.npc.traits.mana.current = 0
+        self.engine.queue_action.reset_mock()
+        npc_take_turn(self.engine, self.npc, self.target)
+        action = self.engine.queue_action.call_args[0][1]
+        self.assertIsInstance(action, SkillAction)

--- a/world/npc_handlers/ai.py
+++ b/world/npc_handlers/ai.py
@@ -5,11 +5,15 @@ from __future__ import annotations
 from random import choice
 from evennia import DefaultObject
 from typeclasses.npcs import BaseNPC
+from combat.ai_combat import npc_take_turn
 
 
 def _ai_aggressive(npc: DefaultObject) -> None:
-    """Very simple aggressive behavior: attack the first player here."""
-    if not npc.location or npc.in_combat:
+    """Aggressive behavior: enter combat or act if already fighting."""
+    if npc.in_combat and npc.db.combat_target:
+        npc_take_turn(None, npc, npc.db.combat_target)
+        return
+    if not npc.location:
         return
     for obj in npc.location.contents:
         if obj.has_account:
@@ -30,8 +34,7 @@ def _ai_wander(npc: DefaultObject) -> None:
 def _ai_defensive(npc: DefaultObject) -> None:
     """Attack only when already in combat."""
     if npc.in_combat and npc.db.combat_target:
-        weapon = npc.wielding[0] if npc.wielding else npc
-        npc.attack(npc.db.combat_target, weapon)
+        npc_take_turn(None, npc, npc.db.combat_target)
 
 
 def _ai_scripted(npc: DefaultObject) -> None:

--- a/world/prototypes/npcs.json
+++ b/world/prototypes/npcs.json
@@ -24,6 +24,8 @@
         "npc_type": "guard",
         "ai_type": "defensive",
         "level": 1,
-        "actflags": ["assist", "call_for_help"]
+        "actflags": ["assist", "call_for_help"],
+        "skills": ["shield bash"],
+        "spells": ["heal"]
     }
 }


### PR DESCRIPTION
## Summary
- overhaul `npc_take_turn` with a priority based behaviour system
- trigger ally down callbacks and low HP hooks during combat
- allow aggressive and defensive NPCs to use skills and spells
- update the basic guard prototype with sample abilities
- add unit tests covering combat AI decisions

## Testing
- `pytest -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6846e75a6134832cb0ac0c08f6f7a6c8