### PR TITLE
Enable attack default for new mobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,8 @@ Prototype** to spawn it and also store the prototype in
 `world/prototypes/npcs.json` with `mob_` prefixed to the key. Use
 `@mspawn <prototype>` to create additional copies and `@mstat <key>` to inspect
 them. Prototype entries can be adjusted with `@mcreate`, `@mset` and viewed with
-`@mlist`.
+`@mlist`. Mobs created this way are flagged with `can_attack` and are given a
+simple punch attack so they can fight back without equipment.
 
 Example::
 

--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -950,6 +950,16 @@ def _create_npc(caller, raw_string, register=False, **kwargs):
         except Exception as err:  # pragma: no cover - log errors
             caller.msg(f"Could not attach script {script_path}: {err}")
     npc.db.creature_type = data.get("creature_type")
+    if data.get("use_mob"):
+        npc.db.can_attack = True
+        if not npc.db.natural_weapon:
+            npc.db.natural_weapon = {
+                "name": "fists",
+                "damage_type": "bash",
+                "damage": 1,
+                "speed": 10,
+                "stamina_cost": 5,
+            }
     npc.db.level = data.get("level", 1)
     for trait, val in {
         "health": data.get("hp"),
@@ -981,6 +991,18 @@ def _create_npc(caller, raw_string, register=False, **kwargs):
             proto_key = f"mob_{proto_key}"
             data["proto_key"] = proto_key
         proto = {k: v for k, v in data.items() if k not in ("edit_obj", "proto_key")}
+        if data.get("use_mob"):
+            proto["can_attack"] = True
+            proto.setdefault(
+                "natural_weapon",
+                {
+                    "name": "fists",
+                    "damage_type": "bash",
+                    "damage": 1,
+                    "speed": 10,
+                    "stamina_cost": 5,
+                },
+            )
         if data.get("script"):
             proto["scripts"] = [data["script"]]
         prototypes.register_npc_prototype(proto_key, proto)


### PR DESCRIPTION
## Summary
- set can_attack and natural_weapon defaults when mobbuilder spawns NPCs
- persist the flags in saved prototypes
- document automatic attack defaults in Mob Builder docs

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68473015ab60832c91bf555328a82c99