### PR TITLE
Add mob db script

### DIFF
--- a/server/conf/at_server_startstop.py
+++ b/server/conf/at_server_startstop.py
@@ -38,12 +38,16 @@ def at_server_start():
     """
     from evennia.utils import create
     from evennia.scripts.models import ScriptDB
+    from world.scripts.mob_db import get_mobdb
 
     script = ScriptDB.objects.filter(db_key="global_tick").first()
     if not script or script.typeclass_path != "typeclasses.scripts.GlobalTick":
         if script:
             script.delete()
         create.create_script("typeclasses.scripts.GlobalTick", key="global_tick")
+
+    # Ensure mob database script exists
+    get_mobdb()
 
     # Ensure all characters are marked tickable for the global ticker
     from typeclasses.characters import Character

--- a/world/scripts/mob_db.py
+++ b/world/scripts/mob_db.py
@@ -1,0 +1,48 @@
+from evennia.utils import create
+from evennia.scripts.scripts import DefaultScript
+from evennia.scripts.models import ScriptDB
+
+
+class MobDB(DefaultScript):
+    """Simple in-memory database for NPC prototypes keyed by vnum."""
+
+    def at_script_creation(self):
+        """Initialize the script on first creation."""
+        self.key = "mob_db"
+        self.persistent = True
+        self.db.vnums = {}
+        self.db.next_vnum = 1
+
+    # ------------------------------------------------------------------
+    # Convenience API
+    # ------------------------------------------------------------------
+    def get_proto(self, vnum):
+        """Return prototype dict for ``vnum`` or ``None``."""
+        return self.db.vnums.get(int(vnum))
+
+    def add_proto(self, vnum, data):
+        """Store ``data`` for ``vnum``."""
+        self.db.vnums[int(vnum)] = data
+
+    def delete_proto(self, vnum):
+        """Remove ``vnum`` from the database."""
+        self.db.vnums.pop(int(vnum), None)
+
+    def next_vnum(self):
+        """Return the next available vnum and increment the counter."""
+        vnum = int(self.db.next_vnum or 1)
+        self.db.next_vnum = vnum + 1
+        return vnum
+
+
+def get_mobdb():
+    """Return the global ``MobDB`` script, creating it if needed."""
+    script, _ = ScriptDB.objects.get_or_create(
+        db_key="mob_db",
+        defaults={"db_typeclass_path": "world.scripts.mob_db.MobDB"},
+    )
+    # ensure correct typeclass
+    if script.typeclass_path != "world.scripts.mob_db.MobDB":
+        script.delete()
+        script = create.create_script("world.scripts.mob_db.MobDB", key="mob_db")
+    return script


### PR DESCRIPTION
## Summary
- add a MobDB script storing NPC prototypes
- ensure mob_db script is created at server startup

## Testing
- `pytest -q` *(fails: OperationalError - no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6847adbb7320832c874a1a6989edaa8a