### PR TITLE
Update mobbuilder to spawn and save

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,12 +207,20 @@ giver.
 ### Mob Builder
 
 Run `mobbuilder` to open the same menu driven builder used by `cnpc`. The
-workflow now supports optional mob specific fields like act flags and
-resistances. Confirming the menu saves the data to
+workflow supports mob‑specific fields like act flags and resistances. At the
+end of the menu you may choose **Yes** to spawn the NPC or **Yes & Save
+Prototype** to spawn it and also store the prototype in
 `world/prototypes/npcs.json` with `mob_` prefixed to the key. Use
-`@mspawn <prototype>` to create the NPC from the stored prototype and
-`@mstat <key>` to inspect the result or any existing NPC. Prototype entries can
-be adjusted with `@mcreate`, `@mset` and viewed with `@mlist`.
+`@mspawn <prototype>` to create additional copies and `@mstat <key>` to inspect
+them. Prototype entries can be adjusted with `@mcreate`, `@mset` and viewed with
+`@mlist`.
+
+Example::
+
+    mobbuilder
+    (fill in the prompts for a goblin)
+    [choose **Yes & Save Prototype**]
+    @mspawn mob_goblin
 
 ## Weapon Creation and Inspection
 

--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -976,6 +976,10 @@ def _create_npc(caller, raw_string, register=False, **kwargs):
         from world import prototypes
 
         proto_key = data.get("proto_key", data.get("key"))
+        # automatically prefix mob prototypes when using mobbuilder
+        if data.get("use_mob") and not proto_key.startswith("mob_"):
+            proto_key = f"mob_{proto_key}"
+            data["proto_key"] = proto_key
         proto = {k: v for k, v in data.items() if k not in ("edit_obj", "proto_key")}
         if data.get("script"):
             proto["scripts"] = [data["script"]]

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -2801,10 +2801,11 @@ Related:
         "category": "Building",
         "text": """Help for mobbuilder
 
-Invokes the same menu-driven builder as |wcnpc|n but instead of creating the
-NPC immediately it stores the result as a prototype prefixed with ``mob_``.
-Additional mob-specific fields such as act flags, skills, spells and
-resistances may be set while stepping through the menu.
+Invokes the same menu-driven builder as |wcnpc|n but the NPC is spawned
+immediately. Choosing |wYes & Save Prototype|n at the end also stores the
+result as a prototype prefixed with ``mob_``. Additional mob specific fields
+such as act flags, skills, spells and resistances may be set while stepping
+through the menu.
 You can also specify a Script typeclass to attach after the languages step.
 
 Usage:
@@ -2815,6 +2816,10 @@ Notes:
       using |w@mlist|n. See |whelp @mlist|n for filtering options.
     - Spawn a stored prototype with |w@mspawn <prototype>|n.
     - Inspect prototypes or NPCs with |w@mstat <key>|n.
+    - Example workflow:
+        1) run |wmobbuilder|n and fill in the prompts
+        2) choose |wYes & Save Prototype|n
+        3) use |w@mspawn mob_<key>|n to spawn more copies
 
 Related:
     help cnpc


### PR DESCRIPTION
## Summary
- allow mobbuilder to register prototypes with a `mob_` prefix automatically
- document mobbuilder spawning behavior
- update help entry for mobbuilder to explain new workflow

## Testing
- `pytest -q` *(fails: KeyboardInterrupt, many failed tests)*

------
https://chatgpt.com/codex/tasks/task_e_6846f70e1ec8832cb060c3a0d0ed49a6