### PR TITLE
Ensure GlobalTick processes status timers

### DIFF
--- a/typeclasses/scripts.py
+++ b/typeclasses/scripts.py
@@ -256,6 +256,9 @@ class GlobalTick(Script):
         from .characters import PlayerCharacter
         from world.system import state_manager
 
+        # Advance timers on all characters before applying regen
+        state_manager.tick_all()
+
         tickables = search_tag(key="tickable")
         for obj in tickables:
             if not hasattr(obj, "traits"):


### PR DESCRIPTION
## Summary
- tick all characters in `GlobalTick.at_repeat`
- adapt GlobalTick tests for `tick_all`
- add new test confirming effects expire on tick

## Testing
- `pytest -q` *(fails: 287 failed, 7 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6847022df3ec832c840e41e9e879e138