### PR TITLE
Add mob templates and command

### DIFF
--- a/commands/admin.py
+++ b/commands/admin.py
@@ -40,7 +40,14 @@ from .mob_builder_commands import (
     CmdRepairSet,
     CmdRepairStat,
 )
-from .mob_builder import CmdMobBuilder, CmdMSpawn, CmdMStat, CmdMList, CmdMedit
+from .mob_builder import (
+    CmdMobBuilder,
+    CmdMSpawn,
+    CmdMStat,
+    CmdMList,
+    CmdMedit,
+    CmdMobTemplate,
+)
 
 
 def _safe_split(text):
@@ -1428,6 +1435,7 @@ class BuilderCmdSet(CmdSet):
         self.add(CmdListNPCs)
         self.add(CmdDupNPC)
         self.add(CmdMobBuilder)
+        self.add(CmdMobTemplate)
         self.add(CmdMSpawn)
         self.add(CmdMCreate)
         self.add(CmdMSet)

--- a/commands/mob_builder.py
+++ b/commands/mob_builder.py
@@ -97,3 +97,27 @@ class CmdMedit(Command):
         data = npc_builder._gather_npc_data(npc)
         self.caller.ndb.buildnpc = data
         EvMenu(self.caller, "commands.npc_builder", startnode="menunode_desc")
+
+
+class CmdMobTemplate(Command):
+    """Load a predefined mob template into the current build."""
+
+    key = "@mobtemplate"
+    locks = "cmd:perm(Builder)"
+    help_category = "Building"
+
+    def func(self):
+        from world.templates.mob_templates import MOB_TEMPLATES, get_template
+
+        arg = self.args.strip().lower()
+        if not arg or arg == "list":
+            names = ", ".join(sorted(MOB_TEMPLATES))
+            self.msg(f"Available templates: {names}")
+            return
+        data = get_template(arg)
+        if not data:
+            self.msg("Unknown template.")
+            return
+        self.caller.ndb.buildnpc = self.caller.ndb.buildnpc or {}
+        self.caller.ndb.buildnpc.update(data)
+        self.msg(f"Template '{arg}' loaded into builder.")

--- a/typeclasses/tests/test_mobtemplate_command.py
+++ b/typeclasses/tests/test_mobtemplate_command.py
@@ -1,0 +1,38 @@
+from unittest.mock import MagicMock
+from tempfile import TemporaryDirectory
+from pathlib import Path
+from unittest import mock
+
+from django.test import override_settings
+from django.conf import settings
+from evennia.utils.test_resources import EvenniaTest
+
+from commands.admin import BuilderCmdSet
+
+
+@override_settings(DEFAULT_HOME=None)
+class TestMobTemplateCommand(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.char1.msg = MagicMock()
+        self.char1.cmdset.add_default(BuilderCmdSet)
+        self.tmp = TemporaryDirectory()
+        patcher = mock.patch.object(
+            settings,
+            "PROTOTYPE_NPC_FILE",
+            Path(self.tmp.name) / "npcs.json",
+        )
+        self.addCleanup(self.tmp.cleanup)
+        self.addCleanup(patcher.stop)
+        patcher.start()
+
+    def test_list_and_apply_template(self):
+        self.char1.execute_cmd("@mobtemplate list")
+        out = self.char1.msg.call_args[0][0]
+        assert "warrior" in out
+        self.char1.msg.reset_mock()
+
+        self.char1.execute_cmd("@mobtemplate warrior")
+        data = self.char1.ndb.buildnpc
+        assert data["hp"] == 30
+        assert "aggressive" in data.get("actflags", [])

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -2935,6 +2935,8 @@ Notes:
     - Inspect prototypes or NPCs with |w@mstat <key>|n.
     - Use |w@makeshop|n or |w@makerepair|n to add vendor data after
       saving the prototype.
+    - Load default stats with |w@mobtemplate list|n then
+      |w@mobtemplate <name>|n while in the builder.
     - Example workflow:
         1) run |wmobbuilder|n and fill in the prompts
         2) choose |wYes & Save Prototype|n

--- a/world/templates/mob_templates.py
+++ b/world/templates/mob_templates.py
@@ -1,0 +1,32 @@
+"""Predefined NPC templates with baseline stats and flags."""
+
+from copy import deepcopy
+
+MOB_TEMPLATES = {
+    "warrior": {
+        "level": 1,
+        "hp": 30,
+        "mp": 0,
+        "sp": 10,
+        "primary_stats": {"STR": 4, "CON": 3, "DEX": 3, "INT": 1, "WIS": 1, "LUCK": 1},
+        "actflags": ["aggressive"],
+        "skills": ["slash"],
+    },
+    "caster": {
+        "level": 1,
+        "hp": 20,
+        "mp": 30,
+        "sp": 5,
+        "primary_stats": {"STR": 1, "CON": 2, "DEX": 2, "INT": 4, "WIS": 4, "LUCK": 1},
+        "spells": ["magic missile"],
+        "actflags": ["sentinel"],
+    },
+}
+
+
+def get_template(name: str):
+    """Return a deep copy of the template dictionary."""
+    data = MOB_TEMPLATES.get(name.lower())
+    if data:
+        return deepcopy(data)
+    return None


### PR DESCRIPTION
## Summary
- create world/templates/mob_templates.py with sample stats
- add `@mobtemplate` command to load templates in builder
- expose command via BuilderCmdSet
- mention templates in help entry for mobbuilder
- test listing and applying templates

## Testing
- `python -m py_compile commands/admin.py commands/mob_builder.py world/templates/mob_templates.py typeclasses/tests/test_mobtemplate_command.py`
- `pytest -q` *(fails: OperationalError: no such table)*

------
https://chatgpt.com/codex/tasks/task_e_6847a16db104832c8af83beb1a9b3ce1