### PR TITLE
Add mob prototype validation

### DIFF
--- a/commands/admin.py
+++ b/commands/admin.py
@@ -39,6 +39,7 @@ from .mob_builder_commands import (
     CmdMakeRepair,
     CmdRepairSet,
     CmdRepairStat,
+    CmdMobValidate,
 )
 from .mob_builder import (
     CmdMobBuilder,
@@ -1449,3 +1450,4 @@ class BuilderCmdSet(CmdSet):
         self.add(CmdMakeRepair)
         self.add(CmdRepairSet)
         self.add(CmdRepairStat)
+        self.add(CmdMobValidate)

--- a/commands/mob_builder_commands.py
+++ b/commands/mob_builder_commands.py
@@ -595,3 +595,27 @@ class CmdRepairStat(Command):
             f"Item Types: {', '.join(repair.get('item_types', []))}",
         ]
         self.msg("\n".join(lines))
+
+
+class CmdMobValidate(Command):
+    """Validate a stored NPC prototype for common issues."""
+
+    key = "@mobvalidate"
+    locks = "cmd:perm(Builder) or perm(Admin) or perm(Developer)"
+    help_category = "Building"
+
+    def func(self):
+        proto_key = self.args.strip()
+        if not proto_key:
+            self.msg("Usage: @mobvalidate <prototype>")
+            return
+        proto = prototypes.get_npc_prototypes().get(proto_key)
+        if not proto:
+            self.msg("Prototype not found.")
+            return
+        warnings = npc_builder.validate_prototype(proto)
+        if warnings:
+            lines = ["Warnings:"] + [f" - {w}" for w in warnings]
+            self.msg("\n".join(lines))
+        else:
+            self.msg("No issues found.")

--- a/typeclasses/tests/test_mobvalidate_command.py
+++ b/typeclasses/tests/test_mobvalidate_command.py
@@ -1,0 +1,40 @@
+from unittest.mock import MagicMock
+from tempfile import TemporaryDirectory
+from pathlib import Path
+from unittest import mock
+
+from django.test import override_settings
+from django.conf import settings
+from evennia.utils.test_resources import EvenniaTest
+
+from commands.admin import BuilderCmdSet
+from world import prototypes
+
+
+@override_settings(DEFAULT_HOME=None)
+class TestMobValidateCommand(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.char1.msg = MagicMock()
+        self.char1.cmdset.add_default(BuilderCmdSet)
+        self.tmp = TemporaryDirectory()
+        patcher = mock.patch.object(
+            settings,
+            "PROTOTYPE_NPC_FILE",
+            Path(self.tmp.name) / "npcs.json",
+        )
+        self.addCleanup(self.tmp.cleanup)
+        self.addCleanup(patcher.stop)
+        patcher.start()
+
+    def test_mobvalidate_reports_warnings(self):
+        prototypes.register_npc_prototype(
+            "goblin",
+            {"key": "goblin", "hp": 0, "actflags": ["aggressive", "wimpy"]},
+        )
+        self.char1.execute_cmd("@mobvalidate goblin")
+        out = self.char1.msg.call_args[0][0]
+        assert "Warnings" in out
+        assert "HP is set to zero" in out
+        assert "aggressive" in out.lower()
+

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -3068,6 +3068,22 @@ Example:
 """,
     },
     {
+        "key": "@mobvalidate",
+        "category": "Building",
+        "text": """Help for @mobvalidate
+
+Check a stored prototype for common problems like zero HP or conflicting
+act flags. Displays a list of warnings or confirms that no issues were
+found.
+
+Usage:
+    @mobvalidate <prototype>
+
+Example:
+    @mobvalidate goblin
+""",
+    },
+    {
         "key": "@makeshop",
         "category": "Building",
         "text": """Help for @makeshop


### PR DESCRIPTION
## Summary
- validate prototype data for issues like zero HP or conflicting flags
- show warnings before finalizing NPCs in builder
- implement `@mobvalidate` command to check stored prototypes
- document new command and add tests

## Testing
- `pytest -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6847a5f40e7c832cbbb3b95982a9c288