### PR TITLE
Add mob prototype utilities

### DIFF
--- a/commands/mob_builder.py
+++ b/commands/mob_builder.py
@@ -2,6 +2,7 @@
 
 from evennia.utils.evmenu import EvMenu
 from evennia.prototypes import spawner
+from utils.mob_proto import spawn_from_vnum
 from evennia.utils import delay
 from world import prototypes
 from typeclasses.characters import NPC
@@ -57,18 +58,24 @@ class CmdMSpawn(Command):
         if not key:
             self.msg("Usage: @mspawn <prototype>")
             return
-        registry = prototypes.get_npc_prototypes()
-        proto = registry.get(key) or registry.get(f"mob_{key}")
-        if not proto:
-            self.msg("Prototype not found.")
-            return
-        tclass_path = npc_builder.NPC_CLASS_MAP.get(
-            proto.get("npc_class", "base"), "typeclasses.npcs.BaseNPC"
-        )
-        proto = dict(proto)
-        proto.setdefault("typeclass", tclass_path)
-        obj = spawner.spawn(proto)[0]
-        obj.move_to(self.caller.location, quiet=True)
+        if key.isdigit():
+            obj = spawn_from_vnum(int(key), location=self.caller.location)
+            if not obj:
+                self.msg("Prototype not found.")
+                return
+        else:
+            registry = prototypes.get_npc_prototypes()
+            proto = registry.get(key) or registry.get(f"mob_{key}")
+            if not proto:
+                self.msg("Prototype not found.")
+                return
+            tclass_path = npc_builder.NPC_CLASS_MAP.get(
+                proto.get("npc_class", "base"), "typeclasses.npcs.BaseNPC"
+            )
+            proto = dict(proto)
+            proto.setdefault("typeclass", tclass_path)
+            obj = spawner.spawn(proto)[0]
+            obj.move_to(self.caller.location, quiet=True)
         self.msg(f"Spawned {obj.key}.")
 
 
@@ -95,18 +102,24 @@ class CmdMobPreview(Command):
         if not key:
             self.msg("Usage: @mobpreview <prototype>")
             return
-        registry = prototypes.get_npc_prototypes()
-        proto = registry.get(key) or registry.get(f"mob_{key}")
-        if not proto:
-            self.msg("Prototype not found.")
-            return
-        tclass_path = npc_builder.NPC_CLASS_MAP.get(
-            proto.get("npc_class", "base"), "typeclasses.npcs.BaseNPC"
-        )
-        proto = dict(proto)
-        proto.setdefault("typeclass", tclass_path)
-        obj = spawner.spawn(proto)[0]
-        obj.move_to(self.caller.location, quiet=True)
+        if key.isdigit():
+            obj = spawn_from_vnum(int(key), location=self.caller.location)
+            if not obj:
+                self.msg("Prototype not found.")
+                return
+        else:
+            registry = prototypes.get_npc_prototypes()
+            proto = registry.get(key) or registry.get(f"mob_{key}")
+            if not proto:
+                self.msg("Prototype not found.")
+                return
+            tclass_path = npc_builder.NPC_CLASS_MAP.get(
+                proto.get("npc_class", "base"), "typeclasses.npcs.BaseNPC"
+            )
+            proto = dict(proto)
+            proto.setdefault("typeclass", tclass_path)
+            obj = spawner.spawn(proto)[0]
+            obj.move_to(self.caller.location, quiet=True)
         delay(30, obj.delete)
         self.msg(f"Previewing {obj.key}. It will vanish soon.")
 

--- a/scripts/area_spawner.py
+++ b/scripts/area_spawner.py
@@ -3,6 +3,7 @@
 from random import choice, randint
 
 from evennia.prototypes import spawner
+from utils.mob_proto import spawn_from_vnum
 from typeclasses.scripts import Script
 from typeclasses.npcs import BaseNPC
 from world import area_npcs, prototypes
@@ -38,11 +39,16 @@ class AreaSpawner(Script):
             return
 
         proto_key = choice(proto_keys)
-        proto = prototypes.get_npc_prototypes().get(proto_key)
-        if not proto:
-            return
-        npc = spawner.spawn(proto)[0]
-        npc.location = room
-        npc.db.prototype_key = proto_key
+        if proto_key.isdigit():
+            npc = spawn_from_vnum(int(proto_key), location=room)
+            if not npc:
+                return
+        else:
+            proto = prototypes.get_npc_prototypes().get(proto_key)
+            if not proto:
+                return
+            npc = spawner.spawn(proto)[0]
+            npc.location = room
+            npc.db.prototype_key = proto_key
         npc.db.area_tag = area
         npc.db.spawn_room = room

--- a/utils/mob_proto.py
+++ b/utils/mob_proto.py
@@ -1,0 +1,39 @@
+"""Helpers for storing and spawning mob prototypes by VNUM."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from evennia.prototypes import spawner
+from world.scripts.mob_db import get_mobdb
+
+
+def register_prototype(data: dict, vnum: int | None = None) -> int:
+    """Register ``data`` in the mob database under ``vnum``."""
+    mob_db = get_mobdb()
+    if vnum is None:
+        vnum = mob_db.next_vnum()
+    mob_db.add_proto(vnum, data)
+    return vnum
+
+
+def get_prototype(vnum: int) -> Optional[dict]:
+    """Return the prototype stored for ``vnum`` or ``None``."""
+    return get_mobdb().get_proto(vnum)
+
+
+def spawn_from_vnum(vnum: int, location=None):
+    """Spawn and return an NPC from ``vnum`` prototype."""
+    mob_db = get_mobdb()
+    proto = mob_db.get_proto(vnum)
+    if not proto:
+        return None
+    proto = dict(proto)
+    npc = spawner.spawn(proto)[0]
+    if location:
+        npc.location = location
+    npc.db.vnum = vnum
+    # track how often this prototype has spawned
+    proto["spawn_count"] = int(proto.get("spawn_count", 0)) + 1
+    mob_db.add_proto(vnum, proto)
+    return npc


### PR DESCRIPTION
## Summary
- add helper module for mob prototypes
- update commands to support vnum spawning
- use new helpers in area spawner

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6847afd6e074832c96f47818d9254dd3