### PR TITLE
Add NPC vnum tags

### DIFF
--- a/commands/cmdmobbuilder.py
+++ b/commands/cmdmobbuilder.py
@@ -5,7 +5,7 @@ import shlex
 from evennia.utils.evmenu import EvMenu
 from evennia import DefaultRoom
 from evennia.utils import evtable
-from evennia.objects.models import ObjectDB
+from evennia.utils.search import search_tag
 
 from .command import Command
 from utils.mob_proto import (
@@ -142,7 +142,7 @@ class CmdMobProto(Command):
             return
         npcs = [
             obj
-            for obj in ObjectDB.objects.get_by_attribute(key="vnum", value=vnum)
+            for obj in search_tag(key=f"M{vnum}", category="vnum")
             if obj.is_typeclass(BaseNPC, exact=False)
         ]
         if npcs:
@@ -204,4 +204,3 @@ class CmdMobProto(Command):
             caller.msg("No differences.")
         else:
             caller.msg(str(table))
-

--- a/typeclasses/tests/test_vnum_mobs.py
+++ b/typeclasses/tests/test_vnum_mobs.py
@@ -39,12 +39,15 @@ class TestVnumMobs(EvenniaTest):
         proto = {"key": "goblin", "typeclass": "typeclasses.npcs.BaseNPC"}
         vnum = register_prototype(proto, vnum=1)
         npc_mock = MagicMock()
-        with patch("evennia.prototypes.spawner.spawn", return_value=[npc_mock]) as mock_spawn:
+        with patch(
+            "evennia.prototypes.spawner.spawn", return_value=[npc_mock]
+        ) as mock_spawn:
             npc = spawn_from_vnum(vnum, location=self.char1.location)
         mock_spawn.assert_called()
         self.assertIs(npc, npc_mock)
         self.assertEqual(npc.location, self.char1.location)
         self.assertEqual(npc.db.vnum, vnum)
+        self.assertEqual(npc.tags.get(category="vnum"), f"M{vnum}")
         mob_db = get_mobdb()
         self.assertEqual(mob_db.get_proto(vnum)["spawn_count"], 1)
 
@@ -59,7 +62,9 @@ class TestVnumMobs(EvenniaTest):
 
         with patch("commands.cmdmobbuilder.EvMenu") as mock_menu:
             self.char1.execute_cmd("@mobproto edit 1")
-        mock_menu.assert_called_with(self.char1, "commands.npc_builder", startnode="menunode_desc")
+        mock_menu.assert_called_with(
+            self.char1, "commands.npc_builder", startnode="menunode_desc"
+        )
         self.assertEqual(self.char1.ndb.mob_vnum, 1)
         self.assertEqual(self.char1.ndb.buildnpc["key"], "gob")
 
@@ -81,4 +86,3 @@ class TestVnumMobs(EvenniaTest):
         self.assertIsNone(get_prototype(1))
         del_msg = self.char1.msg.call_args[0][0]
         self.assertIn("deleted", del_msg.lower())
-

--- a/utils/mob_proto.py
+++ b/utils/mob_proto.py
@@ -38,6 +38,7 @@ def spawn_from_vnum(vnum: int, location=None):
     if location:
         npc.location = location
     npc.db.vnum = vnum
+    npc.tags.add(f"M{vnum}", category="vnum")
     # track how often this prototype has spawned
     mob_db.increment_spawn_count(vnum)
     return npc


### PR DESCRIPTION
## Summary
- tag mobs with their vnum when spawning
- search for NPCs by vnum tag when deleting
- test that spawned mobs include the tag

## Testing
- `black utils/mob_proto.py commands/cmdmobbuilder.py typeclasses/tests/test_vnum_mobs.py`
- `pytest typeclasses/tests/test_vnum_mobs.py::TestVnumMobs::test_register_and_spawn_vnum -q` *(fails: ContentType.DoesNotExist)*

------
https://chatgpt.com/codex/tasks/task_e_6847d35f8084832c8d7a50423847ebac