### PR TITLE
Use log_warn for missing secret settings

### DIFF
--- a/server/conf/settings.py
+++ b/server/conf/settings.py
@@ -117,4 +117,5 @@ CONNECTION_SCREEN_MODULE = "evennia.contrib.base_systems.menu_login.connection_s
 try:
     from server.conf.secret_settings import *
 except ImportError:
-    print("secret_settings.py file not found or failed to import.")
+    from evennia.utils.logger import log_warn
+    log_warn("secret_settings.py file not found or failed to import.")


### PR DESCRIPTION
## Summary
- log a warning if `secret_settings.py` is missing instead of printing to stdout

## Testing
- `pytest -q` *(fails: 316 failed, 7 passed, 2 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6847c8736810832c9949d63504083daf