### PR TITLE
Implement mob prototype diff command

### DIFF
--- a/commands/README.md
+++ b/commands/README.md
@@ -121,3 +121,16 @@ Use `@mobexport <proto> <file>` to write a prototype to JSON in the
 @mobexport goblin goblin.json
 @mobimport goblin.json
 ```
+
+## Prototype Diffing
+
+The `Builder` command set also includes `@mobproto` for managing
+numbered mob prototypes. Use the `diff` subcommand to compare any two
+entries:
+
+```text
+@mobproto diff 1 2
+```
+
+This shows a table of key/value pairs from each prototype with differing
+fields highlighted.


### PR DESCRIPTION
## Summary
- add a diff subcommand for `@mobproto`
- highlight differences using an EvTable
- document how to compare mob prototypes

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6847b5d5f230832cb8e79cf5b9607239