### PR TITLE
Add kill alias to attack command

### DIFF
--- a/commands/combat.py
+++ b/commands/combat.py
@@ -19,7 +19,7 @@ class CmdAttack(Command):
     """
 
     key = "attack"
-    aliases = ("att", "hit", "shoot")
+    aliases = ("att", "hit", "shoot", "kill", "k")
     help_category = "Combat"
 
     def parse(self):

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -2365,6 +2365,7 @@ Related:
     },
     {
         "key": "attack",
+        "aliases": ["att", "hit", "shoot", "kill", "k"],
         "category": "Combat",
         "text": """
 Help for attack


### PR DESCRIPTION
## Summary
- allow `attack` to be triggered using `kill` or `k`
- document aliases in help text

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6847188638f4832cb718ff4f640dd14b