### PR TITLE
Add command to delete rooms

### DIFF
--- a/commands/admin.py
+++ b/commands/admin.py
@@ -14,6 +14,7 @@ from .building import (
     CmdSetFlag,
     CmdRemoveFlag,
     CmdDelDir,
+    CmdDelRoom,
 )
 from world.stats import CORE_STAT_KEYS, ALL_STATS
 from world.system import stat_manager
@@ -1417,6 +1418,7 @@ class BuilderCmdSet(CmdSet):
         self.add(CmdSetFlag)
         self.add(CmdRemoveFlag)
         self.add(CmdDelDir)
+        self.add(CmdDelRoom)
         self.add(CmdCNPC)
         self.add(CmdEditNPC)
         self.add(CmdMedit)

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -36,7 +36,7 @@ from commands.info import InfoCmdSet
 from commands.guilds import GuildCmdSet
 from commands.rest import RestCmdSet
 from commands.who import CmdWho
-from commands.building import CmdDig, CmdTeleport
+from commands.building import CmdDig, CmdTeleport, CmdDelRoom
 from commands.areas import AreaCmdSet
 from commands.room_flags import RoomFlagCmdSet
 from commands.admin import AdminCmdSet, BuilderCmdSet
@@ -80,6 +80,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(EquipmentCmdSet)
         self.add(CmdDig)
         self.add(CmdTeleport)
+        self.add(CmdDelRoom)
         self.add(RoomFlagCmdSet)
         self.add(AreaCmdSet)
         self.add(AdminCmdSet)

--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -721,6 +721,27 @@ class TestDelDirCommand(EvenniaTest):
         self.assertNotIn("south", new_room.db.exits)
 
 
+class TestDelRoomCommand(EvenniaTest):
+    def test_delroom_by_direction(self):
+        start = self.char1.location
+        self.char1.execute_cmd("dig north")
+        target = start.db.exits.get("north")
+        self.assertIsNotNone(target)
+        self.char1.execute_cmd("delroom north")
+        self.assertIsNone(target.pk)
+        self.assertNotIn("north", start.db.exits)
+
+    def test_delroom_area_number(self):
+        self.char1.execute_cmd("amake test 1-5")
+        start = self.char1.location
+        self.char1.execute_cmd("dig east test 2")
+        target = start.db.exits.get("east")
+        self.assertIsNotNone(target)
+        self.char1.execute_cmd("delroom test 2")
+        self.assertIsNone(target.pk)
+        self.assertNotIn("east", start.db.exits)
+
+
 class TestRoomFlagCommands(EvenniaTest):
     def setUp(self):
         super().setUp()

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -1482,6 +1482,35 @@ Related:
 """,
     },
     {
+        "key": "delroom",
+        "category": "Building",
+        "text": """
+Help for delroom
+
+Delete a room by direction or by area and number.
+
+Usage:
+    delroom <direction>
+    delroom <area> <number>
+
+Switches:
+    None
+
+Arguments:
+    None
+
+Examples:
+    delroom north
+    delroom test 2
+
+Notes:
+    - Removes any exits to or from the deleted room.
+
+Related:
+    help ansi
+""",
+    },
+    {
         "key": "@teleport",
         "category": "Building",
         "text": """


### PR DESCRIPTION
## Summary
- allow deleting rooms in building commands
- load the new command in builder-related commandsets
- document `delroom` usage
- test command behaviour

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68470e77d52c832cabcab7d9f3e739a6