### PR TITLE
Add mobpreview command

### DIFF
--- a/commands/admin.py
+++ b/commands/admin.py
@@ -43,6 +43,7 @@ from .mob_builder_commands import (
 from .mob_builder import (
     CmdMobBuilder,
     CmdMSpawn,
+    CmdMobPreview,
     CmdMStat,
     CmdMList,
     CmdMedit,
@@ -1437,6 +1438,7 @@ class BuilderCmdSet(CmdSet):
         self.add(CmdMobBuilder)
         self.add(CmdMobTemplate)
         self.add(CmdMSpawn)
+        self.add(CmdMobPreview)
         self.add(CmdMCreate)
         self.add(CmdMSet)
         self.add(CmdMList)

--- a/typeclasses/tests/test_mobpreview_command.py
+++ b/typeclasses/tests/test_mobpreview_command.py
@@ -1,0 +1,38 @@
+from unittest.mock import MagicMock, patch
+from tempfile import TemporaryDirectory
+from pathlib import Path
+from unittest import mock
+
+from django.test import override_settings
+from django.conf import settings
+from evennia.utils.test_resources import EvenniaTest
+
+from commands.admin import BuilderCmdSet
+from world import prototypes
+
+
+@override_settings(DEFAULT_HOME=None)
+class TestMobPreviewCommand(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.char1.msg = MagicMock()
+        self.char1.cmdset.add_default(BuilderCmdSet)
+        self.tmp = TemporaryDirectory()
+        patcher = mock.patch.object(
+            settings,
+            "PROTOTYPE_NPC_FILE",
+            Path(self.tmp.name) / "npcs.json",
+        )
+        self.addCleanup(self.tmp.cleanup)
+        self.addCleanup(patcher.stop)
+        patcher.start()
+
+    def test_mobpreview_spawns_and_deletes(self):
+        prototypes.register_npc_prototype("goblin", {"key": "goblin"})
+        npc = MagicMock()
+        with patch("evennia.prototypes.spawner.spawn", return_value=[npc]) as mock_spawn, \
+             patch("evennia.utils.utils.delay", lambda t, func, *a, **kw: func(*a, **kw)):
+            self.char1.execute_cmd("@mobpreview goblin")
+        mock_spawn.assert_called()
+        npc.move_to.assert_called_with(self.char1.location, quiet=True)
+        npc.delete.assert_called()

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -2932,6 +2932,7 @@ Notes:
     - Edit saved prototypes with |w@mcreate|n or |w@mset|n and review them
       using |w@mlist|n. See |whelp @mlist|n for filtering options.
     - Spawn a stored prototype with |w@mspawn <prototype>|n.
+    - Quickly preview a prototype with |w@mobpreview <prototype>|n.
     - Inspect prototypes or NPCs with |w@mstat <key>|n.
     - Use |w@makeshop|n or |w@makerepair|n to add vendor data after
       saving the prototype.
@@ -3049,6 +3050,21 @@ Usage:
 Examples:
     @mspawn bandit
     @mspawn mob_guard
+""",
+    },
+    {
+        "key": "@mobpreview",
+        "category": "Building",
+        "text": """Help for @mobpreview
+
+Spawn a prototype temporarily in your room. The NPC
+disappears automatically after a short delay.
+
+Usage:
+    @mobpreview <prototype>
+
+Example:
+    @mobpreview goblin
 """,
     },
     {


### PR DESCRIPTION
## Summary
- allow builders to preview prototype NPCs
- integrate mobpreview into builder command set
- document mobpreview help topic
- test mobpreview command

## Testing
- `pytest typeclasses/tests/test_mobpreview_command.py -q` *(fails: OperationalError no such table)*

------
https://chatgpt.com/codex/tasks/task_e_6847a3ea87b8832c98a8109a38226362