### PR TITLE
Restrict AI script imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,8 @@ builder:
 - **scripted** – runs the callback stored in ``npc.db.ai_script``.
 
 For scripted AI you must assign a callable to ``npc.db.ai_script``. This can be
-either a Python import path or a direct function reference. Example::
+either a Python import path or a direct function reference. Callbacks must live
+under the ``scripts`` package. Example::
 
     npc.db.ai_script = "scripts.example_ai.patrol_ai"
 

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -2778,7 +2778,8 @@ The available AI types are stored in `world.npc_handlers.ai`:
 Set the type when prompted in the builder or edit the prototype data.
 The mob builder offers the same AI step for prototypes saved with
 `@mcreate` or `@mset`. For scripted AI, store a callable path on
-``npc.db.ai_script`` such as ``scripts.example_ai.patrol_ai``.
+``npc.db.ai_script`` such as ``scripts.example_ai.patrol_ai``. Only modules
+within the ``scripts`` package can be used.
 
 Related:
     help cnpc


### PR DESCRIPTION
## Summary
- add module whitelist to AI loader
- validate script imports in `npc_builder`
- document the allowed `scripts` package

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -q` *(fails: sqlite3 OperationalError: no such table)*

------
https://chatgpt.com/codex/tasks/task_e_6847c54ba360832c94023673d30c6bf5