### PR TITLE
Add expanded combat tests

### DIFF
--- a/typeclasses/tests/test_combat_flow.py
+++ b/typeclasses/tests/test_combat_flow.py
@@ -1,0 +1,95 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from combat.combat_engine import CombatEngine
+from combat.combat_actions import AttackAction, SkillAction, SpellAction, CombatResult, Action
+from combat.combat_skills import ShieldBash
+from combat.damage_types import DamageType
+from combat.ai_combat import npc_take_turn
+
+
+class Dummy:
+    def __init__(self, hp=10):
+        self.hp = hp
+        self.key = "dummy"
+        self.location = MagicMock()
+        self.traits = MagicMock()
+        self.traits.get.return_value = MagicMock(value=0)
+        self.traits.health = MagicMock(value=hp, max=hp)
+        self.traits.mana = MagicMock(current=20)
+        self.traits.stamina = MagicMock(current=20)
+        self.cooldowns = MagicMock()
+        self.cooldowns.ready.return_value = True
+        self.tags = MagicMock()
+        self.wielding = []
+        self.on_enter_combat = MagicMock()
+        self.on_exit_combat = MagicMock()
+        self.cast_spell = MagicMock()
+        self.use_skill = MagicMock()
+
+
+class KillAction(Action):
+    def resolve(self):
+        self.target.hp = 0
+        return CombatResult(self.actor, self.target, "boom")
+
+
+class TestAttackAction(unittest.TestCase):
+    def test_attack_deals_damage(self):
+        attacker = Dummy()
+        defender = Dummy()
+        weapon = MagicMock()
+        weapon.damage = 5
+        weapon.damage_type = DamageType.SLASHING
+        weapon.at_attack = MagicMock()
+        attacker.wielding = [weapon]
+
+        engine = CombatEngine([attacker, defender], round_time=0)
+        engine.queue_action(attacker, AttackAction(attacker, defender))
+        with patch("combat.combat_actions.utils.inherits_from", return_value=True), \
+             patch("world.system.state_manager.apply_regen"), \
+             patch("random.randint", return_value=0):
+            engine.start_round()
+            engine.process_round()
+
+        self.assertEqual(defender.hp, 5)
+        weapon.at_attack.assert_called_with(attacker, defender)
+
+
+class TestCombatVictory(unittest.TestCase):
+    def test_handle_defeat_removes_participant(self):
+        a = Dummy()
+        b = Dummy()
+        engine = CombatEngine([a, b], round_time=0)
+        engine.queue_action(a, KillAction(a, b))
+        with patch("world.system.state_manager.apply_regen"):
+            engine.start_round()
+            engine.process_round()
+        self.assertNotIn(b, [p.actor for p in engine.participants])
+
+
+class TestNPCBehaviors(unittest.TestCase):
+    def test_low_hp_triggers_callback(self):
+        npc = Dummy()
+        npc.traits.health.value = 2
+        npc.traits.health.max = 10
+        npc.on_low_hp = MagicMock()
+        target = Dummy()
+        npc_take_turn(None, npc, target)
+        npc.on_low_hp.assert_called()
+
+
+
+
+class TestSpellExample(unittest.TestCase):
+    def test_spell_action_calls_cast(self):
+        caster = Dummy()
+        target = Dummy()
+        caster.cast_spell = MagicMock()
+        engine = CombatEngine([caster, target], round_time=0)
+        engine.queue_action(caster, SpellAction(caster, "fireball", target))
+        with patch("world.system.state_manager.apply_regen"), patch("random.randint", return_value=0):
+            engine.start_round()
+            engine.process_round()
+        caster.cast_spell.assert_called_with("fireball", target)
+

--- a/typeclasses/tests/test_skill_spell_usage.py
+++ b/typeclasses/tests/test_skill_spell_usage.py
@@ -1,3 +1,4 @@
+from unittest.mock import patch
 from evennia.utils.test_resources import EvenniaTest
 from combat.combat_skills import SKILL_CLASSES
 from world.spells import SPELLS
@@ -21,4 +22,14 @@ class TestSkillAndSpellUsage(EvenniaTest):
         result = self.char1.use_skill("cleave", target=self.char2)
         self.assertEqual(self.char1.traits.stamina.current, stamina_before - skill_cls().stamina_cost)
         self.assertTrue(self.char1.cooldowns.time_left("cleave", use_int=True))
+
+
+    def test_shield_bash_adds_status_effect(self):
+        self.char2.hp = 10
+        with patch("combat.combat_skills.check_hit", return_value=True), \
+             patch("combat.combat_skills.roll_damage", return_value=4), \
+             patch("world.system.state_manager.add_status_effect") as mock_add:
+            self.char1.use_skill("shield bash", target=self.char2)
+            mock_add.assert_called_with(self.char2, "stunned", 1)
+            self.assertEqual(self.char2.hp, 6)
 


### PR DESCRIPTION
## Summary
- add regression test suite for combat actions, engine and AI
- extend skill & spell tests to check status effects

## Testing
- `pytest -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6846f00bedf0832cb83cf76d8d074a8b