### PR TITLE
Fix NPC spawner typeclass use

### DIFF
--- a/commands/mob_builder.py
+++ b/commands/mob_builder.py
@@ -61,6 +61,11 @@ class CmdMSpawn(Command):
         if not proto:
             self.msg("Prototype not found.")
             return
+        tclass_path = npc_builder.NPC_CLASS_MAP.get(
+            proto.get("npc_class", "base"), "typeclasses.npcs.BaseNPC"
+        )
+        proto = dict(proto)
+        proto.setdefault("typeclass", tclass_path)
         obj = spawner.spawn(proto)[0]
         obj.move_to(self.caller.location, quiet=True)
         self.msg(f"Spawned {obj.key}.")

--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -991,6 +991,7 @@ def _create_npc(caller, raw_string, register=False, **kwargs):
             proto_key = f"mob_{proto_key}"
             data["proto_key"] = proto_key
         proto = {k: v for k, v in data.items() if k not in ("edit_obj", "proto_key")}
+        proto["typeclass"] = tclass_path
         if data.get("use_mob"):
             proto["can_attack"] = True
             proto.setdefault(
@@ -1225,6 +1226,9 @@ class CmdSpawnNPC(Command):
         if not proto:
             self.msg("Unknown NPC prototype.")
             return
+        tclass_path = NPC_CLASS_MAP.get(proto.get("npc_class", "base"), "typeclasses.npcs.BaseNPC")
+        proto = dict(proto)
+        proto.setdefault("typeclass", tclass_path)
         obj = spawner.spawn(proto)[0]
         obj.move_to(self.caller.location, quiet=True)
         obj.db.prototype_key = key

--- a/typeclasses/tests/test_mob_builder.py
+++ b/typeclasses/tests/test_mob_builder.py
@@ -61,10 +61,12 @@ class TestMobBuilder(EvenniaTest):
 
         reg = prototypes.get_npc_prototypes()
         assert "mob_goblin" in reg
+        assert reg["mob_goblin"]["typeclass"] == "typeclasses.npcs.BaseNPC"
 
         self.char1.execute_cmd("@mspawn mob_goblin")
         npc = self._find("goblin")
         assert npc is not None
+        assert npc.is_typeclass(BaseNPC, exact=False)
 
         self.char1.execute_cmd("@mstat mob_goblin")
         out = self.char1.msg.call_args[0][0]


### PR DESCRIPTION
## Summary
- ensure `@spawnnpc` and `@mspawn` set NPC typeclass from `npc_class`
- include `typeclass` when saving NPC prototypes
- test builder spawn uses BaseNPC typeclass

## Testing
- `pytest typeclasses/tests/test_mob_builder.py::TestMobBuilder::test_builder_flow_and_spawn -q` *(fails: django.db.utils.OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684792d96640832c97fa6a777c18d60c