### PR TITLE
Rename combat state manager

### DIFF
--- a/combat/__init__.py
+++ b/combat/__init__.py
@@ -9,7 +9,7 @@ from .combat_actions import (
     SpellAction,
     CombatResult,
 )
-from .combat_states import CombatState, StateManager
+from .combat_states import CombatState, CombatStateManager
 from .combat_skills import Skill, ShieldBash, Cleave, SKILL_CLASSES
 from .damage_types import DamageType
 
@@ -22,7 +22,7 @@ __all__ = [
     "SpellAction",
     "CombatResult",
     "CombatState",
-    "StateManager",
+    "CombatStateManager",
     "Skill",
     "ShieldBash",
     "Cleave",

--- a/combat/combat_states.py
+++ b/combat/combat_states.py
@@ -19,7 +19,7 @@ class CombatState:
     on_tick: Optional[Callable[[object, "CombatState"], None]] = None
 
 
-class StateManager:
+class CombatStateManager:
     """Track active combat states on characters."""
 
     def __init__(self):

--- a/typeclasses/tests/test_combat_states.py
+++ b/typeclasses/tests/test_combat_states.py
@@ -1,5 +1,5 @@
 import unittest
-from combat.combat_states import CombatState, StateManager
+from combat.combat_states import CombatState, CombatStateManager
 
 
 class Dummy:
@@ -8,7 +8,7 @@ class Dummy:
 
 class TestCombatStates(unittest.TestCase):
     def test_stacking_and_diminish(self):
-        mgr = StateManager()
+        mgr = CombatStateManager()
         obj = Dummy()
         base = CombatState(key="bleeding", duration=4, max_stacks=3, diminish=0.5)
         mgr.add_state(obj, base)
@@ -39,7 +39,7 @@ class TestCombatStates(unittest.TestCase):
         def on_expire(o, s):
             events.append("expire")
 
-        mgr = StateManager()
+        mgr = CombatStateManager()
         obj = Dummy()
         state = CombatState(
             key="bleeding",


### PR DESCRIPTION
## Summary
- rename `StateManager` class to `CombatStateManager`
- update exports and imports accordingly
- update combat state tests

## Testing
- `pytest typeclasses/tests/test_combat_states.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68479a9d1e48832cba11d286c1fd7a9c