### PR TITLE
Use detection for stealth check

### DIFF
--- a/typeclasses/tests/test_stats.py
+++ b/typeclasses/tests/test_stats.py
@@ -1,3 +1,4 @@
+from unittest.mock import MagicMock
 from evennia.utils.test_resources import EvenniaTest
 from world import stats
 
@@ -49,3 +50,21 @@ class TestStats(EvenniaTest):
         initial_block = stats.sum_bonus(char, "block_rate")
         char.traits.STR.base += 5
         self.assertGreater(stats.sum_bonus(char, "block_rate"), initial_block)
+
+    def test_stealth_fails_against_high_detection(self):
+        attacker = self.char1
+        target = self.char2
+        stats.apply_stats(attacker)
+        stats.apply_stats(target)
+        attacker.traits.stealth.base = 5
+        target.traits.detection.base = 10
+        attacker.db.is_stealthed = True
+        attacker.msg = MagicMock()
+        target.msg = MagicMock()
+
+        failed = stats.check_stealth_detection(attacker, target)
+
+        self.assertTrue(failed)
+        self.assertFalse(attacker.db.is_stealthed)
+        attacker.msg.assert_called()
+        target.msg.assert_called()

--- a/world/stats.py
+++ b/world/stats.py
@@ -160,12 +160,12 @@ from world.system import state_manager
 
 
 def check_stealth_detection(attacker, target) -> bool:
-    """Compare attacker stealth vs target perception."""
+    """Compare attacker stealth vs target detection."""
     attacker_stealth = state_manager.get_effective_stat(attacker, "stealth")
-    target_perception = state_manager.get_effective_stat(target, "perception")
-    if target_perception >= attacker_stealth:
+    target_detection = state_manager.get_effective_stat(target, "detection")
+    if target_detection >= attacker_stealth:
         attacker.msg(
-            "|rYour stealth attempt fails. The target's perception is too high – they notice you!|n"
+            "|rYour stealth attempt fails. The target's detection is too high – they notice you!|n"
         )
         target.msg(
             "|gYou sense movement nearby and spot the incoming attack before it lands!|n"


### PR DESCRIPTION
## Summary
- rely on detection for stealth checks
- update stealth detection failure message
- add unit test to verify detection vs stealth

## Testing
- `python -m py_compile world/stats.py typeclasses/tests/test_stats.py`
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6846ffd8154c832c945ebf74eea6040e