### PR TITLE
Add new test for practice and training labels

### DIFF
--- a/utils/tests/test_stats_utils.py
+++ b/utils/tests/test_stats_utils.py
@@ -37,3 +37,11 @@ class TestDisplayScroll(EvenniaTest):
         sheet = get_display_scroll(char)
         self.assertIn("Prac 2", sheet)
         self.assertIn("TP 1", sheet)
+
+    def test_practice_and_training_labels_present(self):
+        char = self.char1
+        char.db.practice_sessions = 3
+        char.db.training_points = 5
+        sheet = get_display_scroll(char)
+        self.assertIn("Prac", sheet)
+        self.assertIn("TP", sheet)


### PR DESCRIPTION
## Summary
- add regression test to verify practice and training labels are shown in display scroll

## Testing
- `pytest -q` *(fails: OperationalError - no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6847e9a77498832c81388e2a6c95f702