### PR TITLE
Centralize combat roll helpers

### DIFF
--- a/combat/combat_skills.py
+++ b/combat/combat_skills.py
@@ -15,8 +15,9 @@ class SkillCategory(str, Enum):
     MAGIC = "magic"
 
 from .combat_actions import CombatResult
-from .combat_utils import roll_damage, check_hit, roll_evade
+from .combat_utils import roll_damage, roll_evade
 from .combat_states import CombatState
+from world.system import stat_manager
 
 
 @dataclass
@@ -45,7 +46,7 @@ class ShieldBash(Skill):
     def resolve(self, user, target):
         if not getattr(target, "is_alive", lambda: True)():
             return CombatResult(actor=user, target=target, message="They are already down.")
-        hit = check_hit(user, target)
+        hit = stat_manager.check_hit(user, target)
         if hit:
             if roll_evade(user, target):
                 return CombatResult(
@@ -80,7 +81,7 @@ class Cleave(Skill):
     def resolve(self, user, target):
         if not getattr(target, "is_alive", lambda: True)():
             return CombatResult(actor=user, target=target, message="They are already down.")
-        if check_hit(user, target):
+        if stat_manager.check_hit(user, target):
             if roll_evade(user, target):
                 msg = f"{user.key}'s cleave misses {target.key}."
             else:

--- a/combat/combat_utils.py
+++ b/combat/combat_utils.py
@@ -5,6 +5,7 @@ import random
 from typing import Tuple
 
 from world.system import state_manager
+from world.system.stat_manager import check_hit, roll_crit, crit_damage
 
 logger = logging.getLogger(__name__)
 
@@ -13,48 +14,6 @@ def roll_damage(dice: Tuple[int, int]) -> int:
     """Roll NdN style damage."""
     count, sides = dice
     return sum(random.randint(1, sides) for _ in range(count))
-
-
-def check_hit(attacker, target, bonus: int = 0) -> bool:
-    """Determine if attacker hits target."""
-    attack = state_manager.get_effective_stat(attacker, "accuracy") + bonus
-    defense = state_manager.get_effective_stat(target, "dodge")
-    roll = random.randint(1, 20)
-    result = roll + attack >= 10 + defense
-    logger.debug(
-        "hit roll=%s att=%s def=%s result=%s",
-        roll,
-        attack,
-        defense,
-        result,
-    )
-    return result
-
-
-def roll_crit(attacker, target) -> bool:
-    """Return ``True`` if ``attacker`` scores a critical hit."""
-
-    chance = state_manager.get_effective_stat(attacker, "crit_chance")
-    chance -= state_manager.get_effective_stat(target, "crit_resist")
-    chance = max(0, chance)
-    roll = random.randint(1, 100)
-    result = roll <= chance
-    logger.debug(
-        "crit roll=%s chance=%s result=%s",
-        roll,
-        chance,
-        result,
-    )
-    return result
-
-
-def crit_damage(attacker, damage: int) -> int:
-    """Return ``damage`` adjusted by ``attacker``'s crit bonus."""
-
-    bonus = state_manager.get_effective_stat(attacker, "crit_bonus")
-    result = int(round(damage * (1 + bonus / 100)))
-    logger.debug("crit damage=%s bonus=%s result=%s", damage, bonus, result)
-    return result
 
 
 def roll_evade(attacker, target, base: int = 50) -> bool:

--- a/typeclasses/tests/test_skill_spell_usage.py
+++ b/typeclasses/tests/test_skill_spell_usage.py
@@ -26,18 +26,18 @@ class TestSkillAndSpellUsage(EvenniaTest):
 
     def test_shield_bash_adds_status_effect(self):
         self.char2.hp = 10
-        with patch("combat.combat_skills.check_hit", return_value=True), \
+        with patch("world.system.stat_manager.check_hit", return_value=True), \
              patch("combat.combat_skills.roll_damage", return_value=4), \
-             patch("world.system.state_manager.add_status_effect") as mock_add:
+              patch("world.system.state_manager.add_status_effect") as mock_add:
             self.char1.use_skill("shield bash", target=self.char2)
             mock_add.assert_called_with(self.char2, "stunned", 1)
             self.assertEqual(self.char2.hp, 6)
 
     def test_skill_evade_prevents_damage(self):
         self.char2.hp = 10
-        with patch("combat.combat_skills.check_hit", return_value=True), \
+        with patch("world.system.stat_manager.check_hit", return_value=True), \
              patch("combat.combat_skills.roll_evade", return_value=True), \
-             patch("combat.combat_skills.roll_damage", return_value=4):
+              patch("combat.combat_skills.roll_damage", return_value=4):
             result = self.char1.use_skill("cleave", target=self.char2)
         self.assertEqual(self.char2.hp, 10)
         self.assertIn("misses", result.message)

--- a/utils/tests/test_combat_utils.py
+++ b/utils/tests/test_combat_utils.py
@@ -60,9 +60,9 @@ class TestCombatUtils(EvenniaTest):
         self.char2.db.stat_overrides = {"crit_resist": 0}
         stat_manager.refresh_stats(self.char1)
         stat_manager.refresh_stats(self.char2)
-        with patch("combat.combat_utils.random.randint", return_value=10):
-            self.assertTrue(combat_utils.roll_crit(self.char1, self.char2))
-        self.assertEqual(combat_utils.crit_damage(self.char1, 10), 15)
+        with patch("world.system.stat_manager.randint", return_value=10):
+            self.assertTrue(stat_manager.roll_crit(self.char1, self.char2))
+        self.assertEqual(stat_manager.crit_damage(self.char1, 10), 15)
 
     def test_roll_evade(self):
         from combat import combat_utils


### PR DESCRIPTION
## Summary
- consolidate hit, crit, and crit damage logic in `stat_manager`
- pull helper imports from `stat_manager` inside combat utilities
- adjust combat skills to call `stat_manager.check_hit`
- update tests for new import paths

## Testing
- `pytest -q` *(fails: django.db.utils.OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6847979c486c832c852034395ed6b292