### PR TITLE
Add VNUM registry utility

### DIFF
--- a/server/conf/settings.py
+++ b/server/conf/settings.py
@@ -57,6 +57,9 @@ PROTOTYPE_NPC_FILE = Path(GAME_DIR) / "world" / "prototypes" / "npcs.json"
 
 PROTOTYPE_NPC_EXPORT_DIR = Path(GAME_DIR) / "exports" / "npc_prototypes"
 
+# File tracking used VNUMs
+VNUM_REGISTRY_FILE = Path(GAME_DIR) / "world" / "vnum_registry.json"
+
 # Clothing - https://www.evennia.com/docs/latest/Contribs/Contrib-Clothing.html#configuration
 CLOTHING_WEARSTYLE_MAXLENGTH = 40
 CLOTHING_TYPE_ORDERED = [

--- a/typeclasses/tests/test_mob_proto_commands.py
+++ b/typeclasses/tests/test_mob_proto_commands.py
@@ -19,14 +19,21 @@ class TestMobPrototypeCommands(EvenniaTest):
         self.char1.msg = MagicMock()
         self.char1.cmdset.add_default(BuilderCmdSet)
         self.tmp = TemporaryDirectory()
-        patcher = mock.patch.object(
+        patcher1 = mock.patch.object(
             settings,
             "PROTOTYPE_NPC_FILE",
             Path(self.tmp.name) / "npcs.json",
         )
+        patcher2 = mock.patch.object(
+            settings,
+            "VNUM_REGISTRY_FILE",
+            Path(self.tmp.name) / "vnums.json",
+        )
         self.addCleanup(self.tmp.cleanup)
-        self.addCleanup(patcher.stop)
-        patcher.start()
+        self.addCleanup(patcher1.stop)
+        self.addCleanup(patcher2.stop)
+        patcher1.start()
+        patcher2.start()
 
     def test_mcreate_and_mset(self):
         self.char1.execute_cmd("@mcreate goblin")
@@ -104,3 +111,4 @@ class TestMobPrototypeCommands(EvenniaTest):
         out = self.char1.msg.call_args[0][0]
         self.assertIn("deleted", out)
         self.assertIsNone(get_prototype(vnum))
+

--- a/typeclasses/tests/test_vnum_mobs.py
+++ b/typeclasses/tests/test_vnum_mobs.py
@@ -19,14 +19,21 @@ class TestVnumMobs(EvenniaTest):
         self.char1.msg = MagicMock()
         self.char1.cmdset.add_default(BuilderCmdSet)
         self.tmp = TemporaryDirectory()
-        patcher = mock.patch.object(
+        patcher1 = mock.patch.object(
             settings,
             "PROTOTYPE_NPC_FILE",
             Path(self.tmp.name) / "npcs.json",
         )
+        patcher2 = mock.patch.object(
+            settings,
+            "VNUM_REGISTRY_FILE",
+            Path(self.tmp.name) / "vnums.json",
+        )
         self.addCleanup(self.tmp.cleanup)
-        self.addCleanup(patcher.stop)
-        patcher.start()
+        self.addCleanup(patcher1.stop)
+        self.addCleanup(patcher2.stop)
+        patcher1.start()
+        patcher2.start()
 
     def test_register_and_spawn_vnum(self):
         proto = {"key": "goblin", "typeclass": "typeclasses.npcs.BaseNPC"}
@@ -74,3 +81,4 @@ class TestVnumMobs(EvenniaTest):
         self.assertIsNone(get_prototype(1))
         del_msg = self.char1.msg.call_args[0][0]
         self.assertIn("deleted", del_msg.lower())
+

--- a/utils/mob_proto.py
+++ b/utils/mob_proto.py
@@ -6,13 +6,18 @@ from typing import Optional
 
 from evennia.prototypes import spawner
 from world.scripts.mob_db import get_mobdb
+from .vnum_registry import get_next_vnum, register_vnum, validate_vnum
 
 
 def register_prototype(data: dict, vnum: int | None = None) -> int:
     """Register ``data`` in the mob database under ``vnum``."""
     mob_db = get_mobdb()
     if vnum is None:
-        vnum = mob_db.next_vnum()
+        vnum = get_next_vnum("npc")
+    else:
+        if not validate_vnum(vnum, "npc"):
+            raise ValueError("Invalid or already used VNUM")
+        register_vnum(vnum)
     mob_db.add_proto(vnum, data)
     return vnum
 

--- a/utils/vnum_registry.py
+++ b/utils/vnum_registry.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Tuple
+
+from django.conf import settings
+
+__all__ = [
+    "VNUM_RANGES",
+    "validate_vnum",
+    "register_vnum",
+    "get_next_vnum",
+]
+
+# Mapping of category -> (start, end) of allowed VNUM range
+VNUM_RANGES: Dict[str, Tuple[int, int]] = {
+    "npc": (1, 99999),
+    "object": (100000, 199999),
+    "room": (200000, 299999),
+}
+
+_REG_PATH = Path(getattr(settings, "VNUM_REGISTRY_FILE", Path(settings.GAME_DIR) / "world" / "vnum_registry.json"))
+
+
+def _load() -> Dict[str, Dict]:
+    try:
+        with _REG_PATH.open("r") as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return {}
+    except json.JSONDecodeError:
+        return {}
+
+
+def _save(data: Dict[str, Dict]):
+    _REG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with _REG_PATH.open("w") as f:
+        json.dump(data, f, indent=4)
+
+
+def validate_vnum(vnum: int, category: str) -> bool:
+    """Return ``True`` if ``vnum`` is valid and unused for ``category``."""
+    if category not in VNUM_RANGES:
+        raise KeyError(f"Unknown category: {category}")
+    start, end = VNUM_RANGES[category]
+    if not (start <= vnum <= end):
+        return False
+    data = _load()
+    used = set(data.get(category, {}).get("used", []))
+    return vnum not in used
+
+
+def register_vnum(vnum: int):
+    """Record ``vnum`` as used in its category."""
+    data = _load()
+    for cat, (start, end) in VNUM_RANGES.items():
+        if start <= vnum <= end:
+            entry = data.setdefault(cat, {"used": [], "next": start})
+            if vnum not in entry["used"]:
+                entry["used"].append(vnum)
+                if entry["next"] <= vnum:
+                    entry["next"] = vnum + 1
+                data[cat] = entry
+                _save(data)
+            return
+    raise ValueError("VNUM outside defined ranges")
+
+
+def get_next_vnum(category: str) -> int:
+    """Return and reserve the next available VNUM for ``category``."""
+    if category not in VNUM_RANGES:
+        raise KeyError(f"Unknown category: {category}")
+    start, end = VNUM_RANGES[category]
+    data = _load()
+    entry = data.setdefault(category, {"used": [], "next": start})
+    vnum = max(entry.get("next", start), start)
+    used = set(entry.get("used", []))
+    while vnum in used and vnum <= end:
+        vnum += 1
+    if vnum > end:
+        raise ValueError("No available VNUMs in range")
+    used.add(vnum)
+    entry["used"] = sorted(used)
+    entry["next"] = vnum + 1
+    data[category] = entry
+    _save(data)
+    return vnum
+


### PR DESCRIPTION
## Summary
- add utils/vnum_registry for managing number ranges
- validate and track NPC vnums when registering prototypes
- expose new path in settings
- patch tests to use temp registry file

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6847cd5381b0832c852124a59fb50cae