### PR TITLE
Add VNUM docs

### DIFF
--- a/commands/README.md
+++ b/commands/README.md
@@ -154,3 +154,19 @@ argument selects the category:
 * **S** – script VNUM
 
 The returned number is automatically marked as used in the registry.
+
+## VNUM Prefixes
+
+Numbers may be referenced with a single letter prefix indicating the
+category.  ``M`` is used for mobs, ``O`` or ``I`` for objects, ``R`` for rooms,
+``Q`` for quests and ``S`` for scripts.  For example ``M200001`` refers to the
+mob prototype with VNUM ``200001``.  The prefix form works anywhere a command
+expects a prototype key and avoids confusion with other numeric arguments.
+
+## Automatic Assignment in the Mob Builder
+
+When using the menu driven mob builder you may enter ``auto`` at the VNUM
+prompt. This calls ``@nextvnum M`` behind the scenes and registers the number
+immediately.  Prototypes saved from the builder use the ``mob_`` prefix and any
+NPC spawned from a VNUM prototype receives a ``M<number>`` tag.  You can search
+for live NPCs with ``search_tag(key="M<number>", category="vnum")``.

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -2939,6 +2939,8 @@ Notes:
       saving the prototype.
     - Load default stats with |w@mobtemplate list|n then
       |w@mobtemplate <name>|n while in the builder.
+    - Type |wauto|n at the VNUM prompt to automatically reserve the next
+      available number.
     - Example workflow:
         1) run |wmobbuilder|n and fill in the prompts
         2) choose |wYes & Save Prototype|n
@@ -3052,6 +3054,11 @@ Examples:
     @mspawn bandit
     @mspawn mob_guard
     @mspawn M200001
+
+Notes:
+    - ``M<number>`` spawns a prototype by its VNUM.
+    - NPCs spawned this way are tagged ``M<number>`` for easy lookup
+      with ``search_tag``.
 """,
     },
     {
@@ -3481,6 +3488,24 @@ NPC behavior is controlled by an AI type set in the |wcnpc|n builder or
 |wmobbuilder|n. Available types are passive, aggressive, defensive,
 wander and scripted. Scripted AI runs the callback stored on
 |wnpc.db.ai_script|n.
+""",
+    },
+    {
+        "key": "vnums",
+        "category": "Building",
+        "text": """Help for vnums
+
+VNUMs are numeric identifiers reserved in a registry. Each category has a
+dedicated range:
+
+    NPCs: 1-99999
+    Objects: 100000-199999
+    Rooms: 200000-299999
+
+Use |w@nextvnum <I|M|R|O|Q|S>|n to fetch the next free number. Prefix the
+value with its letter, like |wM5|n, when spawning or referencing by VNUM.
+NPCs spawned from a VNUM automatically gain a |wM<number>|n tag so you can
+find them later with |wsearch_tag(key="M<number>", category="vnum")|n.
 """,
     },
     {


### PR DESCRIPTION
## Summary
- document @nextvnum, prefixes and mob builder auto-assign
- expand mobbuilder and mspawn help
- add help for VNUM ranges and tagging

## Testing
- `pytest -q` *(fails: Combat calculations, currency, menu utils, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6847d7c7c50c832cbadb385001e25c51