### PR TITLE
Add evasion rolls to more attack types

### DIFF
--- a/combat/combat_skills.py
+++ b/combat/combat_skills.py
@@ -15,7 +15,7 @@ class SkillCategory(str, Enum):
     MAGIC = "magic"
 
 from .combat_actions import CombatResult
-from .combat_utils import roll_damage, check_hit
+from .combat_utils import roll_damage, check_hit, roll_evade
 from .combat_states import CombatState
 
 
@@ -47,6 +47,12 @@ class ShieldBash(Skill):
             return CombatResult(actor=user, target=target, message="They are already down.")
         hit = check_hit(user, target)
         if hit:
+            if roll_evade(user, target):
+                return CombatResult(
+                    actor=user,
+                    target=target,
+                    message=f"{user.key}'s shield bash misses {target.key}.",
+                )
             dmg = roll_damage(self.damage)
             target.hp = max(target.hp - dmg, 0)
             return CombatResult(
@@ -75,9 +81,12 @@ class Cleave(Skill):
         if not getattr(target, "is_alive", lambda: True)():
             return CombatResult(actor=user, target=target, message="They are already down.")
         if check_hit(user, target):
-            dmg = roll_damage(self.damage)
-            target.hp = max(target.hp - dmg, 0)
-            msg = f"{user.key} cleaves {target.key} for {dmg} damage!"
+            if roll_evade(user, target):
+                msg = f"{user.key}'s cleave misses {target.key}."
+            else:
+                dmg = roll_damage(self.damage)
+                target.hp = max(target.hp - dmg, 0)
+                msg = f"{user.key} cleaves {target.key} for {dmg} damage!"
         else:
             msg = f"{user.key}'s cleave misses {target.key}."
         return CombatResult(actor=user, target=target, message=msg)

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -205,6 +205,7 @@ class Character(ObjectParent, ClothedCharacter):
     def at_object_creation(self):
         from world import stats
         from world.system import stat_manager
+        from combat import combat_utils
 
         # Apply all default stats in a single modular step. If stats already
         # exist on the character, `apply_stats` will not overwrite them.
@@ -1105,6 +1106,14 @@ class NPC(Character):
                 mapping={"target": target},
             )
         else:
+            if combat_utils.roll_evade(wielder, target):
+                self.at_emote(
+                    f"$conj(swings) $pron(your) {weapon.get('name')} at $you(target), but they evade.",
+                    mapping={"target": target},
+                )
+                wielder.msg(f"[ Cooldown: {speed} seconds ]")
+                wielder.cooldowns.add("attack", speed)
+                return
             verb = weapon.get("damage_type", "hits")
             crit = stat_manager.roll_crit(wielder, target)
             if crit:

--- a/typeclasses/tests/test_characters.py
+++ b/typeclasses/tests/test_characters.py
@@ -397,3 +397,12 @@ class TestCombatResists(EvenniaTest):
         base = self.char2.traits.health.current
         self.char2.at_damage(self.char1, 10)
         self.assertEqual(self.char2.traits.health.current, base - 5)
+
+    def test_evasion_prevents_weapon_damage(self):
+        self.char2.traits.evasion.base = 100
+        with patch("world.system.stat_manager.check_hit", return_value=True), patch(
+            "combat.combat_utils.random.randint", return_value=1
+        ):
+            before = self.char2.traits.health.current
+            self.weapon.at_attack(self.char1, self.char2)
+            self.assertEqual(self.char2.traits.health.current, before)

--- a/typeclasses/tests/test_skill_spell_usage.py
+++ b/typeclasses/tests/test_skill_spell_usage.py
@@ -33,3 +33,12 @@ class TestSkillAndSpellUsage(EvenniaTest):
             mock_add.assert_called_with(self.char2, "stunned", 1)
             self.assertEqual(self.char2.hp, 6)
 
+    def test_skill_evade_prevents_damage(self):
+        self.char2.hp = 10
+        with patch("combat.combat_skills.check_hit", return_value=True), \
+             patch("combat.combat_skills.roll_evade", return_value=True), \
+             patch("combat.combat_skills.roll_damage", return_value=4):
+            result = self.char1.use_skill("cleave", target=self.char2)
+        self.assertEqual(self.char2.hp, 10)
+        self.assertIn("misses", result.message)
+


### PR DESCRIPTION
## Summary
- call `combat_utils.roll_evade` in Character natural attacks and combat skills
- add unit tests for evasion negating melee weapon and skill damage

## Testing
- `pytest -q` *(fails: OperationalError no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684708f44be0832cbec7b052b47d0db8