### PR TITLE
Improve NPC builder documentation

### DIFF
--- a/commands/mob_builder.py
+++ b/commands/mob_builder.py
@@ -33,7 +33,19 @@ class CmdMobBuilder(Command):
 
 
 class CmdMSpawn(Command):
-    """Spawn a mob prototype."""
+    """
+    Spawn a mob prototype.
+
+    Prototypes are loaded from ``world/prototypes/npcs.json``. Spawning creates
+    a new NPC and leaves any existing ones unchanged. Use ``@medit`` to modify
+    a live NPC.
+
+    Usage:
+        @mspawn <prototype>
+
+    Example:
+        @mspawn bandit
+    """
 
     key = "@mspawn"
     locks = "cmd:perm(Builder)"

--- a/commands/mob_builder_commands.py
+++ b/commands/mob_builder_commands.py
@@ -25,7 +25,19 @@ from world.mob_constants import (
 
 
 class CmdMStat(Command):
-    """Inspect an NPC or prototype."""
+    """
+    Inspect an NPC or stored prototype.
+
+    Prototype data is read from ``world/prototypes/npcs.json``. This is a
+    read-only command and will not change any existing NPCs. Use ``@medit`` if
+    you need to update a live NPC from a prototype.
+
+    Usage:
+        @mstat <npc or proto>
+
+    Example:
+        @mstat bandit
+    """
 
     key = "@mstat"
     locks = "cmd:perm(Builder) or perm(Admin) or perm(Developer)"
@@ -107,7 +119,19 @@ class CmdMStat(Command):
 
 
 class CmdMCreate(Command):
-    """Create a new NPC prototype."""
+    """
+    Create a new NPC prototype.
+
+    The prototype is stored in ``world/prototypes/npcs.json`` and does not
+    affect any already spawned NPCs. Use ``@medit`` later if you need to update
+    a live NPC from the saved prototype.
+
+    Usage:
+        @mcreate <key> [copy_key]
+
+    Example:
+        @mcreate guard_02 basic_guard
+    """
 
     key = "@mcreate"
     locks = "cmd:perm(Builder) or perm(Admin) or perm(Developer)"
@@ -139,7 +163,18 @@ class CmdMCreate(Command):
 
 
 class CmdMSet(Command):
-    """Edit a field on an NPC prototype."""
+    """
+    Edit a field on an NPC prototype.
+
+    Changes are written to ``world/prototypes/npcs.json``. Existing NPCs are
+    unaffected until you apply the prototype with ``@medit``.
+
+    Usage:
+        @mset <key> <field> <value>
+
+    Example:
+        @mset bandit level 5
+    """
 
     key = "@mset"
     locks = "cmd:perm(Builder) or perm(Admin) or perm(Developer)"
@@ -207,7 +242,19 @@ class CmdMSet(Command):
 
 
 class CmdMList(Command):
-    """List NPC prototypes or spawned NPCs."""
+    """
+    List stored NPC prototypes or spawned NPCs.
+
+    Prototype information is read from ``world/prototypes/npcs.json``. Listing
+    does not alter any existing NPCs. Use ``@medit`` if you want to modify a
+    spawned NPC.
+
+    Usage:
+        @mlist [area] [/room|/area] [filters]
+
+    Example:
+        @mlist /room
+    """
 
     key = "@mlist"
     locks = "cmd:perm(Builder) or perm(Admin) or perm(Developer)"

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -2828,6 +2828,92 @@ Related:
 """,
     },
     {
+        "key": "@mcreate",
+        "category": "Building",
+        "text": """Help for @mcreate
+
+Create a new NPC prototype. The prototype data is stored in
+``world/prototypes/npcs.json`` and does not affect any existing NPCs
+until you update them with |w@medit|n.
+
+Usage:
+    @mcreate <key> [copy_key]
+
+Examples:
+    @mcreate merchant_02
+    @mcreate elite_guard basic_guard
+""",
+    },
+    {
+        "key": "@mset",
+        "category": "Building",
+        "text": """Help for @mset
+
+Edit a field on an NPC prototype stored in
+``world/prototypes/npcs.json``. Existing NPCs remain unchanged unless
+you later apply the prototype with |w@medit|n.
+
+Usage:
+    @mset <proto> <field> <value>
+
+Examples:
+    @mset merchant level 10
+    @mset merchant actflags aggressive,stay_area
+""",
+    },
+    {
+        "key": "@mstat",
+        "category": "Building",
+        "text": """Help for @mstat
+
+Display stats for an NPC or prototype. Prototype information is read
+from ``world/prototypes/npcs.json`` and this command never changes an
+NPC. Use |w@medit|n for modifications.
+
+Usage:
+    @mstat <npc or proto>
+
+Examples:
+    @mstat bandit
+    @mstat Bob
+""",
+    },
+    {
+        "key": "@mlist",
+        "category": "Building",
+        "text": """Help for @mlist
+
+List NPC prototypes or counts of spawned NPCs. Prototypes are read from
+``world/prototypes/npcs.json``. Listing does not modify any NPCs; use
+|w@medit|n if you need to update them.
+
+Usage:
+    @mlist [area] [/room|/area] [filters]
+
+Examples:
+    @mlist
+    @mlist town
+    @mlist /room
+""",
+    },
+    {
+        "key": "@mspawn",
+        "category": "Building",
+        "text": """Help for @mspawn
+
+Spawn an NPC from a prototype defined in
+``world/prototypes/npcs.json``. Spawning creates a new NPC and leaves
+existing ones untouched. Modify live NPCs with |w@medit|n.
+
+Usage:
+    @mspawn <prototype>
+
+Examples:
+    @mspawn bandit
+    @mspawn mob_guard
+""",
+    },
+    {
         "key": "triggers",
         "category": "Building",
         "text": """


### PR DESCRIPTION
## Summary
- expand in-code docs for `CmdMCreate`, `CmdMSet`, `CmdMStat`, `CmdMList`, and `CmdMSpawn`
- add dedicated help entries describing how these commands interact with `world/prototypes/npcs.json`

## Testing
- `flake8` *(fails: command not found)*
- `pytest -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6846f9d24c7c832c8775e6e0191091a0