### PR TITLE
Improve NPC builder skills guidance

### DIFF
--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -24,6 +24,7 @@ from world.mob_constants import (
     DEFENSE_TYPES,
     parse_flag_list,
 )
+from combat.combat_skills import SKILL_CLASSES
 
 
 def validate_prototype(data: dict) -> list[str]:
@@ -77,6 +78,20 @@ NPC_CLASS_MAP = {
     "combat_trainer": "typeclasses.npcs.combat_trainer.CombatTrainerNPC",
     "event_npc": "typeclasses.npcs.event_npc.EventNPC",
 }
+
+
+# Suggested skill lists for each NPC class
+DEFAULT_SKILLS = list(SKILL_CLASSES.keys())
+SKILLS_BY_CLASS = {
+    "merchant": ["appraise"],
+    "combat_trainer": DEFAULT_SKILLS,
+    "base": DEFAULT_SKILLS,
+}
+
+
+def get_skills_for_class(npc_class: str) -> list[str]:
+    """Return list of suggested skills for ``npc_class``."""
+    return SKILLS_BY_CLASS.get(npc_class, DEFAULT_SKILLS)
 
 
 # Additional configuration options
@@ -724,9 +739,12 @@ def _set_behavior(caller, raw_string, **kwargs):
 def menunode_skills(caller, raw_string="", **kwargs):
     skills = caller.ndb.buildnpc.get("skills", [])
     default = ", ".join(skills)
+    npc_class = caller.ndb.buildnpc.get("npc_class", "base")
+    suggested = ", ".join(get_skills_for_class(npc_class))
     text = "|wList any skills or attacks (comma separated)|n"
     if default:
         text += f" [default: {default}]"
+    text += f"\nSuggested for {npc_class}: {suggested}"
     text += "\nExample: |wfireball, slash, heal|n"
     text += "\n(back to go back, skip for default)"
     options = add_back_skip({"key": "_default", "goto": _set_skills}, _set_skills)

--- a/typeclasses/tests/test_mob_builder.py
+++ b/typeclasses/tests/test_mob_builder.py
@@ -134,3 +134,10 @@ class TestMobBuilder(EvenniaTest):
         result = npc_builder._set_vnum(self.char1, "skip")
         assert self.char1.ndb.buildnpc["vnum"] == 5
         assert result == "menunode_creature_type"
+
+    def test_skills_menu_shows_suggestions(self):
+        """menunode_skills should list suggested skills for the class."""
+        self.char1.ndb.buildnpc = {"npc_class": "combat_trainer"}
+        text, _ = npc_builder.menunode_skills(self.char1)
+        for skill in npc_builder.DEFAULT_SKILLS:
+            assert skill in text

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -2691,6 +2691,7 @@ Notes:
       Quadrupeds receive head, body, front_legs and hind_legs and lack weapon
       slots. Unique lets you add or remove any slots in the next step.
     - Prompts accept |wback|n to return or |wskip|n to keep defaults.
+    - The skills prompt lists suggested abilities for the chosen class.
     - When multiple values are allowed, use comma or space separated lists as
       shown in each example.
     - After reviewing the summary choose |wYes|n to confirm and create or


### PR DESCRIPTION
## Summary
- show recommended skills for NPC class
- document new guidance in help
- test for skills suggestions in `menunode_skills`

## Testing
- `pytest -q` *(fails: OperationalError no such table accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68480e689aa4832caf142004b42729bc