### PR TITLE
Update starvation effects

### DIFF
--- a/typeclasses/tests/test_state_manager.py
+++ b/typeclasses/tests/test_state_manager.py
@@ -81,6 +81,17 @@ class TestStateManager(EvenniaTest):
         self.assertFalse(char.tags.has("hungry_thirsty", category="status"))
         self.assertEqual(char.traits.health.current, hp)
 
+    def test_hunger_drains_all_resources(self):
+        char = self.char1
+        char.db.sated = 0
+        hp = char.traits.health.current
+        mp = char.traits.mana.current
+        sp = char.traits.stamina.current
+        state_manager.tick_character(char)
+        self.assertEqual(char.traits.health.current, hp - 1)
+        self.assertEqual(char.traits.mana.current, mp - 1)
+        self.assertEqual(char.traits.stamina.current, sp - 1)
+
     def test_apply_regen_uses_derived_stats(self):
         char = self.char1
         for key in ("health", "mana", "stamina"):

--- a/world/system/state_manager.py
+++ b/world/system/state_manager.py
@@ -269,6 +269,9 @@ def tick_character(chara):
             add_effect(chara, "hungry_thirsty", 1)
             if (hp := chara.traits.get("health")):
                 hp.current = max(hp.current - 1, 0)
+            for res in ("mana", "stamina"):
+                if (trait := chara.traits.get(res)):
+                    trait.current = max(trait.current - 1, 0)
 
 
 def tick_all():


### PR DESCRIPTION
## Summary
- drain mana and stamina when starving
- test that hunger drains all resources

## Testing
- `pytest typeclasses/tests/test_state_manager.py::TestStateManager::test_hunger_drains_all_resources -q`

------
https://chatgpt.com/codex/tasks/task_e_6847ecc91960832c842f4e1bb7bc771f