### PR TITLE
Add mob import/export commands

### DIFF
--- a/commands/README.md
+++ b/commands/README.md
@@ -110,3 +110,14 @@ sections with `@makeshop` and `@makerepair` and then configure them with
 
 Use `@shopstat <proto>` or `@repairstat <proto>` to review the settings.
 
+
+## Importing and Exporting
+
+Use `@mobexport <proto> <file>` to write a prototype to JSON in the
+`PROTOTYPE_NPC_EXPORT_DIR` directory. Load a file with
+`@mobimport <file>` which will register or replace that prototype.
+
+```text
+@mobexport goblin goblin.json
+@mobimport goblin.json
+```

--- a/commands/admin.py
+++ b/commands/admin.py
@@ -38,6 +38,8 @@ from .mob_builder_commands import (
     CmdShopStat,
     CmdMakeRepair,
     CmdRepairSet,
+    CmdMobExport,
+    CmdMobImport,
     CmdRepairStat,
     CmdMobValidate,
 )
@@ -1446,6 +1448,8 @@ class BuilderCmdSet(CmdSet):
         self.add(CmdMStat)
         self.add(CmdMakeShop)
         self.add(CmdShopSet)
+        self.add(CmdMobExport)
+        self.add(CmdMobImport)
         self.add(CmdShopStat)
         self.add(CmdMakeRepair)
         self.add(CmdRepairSet)

--- a/server/conf/settings.py
+++ b/server/conf/settings.py
@@ -55,6 +55,7 @@ XYZROOM_PROTOTYPE_OVERRIDE = {"typeclass": "typeclasses.rooms.XYGridRoom"}
 # File used for storing NPC prototypes
 PROTOTYPE_NPC_FILE = Path(GAME_DIR) / "world" / "prototypes" / "npcs.json"
 
+PROTOTYPE_NPC_EXPORT_DIR = Path(GAME_DIR) / "exports" / "npc_prototypes"
 
 # Clothing - https://www.evennia.com/docs/latest/Contribs/Contrib-Clothing.html#configuration
 CLOTHING_WEARSTYLE_MAXLENGTH = 40

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -3084,6 +3084,34 @@ Example:
 """,
     },
     {
+        "key": "@mobexport",
+        "category": "Building",
+        "text": """Help for @mobexport
+
+Write a stored prototype to a JSON file in the directory defined by ``PROTOTYPE_NPC_EXPORT_DIR``. The filename may omit the ``.json`` extension. Existing files will be overwritten.
+
+Usage:
+    @mobexport <proto> <file>
+
+Example:
+    @mobexport goblin goblin.json
+""",
+    },
+    {
+        "key": "@mobimport",
+        "category": "Building",
+        "text": """Help for @mobimport
+
+Load prototype data from a JSON file previously exported with ``@mobexport``. The loaded prototype will be registered and replace any existing entry with the same key.
+
+Usage:
+    @mobimport <file>
+
+Example:
+    @mobimport goblin.json
+""",
+    },
+    {
         "key": "@makeshop",
         "category": "Building",
         "text": """Help for @makeshop


### PR DESCRIPTION
## Summary
- add `@mobexport` and `@mobimport` commands for NPC prototypes
- document export/import workflow
- wire new commands into builder cmdset
- allow configuring export directory via settings
- update help entries with usage info

## Testing
- `python -m py_compile commands/mob_builder_commands.py`
- `python -m py_compile world/help_entries.py`
- `pytest -q` *(fails: OperationalError - no such table accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6847a88cbd40832c9c0cf10ec1338465