### PR TITLE
Update NPC class prompt

### DIFF
--- a/commands/README.md
+++ b/commands/README.md
@@ -70,7 +70,7 @@ NPCs are saved as prototypes in `world/prototypes/npcs.json` and can be
 spawned later with `@spawnnpc`. These commands help you manage the prototypes:
 
 *A role describes what the NPC does (merchant, questgiver...),*
-*while the class determines combat style (warrior, wizard...).*
+*while the class selects the NPC typeclass (base, merchant, banker...).*
 
 * `@mcreate <key> [copy_key]` – make a new prototype, optionally copying an
   existing one.

--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -566,7 +566,8 @@ def _edit_custom_slots(caller, raw_string, **kwargs):
 def menunode_npc_class(caller, raw_string="", **kwargs):
     default = caller.ndb.buildnpc.get("npc_class", "base")
     classes = "/".join(NPC_CLASS_MAP)
-    text = f"|wClass (warrior, wizard...)|n ({classes})"
+    example = ", ".join(list(NPC_CLASS_MAP)[:3])
+    text = f"|wNPC class ({example}...)|n ({classes})"
     if default:
         text += f" [default: {default}]"
     text += "\n(back to go back, skip for default)"


### PR DESCRIPTION
## Summary
- update NPC class prompt in the builder
- update docs to show valid NPC classes

## Testing
- `pytest -q` *(fails: django.db.utils.OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68481e8c740c832ca1a9a9919be53b10