### PR TITLE
Sort help index alphabetically

### DIFF
--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -17,6 +17,7 @@ own cmdsets by inheriting from them or directly from `evennia.CmdSet`.
 from evennia import default_cmds
 from evennia.contrib.game_systems.clothing import ClothedCharacterCmdSet
 from commands.equip import CmdWear
+from commands.help import CmdHelp
 
 from evennia.contrib.game_systems.containers.containers import ContainerCmdSet
 from evennia.contrib.grid.xyzgrid.commands import XYZGridCmdSet
@@ -62,6 +63,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         #
         # any commands you add below will overload the default ones.
         #
+        self.add(CmdHelp())
         self.add(ClothedCharacterCmdSet)
         self.add(CmdWear())
         self.add(CmdMoney)
@@ -87,6 +89,8 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(BuilderCmdSet)
         self.add(QuestCmdSet)
         self.add(AchievementCmdSet)
+        # Override the default help command to sort the index alphabetically
+        self.add(CmdHelp())
 
 
 class AccountCmdSet(default_cmds.AccountCmdSet):
@@ -110,6 +114,8 @@ class AccountCmdSet(default_cmds.AccountCmdSet):
         self.add(ContribCmdCharCreate)
         self.add(AccountOptsCmdSet)
         self.add(CmdWho)
+        # Override the default help command to sort the index alphabetically
+        self.add(CmdHelp())
 
 
 class UnloggedinCmdSet(default_cmds.UnloggedinCmdSet):
@@ -128,6 +134,7 @@ class UnloggedinCmdSet(default_cmds.UnloggedinCmdSet):
         #
         # any commands you add below will overload the default ones.
         #
+        self.add(CmdHelp())
 
 
 class SessionCmdSet(default_cmds.SessionCmdSet):
@@ -150,3 +157,4 @@ class SessionCmdSet(default_cmds.SessionCmdSet):
         #
         # any commands you add below will overload the default ones.
         #
+        self.add(CmdHelp())

--- a/commands/help.py
+++ b/commands/help.py
@@ -1,0 +1,26 @@
+from evennia.commands.default.help import CmdHelp as DefaultCmdHelp
+
+
+class CmdHelp(DefaultCmdHelp):
+    """Help command with alphabetically sorted index."""
+
+    def format_help_index(
+        self,
+        cmd_help_dict=None,
+        db_help_dict=None,
+        title_lone_category=False,
+        click_topics=True,
+    ):
+        """Ensure help topics are sorted alphabetically before display."""
+        cmd_help_dict = {
+            cat: sorted(topics)
+            for cat, topics in sorted((cmd_help_dict or {}).items())
+        }
+        db_help_dict = {
+            cat: sorted(topics)
+            for cat, topics in sorted((db_help_dict or {}).items())
+        }
+        return super().format_help_index(
+            cmd_help_dict, db_help_dict, title_lone_category, click_topics
+        )
+

--- a/typeclasses/tests/test_help_index.py
+++ b/typeclasses/tests/test_help_index.py
@@ -1,0 +1,22 @@
+from unittest.mock import MagicMock
+from evennia.utils.test_resources import EvenniaTest
+from django.test import override_settings
+from evennia.utils.ansi import strip_ansi
+
+@override_settings(DEFAULT_HOME=None)
+class TestHelpIndexOrdering(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.char1.msg = MagicMock()
+
+    def test_help_index_sorted(self):
+        self.char1.execute_cmd('help')
+        out = strip_ansi(self.char1.msg.call_args[0][0])
+        entries = []
+        for line in out.splitlines():
+            line = line.strip()
+            if not line or line.startswith('--') or line.startswith('Commands') or line.startswith('Game'):
+                continue
+            entries.extend(line.split())
+        self.assertEqual(entries, sorted(entries, key=str.lower))
+


### PR DESCRIPTION
## Summary
- customize CmdHelp to sort help index
- use new CmdHelp in default cmdsets
- test that help index is alphabetical

## Testing
- `pytest typeclasses/tests/test_help_index.py::TestHelpIndexOrdering::test_help_index_sorted -q` *(fails: TypeError: 'NoneType' object is not subscriptable)*

------
https://chatgpt.com/codex/tasks/task_e_684726c3a198832caa19359828482318