### PR TITLE
Remove dedicated mob builder command

### DIFF
--- a/commands/admin.py
+++ b/commands/admin.py
@@ -44,7 +44,6 @@ from .mob_builder_commands import (
     CmdMobValidate,
 )
 from .mob_builder import (
-    CmdMobBuilder,
     CmdMSpawn,
     CmdMobPreview,
     CmdMStat,
@@ -1438,7 +1437,6 @@ class BuilderCmdSet(CmdSet):
         self.add(CmdSpawnNPC)
         self.add(CmdListNPCs)
         self.add(CmdDupNPC)
-        self.add(CmdMobBuilder)
         self.add(CmdMobTemplate)
         self.add(CmdMSpawn)
         self.add(CmdMobPreview)

--- a/commands/mob_builder.py
+++ b/commands/mob_builder.py
@@ -14,19 +14,6 @@ from .command import Command
 from .mob_builder_commands import CmdMStat as _OldMStat, CmdMList as _OldMList
 
 
-class CmdMobBuilder(Command):
-    """Launch the CNPC builder pre-configured for mobs."""
-
-    key = "mobbuilder"
-    locks = "cmd:perm(Builder)"
-    help_category = "Building"
-
-    def func(self):
-        """Start the new NPC builder using mob defaults."""
-        self.caller.ndb.buildnpc = {"use_mob": True}
-        EvMenu(self.caller, "commands.npc_builder", startnode="menunode_key")
-
-
 class CmdMSpawn(Command):
     """
     Spawn a mob prototype.

--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -1257,7 +1257,7 @@ class CmdCNPC(Command):
     """Create or edit an NPC using a guided menu."""
 
     key = "cnpc"
-    aliases = ["createnpc"]
+    aliases = ["createnpc", "mobbuilder"]
     locks = "cmd:perm(Builder) or perm(Admin) or perm(Developer)"
     help_category = "Building"
 

--- a/typeclasses/tests/test_mob_builder.py
+++ b/typeclasses/tests/test_mob_builder.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from evennia.utils.test_resources import EvenniaTest
 
 from commands.admin import BuilderCmdSet
-from commands import mob_builder, npc_builder
+from commands import npc_builder
 from world import prototypes
 
 
@@ -36,12 +36,10 @@ class TestMobBuilder(EvenniaTest):
 
     def test_builder_flow_and_spawn(self):
         with patch("commands.npc_builder.EvMenu") as mock_menu:
-            self.char1.execute_cmd("mobbuilder")
-            prompt = self.char1.msg.call_args[0][0]
-            self.assertIn("Run", prompt)
-            self.char1.msg.reset_mock()
-            self.char1.execute_cmd("yes")
-        mock_menu.assert_called()
+            self.char1.execute_cmd("mobbuilder start goblin")
+        mock_menu.assert_called_with(
+            self.char1, "commands.npc_builder", startnode="menunode_desc"
+        )
         npc_builder._set_key(self.char1, "goblin")
         npc_builder._set_desc(self.char1, "A small goblin")
         npc_builder._set_creature_type(self.char1, "humanoid")

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -2922,20 +2922,9 @@ Related:
         "category": "Building",
         "text": """Help for mobbuilder
 
-This command is an alias for |wcnpc|n and launches the same menu driven
-builder with mob defaults. When you finish the prompts the mob is spawned
-immediately. Choosing |wYes & Save Prototype|n stores the prototype with the
-``mob_`` prefix so it can be reused with |w@mspawn|n.
-
-Usage:
-    mobbuilder
-
-Notes:
-    - Equivalent to |wcnpc start <key>|n.
-    - See |whelp cnpc|n for a full explanation of the builder options.
-
-Related:
-    help cnpc
+The |wmobbuilder|n command is now just an alias for |wcnpc|n. All of the
+functionality lives in that command, so use either |wcnpc|n or |wmobbuilder|n
+interchangeably. See |whelp cnpc|n for a complete overview of the builder.
 """,
     },
     {


### PR DESCRIPTION
## Summary
- drop `CmdMobBuilder` and expose `mobbuilder` as alias to `cnpc`
- update builder command set and help text
- adjust tests for the new alias

## Testing
- `python -m pip install 'evennia[extra]>=4.2,<5.0' 'Django>=4.2,<5.0' pytest`
- `pytest -q` *(fails: TestCombatUtils.test_roll_crit_and_damage, ...)*

------
https://chatgpt.com/codex/tasks/task_e_6848007873f8832c933f745e74a09929