### PR TITLE
Improve cnpc builder prompts with running summary

### DIFF
--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -215,6 +215,15 @@ def format_mob_summary(data: dict) -> str:
     return "\n".join(lines)
 
 
+def with_summary(caller, text: str) -> str:
+    """Prepend the current build summary to ``text``."""
+    data = getattr(caller.ndb, "buildnpc", None)
+    if not data:
+        return text
+    summary = format_mob_summary(data)
+    return f"{summary}\n\n{text}"
+
+
 # Menu nodes for NPC creation
 def menunode_key(caller, raw_string="", **kwargs):
     """Prompt for the NPC key."""
@@ -224,7 +233,7 @@ def menunode_key(caller, raw_string="", **kwargs):
         text += f" [default: {default}]"
     text += "\nExample: |wmerchant_01|n"
     options = add_back_skip({"key": "_default", "goto": _set_key}, _set_key)
-    return text, options
+    return with_summary(caller, text), options
 
 
 def _set_key(caller, raw_string, **kwargs):
@@ -250,7 +259,7 @@ def menunode_race(caller, raw_string="", **kwargs):
     if default:
         text += f" [default: {default}]"
     text += "\nExample: |whuman|n"
-    return text, options
+    return with_summary(caller, text), options
 
 
 def _set_race(caller, raw_string, **kwargs):
@@ -282,7 +291,7 @@ def menunode_sex(caller, raw_string="", **kwargs):
     if default:
         text += f" [default: {default}]"
     text += "\nExample: |wmale|n"
-    return text, options
+    return with_summary(caller, text), options
 
 
 def _set_sex(caller, raw_string, **kwargs):
@@ -314,7 +323,7 @@ def menunode_size(caller, raw_string="", **kwargs):
     if default:
         text += f" [default: {default}]"
     text += "\nExample: |wmedium|n"
-    return text, options
+    return with_summary(caller, text), options
 
 
 def _set_size(caller, raw_string, **kwargs):
@@ -347,7 +356,7 @@ def menunode_desc(caller, raw_string="", **kwargs):
         text += f" [default: {default}]"
     text += "\n(back to go back, skip for default)"
     options = add_back_skip({"key": "_default", "goto": _set_desc}, _set_desc)
-    return text, options
+    return with_summary(caller, text), options
 
 
 def _set_desc(caller, raw_string, **kwargs):
@@ -382,7 +391,7 @@ def menunode_vnum(caller, raw_string="", **kwargs):
             return _set_vnum(caller, "auto", **kwargs)
 
         options.insert(0, {"desc": "Auto", "goto": _auto})
-    return text, options
+    return with_summary(caller, text), options
 
 
 def _set_vnum(caller, raw_string, **kwargs):
@@ -427,7 +436,7 @@ def menunode_role(caller, raw_string="", **kwargs):
     if default:
         text += f" [default: {default}]"
     options = add_back_skip({"key": "_default", "goto": _set_role}, _set_role)
-    return text, options
+    return with_summary(caller, text), options
 
 
 def _set_role(caller, raw_string, **kwargs):
@@ -455,7 +464,7 @@ def menunode_guild_affiliation(caller, raw_string="", **kwargs):
     options = add_back_skip(
         {"key": "_default", "goto": _set_guild_affiliation}, _set_guild_affiliation
     )
-    return text, options
+    return with_summary(caller, text), options
 
 
 def _set_guild_affiliation(caller, raw_string, **kwargs):
@@ -483,7 +492,7 @@ def menunode_creature_type(caller, raw_string="", **kwargs):
     options = add_back_skip(
         {"key": "_default", "goto": _set_creature_type}, _set_creature_type
     )
-    return text, options
+    return with_summary(caller, text), options
 
 
 def _set_creature_type(caller, raw_string, **kwargs):
@@ -524,7 +533,7 @@ def menunode_custom_slots(caller, raw_string="", **kwargs):
     options = add_back_skip(
         {"key": "_default", "goto": _edit_custom_slots}, _edit_custom_slots
     )
-    return text, options
+    return with_summary(caller, text), options
 
 
 def _edit_custom_slots(caller, raw_string, **kwargs):
@@ -562,7 +571,7 @@ def menunode_npc_class(caller, raw_string="", **kwargs):
         text += f" [default: {default}]"
     text += "\n(back to go back, skip for default)"
     options = add_back_skip({"key": "_default", "goto": _set_npc_class}, _set_npc_class)
-    return text, options
+    return with_summary(caller, text), options
 
 
 def _set_npc_class(caller, raw_string, **kwargs):
@@ -590,7 +599,7 @@ def menunode_roles(caller, raw_string="", **kwargs):
         "Example: |wadd merchant|n"
     )
     options = add_back_skip({"key": "_default", "goto": _edit_roles}, _edit_roles)
-    return text, options
+    return with_summary(caller, text), options
 
 
 def _edit_roles(caller, raw_string, **kwargs):
@@ -643,7 +652,7 @@ def menunode_merchant_pricing(caller, raw_string="", **kwargs):
     options = add_back_skip(
         {"key": "_default", "goto": _set_merchant_pricing}, _set_merchant_pricing
     )
-    return text, options
+    return with_summary(caller, text), options
 
 
 def _set_merchant_pricing(caller, raw_string, **kwargs):
@@ -672,7 +681,7 @@ def menunode_level(caller, raw_string="", **kwargs):
         """
     )
     options = add_back_skip({"key": "_default", "goto": _set_level}, _set_level)
-    return text, options
+    return with_summary(caller, text), options
 
 
 def _set_level(caller, raw_string, **kwargs):
@@ -710,7 +719,7 @@ def menunode_exp_reward(caller, raw_string="", **kwargs):
     options = add_back_skip(
         {"key": "_default", "goto": _set_exp_reward}, _set_exp_reward
     )
-    return text, options
+    return with_summary(caller, text), options
 
 
 def _set_exp_reward(caller, raw_string, **kwargs):
@@ -743,7 +752,7 @@ def menunode_coin_drop(caller, raw_string="", **kwargs):
     text += "\nExample: |w10 gold 5 silver|n"
     text += "\n(back to go back, skip for default)"
     options = add_back_skip({"key": "_default", "goto": _set_coin_drop}, _set_coin_drop)
-    return text, options
+    return with_summary(caller, text), options
 
 
 def _set_coin_drop(caller, raw_string, **kwargs):
@@ -785,7 +794,7 @@ def menunode_loot_table(caller, raw_string="", **kwargs):
         "Example: |wadd RAW_MEAT 50|n"
     )
     options = add_back_skip({"key": "_default", "goto": _edit_loot_table}, _edit_loot_table)
-    return text, options
+    return with_summary(caller, text), options
 
 
 def _edit_loot_table(caller, raw_string, **kwargs):
@@ -837,7 +846,7 @@ def menunode_resources(caller, raw_string="", **kwargs):
         """
     )
     options = add_back_skip({"key": "_default", "goto": _set_resources}, _set_resources)
-    return text, options
+    return with_summary(caller, text), options
 
 
 def _set_resources(caller, raw_string, **kwargs):
@@ -871,7 +880,7 @@ def menunode_stats(caller, raw_string="", **kwargs):
         """
     )
     options = add_back_skip({"key": "_default", "goto": _set_stats}, _set_stats)
-    return text, options
+    return with_summary(caller, text), options
 
 
 def _set_stats(caller, raw_string, **kwargs):
@@ -903,7 +912,7 @@ def menunode_behavior(caller, raw_string="", **kwargs):
     text += "\nExample: |wSells potions and greets players|n"
     text += "\n(back to go back, skip for default)"
     options = add_back_skip({"key": "_default", "goto": _set_behavior}, _set_behavior)
-    return text, options
+    return with_summary(caller, text), options
 
 
 def _set_behavior(caller, raw_string, **kwargs):
@@ -928,7 +937,7 @@ def menunode_skills(caller, raw_string="", **kwargs):
     text += "\nExample: |wfireball, slash, heal|n"
     text += "\n(back to go back, skip for default)"
     options = add_back_skip({"key": "_default", "goto": _set_skills}, _set_skills)
-    return text, options
+    return with_summary(caller, text), options
 
 
 def _set_skills(caller, raw_string, **kwargs):
@@ -952,7 +961,7 @@ def menunode_spells(caller, raw_string="", **kwargs):
     text += "\nExample: |wfireball, heal|n"
     text += "\n(back to go back, skip for default)"
     options = add_back_skip({"key": "_default", "goto": _set_spells}, _set_spells)
-    return text, options
+    return with_summary(caller, text), options
 
 
 def _set_spells(caller, raw_string, **kwargs):
@@ -980,7 +989,7 @@ def menunode_ai(caller, raw_string="", **kwargs):
     if default:
         text += f" [default: {default}]"
     options = add_back_skip({"key": "_default", "goto": _set_ai}, _set_ai)
-    return text, options
+    return with_summary(caller, text), options
 
 
 def _set_ai(caller, raw_string, **kwargs):
@@ -1008,7 +1017,7 @@ def menunode_actflags(caller, raw_string="", **kwargs):
     text += "\nExample: |wsentinel aggressive assist call_for_help|n"
     text += "\n(back to go back, skip for default)"
     options = add_back_skip({"key": "_default", "goto": _set_actflags}, _set_actflags)
-    return text, options
+    return with_summary(caller, text), options
 
 
 def _set_actflags(caller, raw_string, **kwargs):
@@ -1037,7 +1046,7 @@ def menunode_affects(caller, raw_string="", **kwargs):
     text += "\nExample: |winvisible detect_magic|n"
     text += "\n(back to go back, skip for default)"
     options = add_back_skip({"key": "_default", "goto": _set_affects}, _set_affects)
-    return text, options
+    return with_summary(caller, text), options
 
 
 def _set_affects(caller, raw_string, **kwargs):
@@ -1066,7 +1075,7 @@ def menunode_resists(caller, raw_string="", **kwargs):
     text += "\nExample: |wfire cold energy|n"
     text += "\n(back to go back, skip for default)"
     options = add_back_skip({"key": "_default", "goto": _set_resists}, _set_resists)
-    return text, options
+    return with_summary(caller, text), options
 
 
 def _set_resists(caller, raw_string, **kwargs):
@@ -1095,7 +1104,7 @@ def menunode_bodyparts(caller, raw_string="", **kwargs):
     text += "\nExample: |whead arms legs|n"
     text += "\n(back to go back, skip for default)"
     options = add_back_skip({"key": "_default", "goto": _set_bodyparts}, _set_bodyparts)
-    return text, options
+    return with_summary(caller, text), options
 
 
 def _set_bodyparts(caller, raw_string, **kwargs):
@@ -1124,7 +1133,7 @@ def menunode_attack(caller, raw_string="", **kwargs):
     text += "\nExample: |wbite claw|n"
     text += "\n(back to go back, skip for default)"
     options = add_back_skip({"key": "_default", "goto": _set_attack}, _set_attack)
-    return text, options
+    return with_summary(caller, text), options
 
 
 def _set_attack(caller, raw_string, **kwargs):
@@ -1153,7 +1162,7 @@ def menunode_defense(caller, raw_string="", **kwargs):
     text += "\nExample: |wparry dodge|n"
     text += "\n(back to go back, skip for default)"
     options = add_back_skip({"key": "_default", "goto": _set_defense}, _set_defense)
-    return text, options
+    return with_summary(caller, text), options
 
 
 def _set_defense(caller, raw_string, **kwargs):
@@ -1182,7 +1191,7 @@ def menunode_languages(caller, raw_string="", **kwargs):
     text += "\nExample: |wcommon elvish|n"
     text += "\n(back to go back, skip for default)"
     options = add_back_skip({"key": "_default", "goto": _set_languages}, _set_languages)
-    return text, options
+    return with_summary(caller, text), options
 
 
 def _set_languages(caller, raw_string, **kwargs):
@@ -1208,7 +1217,7 @@ def menunode_script(caller, raw_string="", **kwargs):
         text += f" [default: {default}]"
     text += "\n(back to go back, skip for default)"
     options = add_back_skip({"key": "_default", "goto": _set_script}, _set_script)
-    return text, options
+    return with_summary(caller, text), options
 
 
 def _set_script(caller, raw_string, **kwargs):
@@ -1232,7 +1241,7 @@ def menunode_triggers(caller, raw_string="", **kwargs):
         {"desc": "List triggers", "goto": "menunode_trigger_list"},
         {"desc": "Finish", "goto": "menunode_confirm"},
     ]
-    return text, options
+    return with_summary(caller, text), options
 
 
 def menunode_trigger_list(caller, raw_string="", **kwargs):
@@ -1254,7 +1263,7 @@ def menunode_trigger_list(caller, raw_string="", **kwargs):
     else:
         text += "None\n"
     options = [{"desc": "Back", "goto": "menunode_triggers"}]
-    return text, options
+    return with_summary(caller, text), options
 
 
 def menunode_trigger_add(caller, raw_string="", **kwargs):
@@ -1273,7 +1282,7 @@ def menunode_trigger_add(caller, raw_string="", **kwargs):
         {"desc": "custom", "goto": "menunode_trigger_custom"},
         {"desc": "Back", "goto": "menunode_triggers"},
     ]
-    return text, options
+    return with_summary(caller, text), options
 
 
 def menunode_trigger_custom(caller, raw_string="", **kwargs):
@@ -1282,7 +1291,7 @@ def menunode_trigger_custom(caller, raw_string="", **kwargs):
     options = add_back_skip(
         {"key": "_default", "goto": _set_custom_event}, _set_custom_event
     )
-    return text, options
+    return with_summary(caller, text), options
 
 
 def _set_custom_event(caller, raw_string, **kwargs):
@@ -1303,7 +1312,7 @@ def menunode_trigger_match(caller, raw_string="", **kwargs):
     options = add_back_skip(
         {"key": "_default", "goto": _set_trigger_match}, _set_trigger_match
     )
-    return text, options
+    return with_summary(caller, text), options
 
 
 def _set_trigger_match(caller, raw_string, **kwargs):
@@ -1314,7 +1323,7 @@ def _set_trigger_match(caller, raw_string, **kwargs):
 def menunode_trigger_react(caller, raw_string="", **kwargs):
     text = "|wEnter reaction command(s) (comma or semicolon separated)|n"
     options = add_back_skip({"key": "_default", "goto": _save_trigger}, _save_trigger)
-    return text, options
+    return with_summary(caller, text), options
 
 
 def _save_trigger(caller, raw_string, **kwargs):
@@ -1353,7 +1362,7 @@ def menunode_trigger_delete(caller, raw_string="", **kwargs):
                 {"desc": desc, "goto": (_del_trigger, {"event": event, "index": idx})}
             )
     options.append({"desc": "Back", "goto": "menunode_triggers"})
-    return text, options
+    return with_summary(caller, text), options
 
 
 def _del_trigger(caller, raw_string, event=None, index=None, **kwargs):


### PR DESCRIPTION
## Summary
- add helper to prepend NPC build summary to prompts
- show the summary in every cnpc EvMenu node so builders can review progress while entering data

## Testing
- `pytest typeclasses/tests/test_mob_builder.py::TestMobBuilder.test_summary_contains_sections -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68481ad0d4a8832c8f3714952b368632