### PR TITLE
Remove legacy medit command

### DIFF
--- a/commands/admin.py
+++ b/commands/admin.py
@@ -49,7 +49,6 @@ from .mob_builder import (
     CmdMobPreview,
     CmdMStat,
     CmdMList,
-    CmdMedit,
     CmdMobTemplate,
 )
 from .cmdmobbuilder import CmdMobProto
@@ -1434,7 +1433,6 @@ class BuilderCmdSet(CmdSet):
         self.add(CmdDelRoom)
         self.add(CmdCNPC)
         self.add(CmdEditNPC)
-        self.add(CmdMedit)
         self.add(CmdDeleteNPC)
         self.add(CmdCloneNPC)
         self.add(CmdSpawnNPC)

--- a/commands/mob_builder.py
+++ b/commands/mob_builder.py
@@ -32,7 +32,7 @@ class CmdMSpawn(Command):
     Spawn a mob prototype.
 
     Prototypes are loaded from ``world/prototypes/npcs.json``. Spawning creates
-    a new NPC and leaves any existing ones unchanged. Use ``@medit`` to modify
+    a new NPC and leaves any existing ones unchanged. Use ``@editnpc`` to modify
     a live NPC.
 
     Usage:
@@ -147,25 +147,6 @@ class CmdMStat(_OldMStat):
 class CmdMList(_OldMList):
     pass
 
-
-class CmdMedit(Command):
-    """Edit an NPC and optionally update its prototype."""
-
-    key = "@medit"
-    locks = "cmd:perm(Builder)"
-    help_category = "Building"
-
-    def func(self):
-        if not self.args:
-            self.msg("Usage: @medit <npc>")
-            return
-        npc = self.caller.search(self.args.strip(), global_search=True)
-        if not npc or not npc.is_typeclass(NPC, exact=False):
-            self.msg("Invalid NPC.")
-            return
-        data = npc_builder._gather_npc_data(npc)
-        self.caller.ndb.buildnpc = data
-        EvMenu(self.caller, "commands.npc_builder", startnode="menunode_desc")
 
 
 class CmdMobTemplate(Command):

--- a/commands/mob_builder_commands.py
+++ b/commands/mob_builder_commands.py
@@ -31,7 +31,7 @@ class CmdMStat(Command):
     Inspect an NPC or stored prototype.
 
     Prototype data is read from ``world/prototypes/npcs.json``. This is a
-    read-only command and will not change any existing NPCs. Use ``@medit`` if
+    read-only command and will not change any existing NPCs. Use ``@editnpc`` if
     you need to update a live NPC from a prototype.
 
     Usage:
@@ -125,8 +125,8 @@ class CmdMCreate(Command):
     Create a new NPC prototype.
 
     The prototype is stored in ``world/prototypes/npcs.json`` and does not
-    affect any already spawned NPCs. Use ``@medit`` later if you need to update
-    a live NPC from the saved prototype.
+    affect any already spawned NPCs. Use ``@editnpc`` later if you need to
+    update a live NPC from the saved prototype.
 
     Usage:
         @mcreate <key> [copy_key]
@@ -169,7 +169,7 @@ class CmdMSet(Command):
     Edit a field on an NPC prototype.
 
     Changes are written to ``world/prototypes/npcs.json``. Existing NPCs are
-    unaffected until you apply the prototype with ``@medit``.
+    unaffected until you apply the prototype with ``@editnpc``.
 
     Usage:
         @mset <key> <field> <value>
@@ -248,7 +248,7 @@ class CmdMList(Command):
     List stored NPC prototypes or spawned NPCs.
 
     Prototype information is read from ``world/prototypes/npcs.json``. Listing
-    does not alter any existing NPCs. Use ``@medit`` if you want to modify a
+    does not alter any existing NPCs. Use ``@editnpc`` if you want to modify a
     spawned NPC.
 
     Usage:

--- a/typeclasses/tests/test_editnpc_command.py
+++ b/typeclasses/tests/test_editnpc_command.py
@@ -7,21 +7,21 @@ from typeclasses.npcs import BaseNPC
 
 
 @override_settings(DEFAULT_HOME=None)
-class TestMeditCommand(EvenniaTest):
+class TestEditNPCCommand(EvenniaTest):
     def setUp(self):
         super().setUp()
         self.char1.msg = MagicMock()
         self.char1.cmdset.add_default(BuilderCmdSet)
 
-    def test_medit_opens_menu(self):
+    def test_editnpc_opens_menu(self):
         npc = create.create_object(BaseNPC, key="orc", location=self.room1)
-        with patch("commands.mob_builder.EvMenu") as mock_menu:
-            self.char1.execute_cmd(f"@medit {npc.key}")
+        with patch("commands.npc_builder.EvMenu") as mock_menu:
+            self.char1.execute_cmd(f"@editnpc {npc.key}")
             mock_menu.assert_called_with(self.char1, "commands.npc_builder", startnode="menunode_desc")
             data = self.char1.ndb.buildnpc
             assert data["key"] == "orc"
 
-    def test_medit_invalid(self):
-        self.char1.execute_cmd("@medit nowhere")
+    def test_editnpc_invalid(self):
+        self.char1.execute_cmd("@editnpc nowhere")
         assert "Invalid NPC." in self.char1.msg.call_args[0][0]
 

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -2959,7 +2959,7 @@ Related:
 
 Create a new NPC prototype. The prototype data is stored in
 ``world/prototypes/npcs.json`` and does not affect any existing NPCs
-until you update them with |w@medit|n. If ``copy_key`` is supplied the
+until you update them with |w@editnpc|n. If ``copy_key`` is supplied the
 new prototype will start as a duplicate of that entry.
 
 After creating a prototype use |w@mset|n to edit additional fields like
@@ -2981,7 +2981,7 @@ Examples:
 
 Edit a field on an NPC prototype stored in
 ``world/prototypes/npcs.json``. Existing NPCs remain unchanged unless
-you later apply the prototype with |w@medit|n.
+you later apply the prototype with |w@editnpc|n.
 
 Values containing spaces should be quoted. Some fields accept a comma
 separated list which will replace the old values.
@@ -3001,7 +3001,7 @@ Examples:
 
 Display stats for an NPC or prototype. Prototype information is read
 from ``world/prototypes/npcs.json`` and this command never changes an
-NPC. Use |w@medit|n for modifications. The output lists common combat
+NPC. Use |w@editnpc|n for modifications. The output lists common combat
 attributes along with any flags, resistances and languages defined on
 the target.
 
@@ -3020,7 +3020,7 @@ Examples:
 
 List NPC prototypes or counts of spawned NPCs. Prototypes are read from
 ``world/prototypes/npcs.json``. Listing does not modify any NPCs; use
-|w@medit|n if you need to update them.
+|w@editnpc|n if you need to update them.
 
 You may filter results with ``class=<name>``, ``race=<name>``,
 ``role=<name>``, ``tag=<tag>`` or ``zone=<area>``. Use ``/room`` to count
@@ -3042,7 +3042,7 @@ Examples:
 
 Spawn an NPC from a prototype defined in
 ``world/prototypes/npcs.json``. Spawning creates a new NPC and leaves
-existing ones untouched. Modify live NPCs with |w@medit|n.
+existing ones untouched. Modify live NPCs with |w@editnpc|n.
 
 Prototypes made with |wmobbuilder|n are prefixed with ``mob_``. Use the
 full key when spawning those NPCs.


### PR DESCRIPTION
## Summary
- remove `CmdMedit` and reference `CmdEditNPC`
- update builder command set
- adjust docs and help entries
- rename test for `@editnpc`

## Testing
- `pytest -q` *(fails: OperationalError no such table accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6847f8df8264832cba115856e2749aec