### PR TITLE
Add deldir command

### DIFF
--- a/commands/admin.py
+++ b/commands/admin.py
@@ -13,6 +13,7 @@ from .building import (
     CmdSetBuff,
     CmdSetFlag,
     CmdRemoveFlag,
+    CmdDelDir,
 )
 from world.stats import CORE_STAT_KEYS, ALL_STATS
 from world.system import stat_manager
@@ -1415,6 +1416,7 @@ class BuilderCmdSet(CmdSet):
         self.add(CmdSetBuff)
         self.add(CmdSetFlag)
         self.add(CmdRemoveFlag)
+        self.add(CmdDelDir)
         self.add(CmdCNPC)
         self.add(CmdEditNPC)
         self.add(CmdMedit)

--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -710,6 +710,17 @@ class TestExtendedDigTeleport(EvenniaTest):
         self.assertEqual(self.char1.location, start)
 
 
+class TestDelDirCommand(EvenniaTest):
+    def test_deldir_removes_exits(self):
+        start = self.char1.location
+        self.char1.execute_cmd("dig north")
+        new_room = start.db.exits.get("north")
+        self.assertIsNotNone(new_room)
+        self.char1.execute_cmd("deldir north")
+        self.assertNotIn("north", start.db.exits)
+        self.assertNotIn("south", new_room.db.exits)
+
+
 class TestRoomFlagCommands(EvenniaTest):
     def setUp(self):
         super().setUp()

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -1454,6 +1454,34 @@ Related:
 """,
     },
     {
+        "key": "deldir",
+        "category": "Building",
+        "text": """
+Help for deldir
+
+Delete an exit from the current room.
+
+Usage:
+    deldir <direction>
+
+Switches:
+    None
+
+Arguments:
+    None
+
+Examples:
+    None
+
+Notes:
+    - Removes the exit in the given direction. If the adjoining room
+    - links back here, that exit is removed as well.
+
+Related:
+    help ansi
+""",
+    },
+    {
         "key": "@teleport",
         "category": "Building",
         "text": """


### PR DESCRIPTION
## Summary
- add `CmdDelDir` for builders to remove exits
- make BuilderCmdSet include new command
- document `deldir`
- test that deldir removes exits

## Testing
- `pytest -q` *(fails: OperationalError no such table accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68470c995b78832cb621149580cd97e1