### PR TITLE
Add practice and training info to score

### DIFF
--- a/utils/stats_utils.py
+++ b/utils/stats_utils.py
@@ -182,6 +182,8 @@ def get_display_scroll(chara):
     level = _db_get(chara, "level", 1)
     xp = _db_get(chara, "exp", 0)
     tnl = max(level * 100 - xp, 0)
+    practice_sessions = _db_get(chara, "practice_sessions", 0) or 0
+    training_points = _db_get(chara, "training_points", 0) or 0
 
     hp = chara.traits.get("health")
     mp = chara.traits.get("mana")
@@ -209,7 +211,7 @@ def get_display_scroll(chara):
             sated_disp = f"|g{sated_val}|n"
 
     lines.append(
-        f"|YLvl {level}|n  |CXP|n {xp}  |yTNL|n {tnl}  |rHP|n {hp_disp}  |cMP|n {mp_disp}  |gSP|n {sp_disp}"
+        f"|YLvl {level}|n  |CXP|n {xp}  |yTNL|n {tnl}  |rHP|n {hp_disp}  |cMP|n {mp_disp}  |gSP|n {sp_disp}  Prac {practice_sessions}  TP {training_points}"
     )
     if show_sated:
         lines.append(f"|ySated|n {sated_disp}")

--- a/utils/tests/test_stats_utils.py
+++ b/utils/tests/test_stats_utils.py
@@ -29,3 +29,11 @@ class TestDisplayScroll(EvenniaTest):
         char.db.sated = 50
         sheet = get_display_scroll(char)
         self.assertNotIn("Sated", sheet)
+
+    def test_practice_and_training_display(self):
+        char = self.char1
+        char.db.practice_sessions = 2
+        char.db.training_points = 1
+        sheet = get_display_scroll(char)
+        self.assertIn("Prac 2", sheet)
+        self.assertIn("TP 1", sheet)

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -1874,7 +1874,7 @@ Related:
         "text": """
 Help for score
 
-View your character sheet. Usage: score
+View your character sheet, including remaining practice sessions and training points. Usage: score
 
 Usage:
     score


### PR DESCRIPTION
## Summary
- expand score display to include practice sessions and training points
- mention practice sessions and training points in `score` help entry
- test that score displays practice sessions and training points

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6847e6aaffb0832c9a8922c3860b16d4