### PR TITLE
Add tp alias for teleport command

### DIFF
--- a/commands/building.py
+++ b/commands/building.py
@@ -154,11 +154,13 @@ class CmdTeleport(Command):
 
     Usage:
         @teleport
+        tp
 
     See |whelp @teleport|n for details.
     """
 
     key = "@teleport"
+    aliases = ["tp"]
     locks = "cmd:perm(Builder) or perm(Admin) or perm(Developer)"
     help_category = "Building"
 

--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -733,11 +733,11 @@ class TestExtendedDigTeleport(EvenniaTest):
         start = self.char1.location
         self.char1.execute_cmd("dig east=test:3")
         target = start.db.exits.get("east")
-        self.char1.execute_cmd("@teleport test:3")
+        self.char1.execute_cmd("tp test:3")
         self.assertEqual(self.char1.location, target)
         # out of range should not move
         self.char1.location = start
-        self.char1.execute_cmd("@teleport test:6")
+        self.char1.execute_cmd("tp test:6")
         self.assertEqual(self.char1.location, start)
 
 

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -1540,14 +1540,16 @@ Related:
     },
     {
         "key": "@teleport",
+        "aliases": ["tp"],
         "category": "Building",
         "text": """
-Help for @teleport
+Help for @teleport (tp)
 
 Teleport directly to a room. Usage: @teleport <area>:<number>
 
 Usage:
     @teleport <area>:<number>
+    tp <area>:<number>
 
 Switches:
     None


### PR DESCRIPTION
## Summary
- add `tp` alias for `CmdTeleport`
- mention the new alias in help entries
- update command tests to use `tp`

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684713a67c10832cb9946c59926f3d6d