### PR TITLE
Update npc builder area registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,8 @@ duplicates one, `@deletenpc <npc>` removes it (with confirmation) and
 `@spawnnpc <proto>` spawns a saved prototype from `world/prototypes/npcs.json`.
 You can organize prototypes by area with `@listnpcs <area>`, spawn them with
 `@spawnnpc <area>/<proto>` and duplicate them using
-`@dupnpc <area>/<proto> [= <new_key>]`.
+`@dupnpc <area>/<proto> [= <new_key>]`. Saving a prototype while standing in a
+room that has an `area` set automatically adds it to that area's list.
 
 Several basic NPC prototypes are included out of the box. Try `cnpc dev_spawn basic_merchant`
 or `@spawnnpc basic_merchant` to quickly create a merchant, or `basic_questgiver` for a quest

--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -1548,6 +1548,10 @@ def _create_npc(caller, raw_string, register=False, **kwargs):
         if data.get("script"):
             proto["scripts"] = [data["script"]]
         prototypes.register_npc_prototype(proto_key, proto)
+        area = caller.location.db.area
+        if area:
+            from world import area_npcs
+            area_npcs.add_area_npc(area, proto_key)
         caller.msg(f"NPC {npc.key} created and prototype saved.")
     else:
         caller.msg(f"NPC {npc.key} created.")

--- a/typeclasses/tests/test_cnpc.py
+++ b/typeclasses/tests/test_cnpc.py
@@ -79,13 +79,16 @@ class TestCNPC(EvenniaTest):
         npc_builder._set_behavior(self.char1, "dumb")
         npc_builder._set_skills(self.char1, "smash")
         npc_builder._set_ai(self.char1, "defensive")
+        self.char1.location.db.area = "town"
         npc_builder._create_npc(self.char1, "", register=True)
 
         from world.prototypes import get_npc_prototypes
+        from world import area_npcs
 
         registry = get_npc_prototypes()
         self.assertIn("ogre", registry)
         self.assertEqual(registry["ogre"]["desc"], "A big ogre")
+        self.assertIn("ogre", area_npcs.get_area_npc_list("town"))
 
     def test_triggers_and_reactions(self):
         with patch("commands.npc_builder.EvMenu"):

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -2875,7 +2875,8 @@ Related:
         "category": "Building",
         "text": """Help for @listnpcs
 
-List NPC prototypes assigned to an area.
+List NPC prototypes assigned to an area. Prototypes saved with |wcnpc|n while
+standing in a room belonging to that area are added automatically.
 
 Usage:
     @listnpcs <area>


### PR DESCRIPTION
## Summary
- register new NPC prototypes for the area's list
- document automatic area registration
- mention automatic registration in help text
- extend tests for prototype registration

## Testing
- `pytest -q` *(fails: django.db.utils.OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68482b40ae40832c8f9b516c3ecbd105