### PR TITLE
Implement rmake command

### DIFF
--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -315,6 +315,34 @@ Notes:
     - The id must be unique within the area's range.
 
 Related:
+        help ansi
+""",
+    },
+    {
+        "key": "rmake",
+        "category": "Building",
+        "text": """
+Help for rmake
+
+Create an unlinked room in a registered area.
+
+Usage:
+    rmake <area> <number>
+
+Switches:
+    None
+
+Arguments:
+    None
+
+Examples:
+    rmake dungeon 1
+
+Notes:
+    - The number must fall within the area's range.
+    - The room is not automatically linked to any others.
+
+Related:
     help ansi
 """,
     },


### PR DESCRIPTION
## Summary
- add `CmdRMake` for creating unlinked rooms in a registered area
- document `rmake` command
- test that builders can create first rooms remotely

## Testing
- `pytest -q` *(fails: django.db.utils.OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684711b7a240832ca16e628d555a8835