### PR TITLE
Add race, sex, and size fields to NPC builder

### DIFF
--- a/typeclasses/tests/test_mob_builder.py
+++ b/typeclasses/tests/test_mob_builder.py
@@ -41,6 +41,9 @@ class TestMobBuilder(EvenniaTest):
             self.char1, "commands.npc_builder", startnode="menunode_desc"
         )
         npc_builder._set_key(self.char1, "goblin")
+        npc_builder._set_race(self.char1, "human")
+        npc_builder._set_sex(self.char1, "male")
+        npc_builder._set_size(self.char1, "medium")
         npc_builder._set_desc(self.char1, "A small goblin")
         npc_builder._set_creature_type(self.char1, "humanoid")
         npc_builder._set_role(self.char1, "")
@@ -85,6 +88,9 @@ class TestMobBuilder(EvenniaTest):
         data = {
             "key": "goblin",
             "desc": "A nasty goblin",
+            "race": "orc",
+            "sex": "male",
+            "size": "small",
             "level": 2,
             "hp": 10,
             "mp": 0,

--- a/world/mob_constants.py
+++ b/world/mob_constants.py
@@ -33,6 +33,22 @@ class NPC_RACES(_StrEnum):
     SATYR = "satyr"
 
 
+class NPC_SEXES(_StrEnum):
+    """Biological sex options for NPCs."""
+
+    MALE = "male"
+    FEMALE = "female"
+    NEUTRAL = "neutral"
+
+
+class NPC_SIZES(_StrEnum):
+    """Size categories for NPCs."""
+
+    SMALL = "small"
+    MEDIUM = "medium"
+    LARGE = "large"
+
+
 class NPC_CLASSES(_StrEnum):
     WARRIOR = "warrior"
     MYSTIC = "mystic"
@@ -174,6 +190,8 @@ def flags_to_string(flags: Iterable[_StrEnum]) -> str:
 
 __all__ = [
     "NPC_RACES",
+    "NPC_SEXES",
+    "NPC_SIZES",
     "NPC_CLASSES",
     "ACTFLAGS",
     "AFFECTED_BY",


### PR DESCRIPTION
## Summary
- add `NPC_SEXES` and `NPC_SIZES` enums
- support race, sex, and size in NPC builder menu
- include new fields in prototype summaries
- update mob builder tests for new prompts

## Testing
- `pytest typeclasses/tests/test_mob_builder.py::TestMobBuilder::test_builder_flow_and_spawn -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68481203e934832ca5e0bba2ac4b9c50