### PR TITLE
Add room registration command

### DIFF
--- a/commands/README.md
+++ b/commands/README.md
@@ -35,6 +35,8 @@ Builders can tweak the current room with a few simple commands:
   argument it will show the current description.
 * `rset area <area>` or `rset id <number>` - assign the room to an
   area or change its id within that area.
+* `rreg <area> <number>` or `rreg <room> <area> <number>` - register a
+  room to an area and numeric id.
 
 ## Object Editing Commands
 

--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -842,6 +842,26 @@ class TestRoomSetCommand(EvenniaTest):
         self.char1.msg.assert_called_with("Number outside area range.")
 
 
+class TestRoomRegCommand(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.char1.msg = MagicMock()
+        self.char1.execute_cmd("amake zone 1-10")
+
+    def test_rreg_current_room(self):
+        self.char1.execute_cmd("rreg zone 3")
+        self.assertEqual(self.char1.location.db.area, "zone")
+        self.assertEqual(self.char1.location.db.room_id, 3)
+
+    def test_rreg_other_room(self):
+        start = self.char1.location
+        self.char1.execute_cmd("dig north")
+        target = start.db.exits.get("north")
+        self.char1.execute_cmd(f"rreg #{target.id} zone 4")
+        self.assertEqual(target.db.area, "zone")
+        self.assertEqual(target.db.room_id, 4)
+
+
 class TestAdminCommands(EvenniaTest):
     def setUp(self):
         super().setUp()

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -347,6 +347,35 @@ Related:
 """,
     },
     {
+        "key": "rreg",
+        "category": "Building",
+        "text": """
+Help for rreg
+
+Assign the current room or a specified room to an area and number.
+
+Usage:
+    rreg <area> <number>
+    rreg <room> <area> <number>
+
+Switches:
+    None
+
+Arguments:
+    None
+
+Examples:
+    rreg test 2
+    rreg #10 test 3
+
+Notes:
+    - The number must fall within the area's range and be unique.
+
+Related:
+    help ansi
+""",
+    },
+    {
         "key": "ocreate",
         "category": "Building",
         "text": """


### PR DESCRIPTION
## Summary
- implement `rreg` command to register rooms with an area and number
- document `rreg` in help entries and README
- test room registration

## Testing
- `pytest -q` *(fails: `OperationalError: no such table: accounts_accountdb`)*

------
https://chatgpt.com/codex/tasks/task_e_6847159f5ae8832ca9115647d7a20b19