### PR TITLE
Add interactive prompt before mobbuilder starts

### DIFF
--- a/commands/mob_builder.py
+++ b/commands/mob_builder.py
@@ -22,6 +22,7 @@ class CmdMobBuilder(Command):
     help_category = "Building"
 
     def func(self):
+        """Ask if the interactive builder should be launched."""
         self.caller.ndb.buildnpc = {
             "triggers": {},
             "npc_class": "base",
@@ -33,7 +34,18 @@ class CmdMobBuilder(Command):
             "script": "",
             "use_mob": True,
         }
-        EvMenu(self.caller, "commands.npc_builder", startnode="menunode_key")
+
+        key = self.caller.ndb.buildnpc.get("key", "<unset>")
+        vnum = self.caller.ndb.buildnpc.get("vnum", "auto")
+        confirm = yield (
+            f"Prototype key: {key} | VNUM: {vnum}.\nRun mobbuilder interactively? Yes/No"
+        )
+        if confirm.strip().lower() not in ("y", "yes"):
+            self.caller.msg("Aborted.")
+            self.caller.ndb.buildnpc = None
+            return
+
+        EvMenu(self.caller, "commands.npc_builder", startnode="menunode_summary")
 
 
 class CmdMSpawn(Command):

--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -114,7 +114,23 @@ def _import_script(path: str):
     return getattr(mod, attr)
 
 
+
 # Menu nodes for NPC creation
+
+def menunode_summary(caller, raw_string="", **kwargs):
+    """Show current values before editing."""
+    data = caller.ndb.buildnpc or {}
+    text = "|wCurrent NPC Values|n\n"
+    for field in ("key", "desc", "vnum", "npc_class", "level"):
+        if field in data:
+            text += f"{field}: {data.get(field)}\n"
+    text += "\nChoose an option:"
+    options = [
+        {"desc": "Edit", "goto": "menunode_key"},
+        {"desc": "Continue", "goto": "menunode_confirm"},
+    ]
+    return text, options
+
 
 def menunode_key(caller, raw_string="", **kwargs):
     """Prompt for the NPC key."""

--- a/typeclasses/tests/test_mob_builder.py
+++ b/typeclasses/tests/test_mob_builder.py
@@ -35,8 +35,13 @@ class TestMobBuilder(EvenniaTest):
         return None
 
     def test_builder_flow_and_spawn(self):
-        with patch("commands.npc_builder.EvMenu"):
+        with patch("commands.npc_builder.EvMenu") as mock_menu:
             self.char1.execute_cmd("mobbuilder")
+            prompt = self.char1.msg.call_args[0][0]
+            self.assertIn("Run", prompt)
+            self.char1.msg.reset_mock()
+            self.char1.execute_cmd("yes")
+        mock_menu.assert_called()
         npc_builder._set_key(self.char1, "goblin")
         npc_builder._set_desc(self.char1, "A small goblin")
         npc_builder._set_creature_type(self.char1, "humanoid")


### PR DESCRIPTION
## Summary
- prompt for confirmation when running `mobbuilder`
- add `menunode_summary` for quick review of NPC data
- adjust mob builder test for new prompt

## Testing
- `pytest -q` *(fails: OperationalError no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6847df84db44832cab228983fe4333ee