### PR TITLE
Update leveling tests for reward message

### DIFF
--- a/typeclasses/tests/test_leveling.py
+++ b/typeclasses/tests/test_leveling.py
@@ -19,6 +19,9 @@ class TestLeveling(EvenniaTest):
         self.assertEqual(self.char1.db.practice_sessions, 3)
         self.assertEqual(self.char1.db.training_points, 1)
         self.char1.msg.assert_called()
+        output = self.char1.msg.call_args[0][0]
+        self.assertIn("practice sessions", output)
+        self.assertIn("training point", output)
 
     def test_multiple_level_ups(self):
         self.char1.db.exp = 210
@@ -26,3 +29,6 @@ class TestLeveling(EvenniaTest):
         self.assertEqual(self.char1.db.level, 3)
         self.assertEqual(self.char1.db.practice_sessions, 6)
         self.assertEqual(self.char1.db.training_points, 2)
+        output = self.char1.msg.call_args[0][0]
+        self.assertIn("practice sessions", output)
+        self.assertIn("training point", output)


### PR DESCRIPTION
## Summary
- add explicit reward message assertions in leveling tests

## Testing
- `pytest typeclasses/tests/test_leveling.py::TestLeveling::test_single_level_up_awards_resources -q` *(fails: settings.DEFAULT_HOME does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6847f0b5cbc8832cb6bad670de96dbea