### PR TITLE
Add stat-based combat modifiers

### DIFF
--- a/combat/combat_engine.py
+++ b/combat/combat_engine.py
@@ -81,8 +81,11 @@ class CombatEngine:
     def track_aggro(self, target, attacker) -> None:
         if not target or target is attacker:
             return
+        from world.system import state_manager
+
         data = self.aggro.setdefault(target, {})
-        data[attacker] = data.get(attacker, 0) + 1
+        threat = 1 + state_manager.get_effective_stat(attacker, "threat")
+        data[attacker] = data.get(attacker, 0) + threat
 
     def handle_defeat(self, target, attacker) -> None:
         if hasattr(target, "on_exit_combat"):

--- a/typeclasses/tests/test_extended_stats.py
+++ b/typeclasses/tests/test_extended_stats.py
@@ -1,0 +1,115 @@
+import unittest
+from unittest.mock import patch
+
+from evennia.utils.test_resources import EvenniaTest
+from django.test import override_settings
+from combat import combat_utils
+from typeclasses.gear import BareHand
+from world import stats
+from world.recipes.base import SkillRecipe
+from world.guilds import Guild, auto_promote, ADVENTURERS_GUILD_RANKS
+
+
+class DummyRecipe(SkillRecipe):
+    key = "dummy"
+    skill = ("smithing", 10)
+
+
+@override_settings(DEFAULT_HOME=None)
+class TestExtendedStats(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        stats.apply_stats(self.char1)
+        stats.apply_stats(self.char2)
+
+    def test_evasion_blocks_attack(self):
+        self.char2.traits.evasion.base = 100
+        with patch("combat.combat_utils.random.randint", return_value=1), patch(
+            "world.system.stat_manager.check_hit", return_value=True
+        ):
+            before = self.char2.traits.health.current
+            BareHand().at_attack(self.char1, self.char2)
+            self.assertEqual(self.char2.traits.health.current, before)
+
+    def test_attack_power_increases_damage(self):
+        self.char1.traits.attack_power.base = 100
+        self.char2.traits.armor.base = 0
+        with patch("combat.combat_utils.random.randint", return_value=100), patch(
+            "world.system.stat_manager.check_hit", return_value=True
+        ):
+            before = self.char2.traits.health.current
+            BareHand().at_attack(self.char1, self.char2)
+            self.assertLess(self.char2.traits.health.current, before - BareHand().damage)
+
+    def test_piercing_reduces_armor(self):
+        self.char1.traits.piercing.base = 5
+        self.char2.db.armor = 10
+        dmg = self.char2.at_damage(self.char1, 20)
+        self.assertEqual(dmg, 15)
+
+    def test_spell_pen_and_resist(self):
+        self.char1.traits.spell_penetration.base = 5
+        self.char2.traits.magic_resist.base = 10
+        dmg = self.char2.at_damage(self.char1, 20, damage_type="fire")
+        self.assertEqual(dmg, 15)
+
+    def test_lifesteal_and_leech(self):
+        self.char1.traits.lifesteal.base = 50
+        self.char1.traits.leech.base = 50
+        self.char1.traits.health.current = 50
+        self.char1.traits.mana.current = 50
+        before_hp = self.char1.traits.health.current
+        before_mp = self.char1.traits.mana.current
+        combat_utils.apply_lifesteal(self.char1, 20)
+        self.assertGreater(self.char1.traits.health.current, before_hp)
+        self.assertGreater(self.char1.traits.mana.current, before_mp)
+
+    def test_cooldown_reduction(self):
+        from world.system import state_manager
+
+        self.char1.traits.cooldown_reduction.base = 50
+        state_manager.add_cooldown(self.char1, "test", 10)
+        self.assertLess(self.char1.cooldowns.time_left("test", use_int=True), 10)
+
+    def test_movement_speed_reduces_cost(self):
+        self.char1.traits.movement_speed.base = 2
+        self.char1.db.carry_capacity = 10
+        self.char1.db.carry_weight = 20
+        self.char1.traits.stamina.current = 10
+        self.char1.at_post_move(self.room1)
+        self.assertEqual(self.char1.traits.stamina.current, 9)
+
+    def test_pvp_power_and_resilience(self):
+        self.char1.traits.pvp_power.base = 100
+        self.char2.traits.pvp_resilience.base = 0
+        self.char2.traits.armor.base = 0
+        dmg = self.char2.at_damage(self.char1, 10)
+        self.assertEqual(dmg, 20)
+
+    def test_threat_increases_aggro(self):
+        from combat.combat_engine import CombatEngine
+
+        self.char1.traits.threat.base = 5
+        engine = CombatEngine([self.char1, self.char2], round_time=0)
+        engine.track_aggro(self.char2, self.char1)
+        self.assertGreater(engine.aggro[self.char2][self.char1], 1)
+
+    def test_craft_bonus_affects_roll(self):
+        recipe = DummyRecipe(crafter=self.char1)
+        self.char1.traits.add("smithing", "Smith", trait_type="counter")
+        self.char1.traits.smithing.base = 20
+        self.char1.traits.craft_bonus.base = 5
+        with patch("world.recipes.base.randint", return_value=1) as mock_rand:
+            recipe.craft()
+            mock_rand.assert_called_with(0, 15)
+
+    def test_guild_honor_mod_promotes(self):
+        guild = Guild("Test", ranks=ADVENTURERS_GUILD_RANKS, rank_thresholds={t: v for v, t in ADVENTURERS_GUILD_RANKS})
+        self.char1.db.guild_points = {"Test": 9}
+        self.char1.traits.guild_honor_mod.base = 20
+        auto_promote(self.char1, guild)
+        self.assertEqual(self.char1.db.guild_rank, "Corporal")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/world/guilds.py
+++ b/world/guilds.py
@@ -133,8 +133,12 @@ def auto_promote(player, guild: Guild):
     """Update player's guild rank based on their points in the guild."""
     if not guild.rank_thresholds:
         return
+    from world.system import state_manager
+
     gp_map = player.db.guild_points or {}
     points = gp_map.get(guild.name, 0)
+    mod = state_manager.get_effective_stat(player, "guild_honor_mod")
+    points = int(points * (1 + mod / 100))
     new_rank = ""
     for title, threshold in sorted(guild.rank_thresholds.items(), key=lambda it: it[1]):
         if points >= threshold:

--- a/world/recipes/base.py
+++ b/world/recipes/base.py
@@ -42,7 +42,10 @@ class SkillRecipe(CraftingRecipe):
             )
             return
 
+        from world.system import state_manager
+
         success_rate = int(crafting_skill.value - difficulty)
+        success_rate += state_manager.get_effective_stat(crafter, "craft_bonus")
 
         # at this point the crafting attempt is considered happening, so subtract mana
         crafter.traits.mana.current -= 5

--- a/world/system/state_manager.py
+++ b/world/system/state_manager.py
@@ -100,6 +100,9 @@ def has_status(chara, status: str) -> bool:
 
 def add_cooldown(chara, key: str, duration: int):
     """Wrapper to add a cooldown to ``chara``."""
+    reduction = get_effective_stat(chara, "cooldown_reduction")
+    if reduction:
+        duration = max(0, int(round(duration * (1 - reduction / 100))))
     chara.cooldowns.add(key, duration)
 
 


### PR DESCRIPTION
## Summary
- add blocking, parry, lifesteal and damage scaling helpers
- use new helpers in melee attacks
- factor new stats into Character.defense and cooldown logic
- apply movement speed to movement cost
- extend aggro and guild/crafting systems
- test various stat effects

## Testing
- `pytest -q typeclasses/tests/test_extended_stats.py`
- `pytest -q` *(fails: 56 failed, 32 passed)*


------
https://chatgpt.com/codex/tasks/task_e_68470450fe6c832ca058bae6be731009