### PR TITLE
Add formatted NPC summary helper

### DIFF
--- a/typeclasses/tests/test_cnpc.py
+++ b/typeclasses/tests/test_cnpc.py
@@ -194,3 +194,18 @@ class TestCNPC(EvenniaTest):
         trig = triggers["on_test"][0]
         self.assertEqual(trig["match"], "hello")
         self.assertEqual(trig["responses"], ["say hi", "emote waves", "jump"])
+
+    def test_confirm_formatting(self):
+        """menunode_confirm should return a formatted table."""
+        self.char1.ndb.buildnpc = {
+            "key": "goblin",
+            "desc": "",
+            "npc_class": "base",
+            "level": 1,
+            "primary_stats": {"STR": 1},
+        }
+
+        text, _ = npc_builder.menunode_confirm(self.char1)
+        self.assertIn("Goblin", text)
+        self.assertIn("Field", text)
+        self.assertIn("Primary Stats", text)


### PR DESCRIPTION
## Summary
- create `format_mob_summary` helper for displaying NPC info in a table
- use new helper in `menunode_confirm`
- add regression test for new formatting

## Testing
- `pytest typeclasses/tests/test_cnpc.py::TestCNPC::test_confirm_formatting -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6847fb48b260832ca6e3ad7cd247b7b4