### PR TITLE
Track mob spawns

### DIFF
--- a/commands/cmdmobbuilder.py
+++ b/commands/cmdmobbuilder.py
@@ -99,10 +99,11 @@ class CmdMobProto(Command):
         if not mob_db.db.vnums:
             caller.msg("No mob prototypes registered.")
             return
-        lines = ["|wVNUM|n |wName|n"]
+        lines = ["|wVNUM|n |wName|n |wSpawns|n"]
         for vnum, proto in sorted(mob_db.db.vnums.items()):
             name = proto.get("key", "--")
-            lines.append(f"{vnum:>5} {name}")
+            count = proto.get("spawn_count", 0)
+            lines.append(f"{vnum:>5} {name} {count}")
         caller.msg("\n".join(lines))
 
     def _sub_spawn(self, rest: str):

--- a/utils/mob_proto.py
+++ b/utils/mob_proto.py
@@ -28,12 +28,11 @@ def spawn_from_vnum(vnum: int, location=None):
     proto = mob_db.get_proto(vnum)
     if not proto:
         return None
-    proto = dict(proto)
-    npc = spawner.spawn(proto)[0]
+    proto_data = dict(proto)
+    npc = spawner.spawn(proto_data)[0]
     if location:
         npc.location = location
     npc.db.vnum = vnum
     # track how often this prototype has spawned
-    proto["spawn_count"] = int(proto.get("spawn_count", 0)) + 1
-    mob_db.add_proto(vnum, proto)
+    mob_db.increment_spawn_count(vnum)
     return npc

--- a/world/scripts/mob_db.py
+++ b/world/scripts/mob_db.py
@@ -21,8 +21,22 @@ class MobDB(DefaultScript):
         return self.db.vnums.get(int(vnum))
 
     def add_proto(self, vnum, data):
-        """Store ``data`` for ``vnum``."""
-        self.db.vnums[int(vnum)] = data
+        """Store ``data`` for ``vnum``. Ensure ``spawn_count`` key exists."""
+        vnum = int(vnum)
+        proto = dict(data)
+        # preserve existing spawn counter if re-adding
+        if "spawn_count" not in proto:
+            proto["spawn_count"] = self.db.vnums.get(vnum, {}).get("spawn_count", 0)
+        self.db.vnums[vnum] = proto
+
+    def increment_spawn_count(self, vnum):
+        """Increase the stored spawn counter for ``vnum``."""
+        vnum = int(vnum)
+        proto = self.db.vnums.get(vnum)
+        if not proto:
+            return
+        proto["spawn_count"] = int(proto.get("spawn_count", 0)) + 1
+        self.db.vnums[vnum] = proto
 
     def delete_proto(self, vnum):
         """Remove ``vnum`` from the database."""


### PR DESCRIPTION
## Summary
- store spawn_count for each mob prototype
- increment spawn_count when mobs are spawned
- show spawn_count in `@mobproto/list`

## Testing
- `pytest utils/tests -q` *(fails: no such table accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6847b3f5d1c4832cb3b5f56a9b100d26