### PR TITLE
Update mob builder docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,21 +220,17 @@ mobs when a VNUM has been assigned.
 
 ### Mob Builder
 
-Run `mobbuilder` to open the same menu driven builder used by `cnpc`. The
-workflow supports mob‑specific fields like act flags and resistances. At the
-end of the menu you may choose **Yes** to spawn the NPC or **Yes & Save
-Prototype** to spawn it and also store the prototype in
-`world/prototypes/npcs.json` with `mob_` prefixed to the key. Use
-`@mspawn <prototype>` or the ``M<number>`` form to create additional copies and
-`@mstat <key>` to inspect
-them. Prototype entries can be adjusted with `@mcreate`, `@mset` and viewed with
-`@mlist`. Mobs created this way are flagged with `can_attack` and are given a
-simple punch attack so they can fight back without equipment.
+`mobbuilder` is now an alias for the unified `cnpc` command. It launches the
+same menu with mob defaults and immediately spawns the NPC once you confirm.
+Choosing **Yes & Save Prototype** will also store the entry in
+`world/prototypes/npcs.json` with the `mob_` prefix so you can reuse it with
+`@mspawn <prototype>` or ``M<number>``. The final summary now shows any mob
+specific fields such as act flags and resistances.
 
 Example::
 
-    mobbuilder
-    (fill in the prompts for a goblin)
+    cnpc start goblin
+    [follow the prompts]
     [choose **Yes & Save Prototype**]
     @mspawn mob_goblin
     @mspawn M200001

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -2682,8 +2682,11 @@ Notes:
       guildmaster, guild_receptionist, questgiver, combat_trainer and
       event_npc.
     - The builder prompts for description, role, creature type, level,
-      experience reward, HP MP SP, primary stats, behavior, skills, spells, resistances and
-      AI type.
+      experience reward, HP MP SP, primary stats, behavior, skills, spells,
+      resistances and AI type.
+    - Mob specific fields such as act flags, resistances, skills and spells can
+      now be configured directly in this menu along with an optional Script
+      typeclass to run when the mob spawns.
     - Humanoid body type grants the standard equipment slots automatically.
       Quadrupeds receive head, body, front_legs and hind_legs and lack weapon
       slots. Unique lets you add or remove any slots in the next step.
@@ -2919,37 +2922,20 @@ Related:
         "category": "Building",
         "text": """Help for mobbuilder
 
-Invokes the same menu-driven builder as |wcnpc|n but the NPC is spawned
-immediately. Choosing |wYes & Save Prototype|n at the end also stores the
-result as a prototype prefixed with ``mob_``. Additional mob specific fields
-such as act flags, skills, spells and resistances may be set while stepping
-through the menu.
-You can also specify a Script typeclass to attach after the languages step.
+This command is an alias for |wcnpc|n and launches the same menu driven
+builder with mob defaults. When you finish the prompts the mob is spawned
+immediately. Choosing |wYes & Save Prototype|n stores the prototype with the
+``mob_`` prefix so it can be reused with |w@mspawn|n.
 
 Usage:
     mobbuilder
 
 Notes:
-    - Edit saved prototypes with |w@mcreate|n or |w@mset|n and review them
-      using |w@mlist|n. See |whelp @mlist|n for filtering options.
-    - Spawn a stored prototype with |w@mspawn <prototype>|n or |w@mspawn M<number>|n.
-    - Quickly preview a prototype with |w@mobpreview <prototype>|n.
-    - Inspect prototypes or NPCs with |w@mstat <key>|n.
-    - Use |w@makeshop|n or |w@makerepair|n to add vendor data after
-      saving the prototype.
-    - Load default stats with |w@mobtemplate list|n then
-      |w@mobtemplate <name>|n while in the builder.
-    - Type |wauto|n at the VNUM prompt to automatically reserve the next
-      available number.
-    - Example workflow:
-        1) run |wmobbuilder|n and fill in the prompts
-        2) choose |wYes & Save Prototype|n
-        3) use |w@mspawn mob_<key>|n or |w@mspawn M<number>|n to spawn more copies
+    - Equivalent to |wcnpc start <key>|n.
+    - See |whelp cnpc|n for a full explanation of the builder options.
 
 Related:
     help cnpc
-    help @mspawn
-    help @mstat
 """,
     },
     {


### PR DESCRIPTION
## Summary
- document new unified CNPC command
- describe mob-specific fields in the CNPC help entry
- update README mob builder section

## Testing
- `pytest -q` *(fails: TestCombatUtils::test_roll_crit_and_damage and others)*

------
https://chatgpt.com/codex/tasks/task_e_6847fd847094832cba6ea541bcd358dc