### PR TITLE
Add @nextvnum command

### DIFF
--- a/commands/README.md
+++ b/commands/README.md
@@ -137,3 +137,20 @@ fields highlighted.
 
 Delete a prototype with `@mobproto delete <vnum>`. Deletion will fail if any
 live NPCs spawned from that VNUM still exist.
+
+## VNUM Utility
+
+Use `@nextvnum` to reserve the next available VNUM for a type of object. The
+argument selects the category:
+
+```
+@nextvnum <I|M|R|O|Q|S>
+```
+
+* **I** or **O** – object/item VNUM
+* **M** – mob/NPC VNUM
+* **R** – room VNUM
+* **Q** – quest VNUM
+* **S** – script VNUM
+
+The returned number is automatically marked as used in the registry.

--- a/commands/admin.py
+++ b/commands/admin.py
@@ -53,6 +53,7 @@ from .mob_builder import (
     CmdMobTemplate,
 )
 from .cmdmobbuilder import CmdMobProto
+from .nextvnum import CmdNextVnum
 
 
 def _safe_split(text):
@@ -1457,3 +1458,4 @@ class BuilderCmdSet(CmdSet):
         self.add(CmdRepairStat)
         self.add(CmdMobValidate)
         self.add(CmdMobProto)
+        self.add(CmdNextVnum)

--- a/commands/nextvnum.py
+++ b/commands/nextvnum.py
@@ -1,0 +1,33 @@
+from .command import Command
+from utils import vnum_registry
+
+
+class CmdNextVnum(Command):
+    """Return the next available VNUM for a category."""
+
+    key = "@nextvnum"
+    locks = "cmd:perm(Builder)"
+    help_category = "Building"
+
+    def func(self):
+        arg = self.args.strip().upper()
+        if arg not in {"I", "M", "R", "O", "Q", "S"}:
+            self.msg("Usage: @nextvnum <I|M|R|O|Q|S>")
+            return
+
+        category_map = {
+            "M": "npc",
+            "I": "object",
+            "O": "object",
+            "R": "room",
+            "Q": "quest",
+            "S": "script",
+        }
+        category = category_map[arg]
+        try:
+            vnum = vnum_registry.get_next_vnum(category)
+        except KeyError:
+            self.msg("Unsupported VNUM category.")
+            return
+        self.msg(str(vnum))
+

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -3482,4 +3482,31 @@ wander and scripted. Scripted AI runs the callback stored on
 |wnpc.db.ai_script|n.
 """,
     },
+    {
+        "key": "nextvnum",
+        "category": "Building",
+        "text": """Help for nextvnum
+
+Fetch the next unused VNUM for a category.
+
+Usage:
+    @nextvnum <I|M|R|O|Q|S>
+
+Switches:
+    None
+
+Arguments:
+    None
+
+Examples:
+    @nextvnum M
+
+Notes:
+    - I and O return an object VNUM.
+    - The number is reserved immediately.
+
+Related:
+    help ansi
+""",
+    },
 ]


### PR DESCRIPTION
## Summary
- add `CmdNextVnum` command to return the next available VNUM
- hook the command into the `Builder` command set
- document `@nextvnum` usage in README
- add help entry for `nextvnum`

## Testing
- `pytest -q` *(fails: django.db.utils.OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6847d19399f0832ca22541f408e7c9e9