### PR TITLE
Update docs for combat features

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,23 @@ print(mult)  # 0.5
 
 Resistances can be assigned via the mob builder menu when creating NPCs.
 
+### Status Effects
+
+Many combat abilities apply temporary status conditions. Effects like
+`stunned` or `defending` last a set number of combat ticks and may alter
+stats or restrict actions. Use the `affects` command or `status` to view
+your current buffs and conditions. Effects expire automatically when
+their duration reaches zero.
+
+### AI Settings
+
+NPC behavior is configured by an AI type during `cnpc` or `mobbuilder`.
+Choose from `passive`, `aggressive`, `defensive`, `wander` or
+`scripted`. Scripted AI runs the callable stored on `npc.db.ai_script`.
+These options let builders quickly create enemies that fight or roam on
+their own. The combat command set includes `attack`, `wield`, `unwield`,
+`flee`, `berserk`, `respawn`, `revive` and `status`.
+
 
 ## Running the Tests
 

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -140,6 +140,10 @@ Help for affects
 
 View your active buffs and status effects.
 
+Status effects include temporary conditions like |wstunned|n or
+|wdefending|n applied during combat. They modify your stats or actions
+until their duration expires.
+
 Usage:
     affects
 
@@ -2655,8 +2659,9 @@ The available AI types are stored in `world.npc_handlers.ai`:
     scripted - run npc.db.ai_script callback
 
 Set the type when prompted in the builder or edit the prototype data.
-For scripted AI, store a callable path on ``npc.db.ai_script`` such as
-``scripts.example_ai.patrol_ai``.
+The mob builder offers the same AI step for prototypes saved with
+`@mcreate` or `@mset`. For scripted AI, store a callable path on
+``npc.db.ai_script`` such as ``scripts.example_ai.patrol_ai``.
 
 Related:
     help cnpc
@@ -3065,6 +3070,36 @@ Notes:
 
 Related:
     help cnpc
+""",
+    },
+    {
+        "key": "damage types",
+        "aliases": ["damage", "elemental damage"],
+        "category": "Combat",
+        "text": """Help for damage types
+
+Attacks are categorized as slashing, piercing, bludgeoning and elemental
+types like fire or shadow. NPCs may gain resistances during the builder.
+When damage is applied the engine checks these resistances and multiplies
+the amount accordingly. Values below 1.0 mean the target resists that
+type while values above 1.0 indicate vulnerability.
+""",
+    },
+    {
+        "key": "combat system",
+        "aliases": ["combat"],
+        "category": "Combat",
+        "text": """Help for combat system
+
+Combat is round based. Use |wattack <target>|n to begin a fight then
+queue actions like attacks or skills each round. Status effects such as
+|wstunned|n come from abilities and expire after a few ticks. Check them
+with |waffects|n or |wstatus|n.
+
+NPC behavior is controlled by an AI type set in the |wcnpc|n builder or
+|wmobbuilder|n. Available types are passive, aggressive, defensive,
+wander and scripted. Scripted AI runs the callback stored on
+|wnpc.db.ai_script|n.
 """,
     },
 ]


### PR DESCRIPTION
## Summary
- detail status effects and AI settings in README
- document expanded combat help entries

## Testing
- `pytest -q` *(fails: no such table)*

------
https://chatgpt.com/codex/tasks/task_e_6846ec770210832c8da61be7a7f764a0