### PR TITLE
Clarify NPC creation options

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,9 +210,9 @@ giver.
 
 A prototype is a JSON record stored in `world/prototypes/npcs.json` describing
 all of an NPC's settings such as stats, roles, triggers and AI. When you finish
-the builder and choose **Yes & Save Prototype**, these details are written to
-that file so you can recreate the NPC later. The same step also spawns the NPC
-immediately.
+the builder, selecting **Yes** spawns the NPC in your current location.
+Choosing **Yes & Save Prototype** spawns the NPC and writes the prototype to
+that file so you can recreate it later.
 
 You can spawn a saved prototype at any time with `@spawnnpc <key>`. Prototypes
 made with `mobbuilder` are automatically given the `mob_` prefix. Use

--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -1416,7 +1416,11 @@ def menunode_confirm(caller, raw_string="", **kwargs):
             {"desc": "Confirm", "goto": (_create_npc, {"register": False})},
         ]
     else:
-        text += "\nCreate this NPC?"
+        text += (
+            "\nCreate this NPC?\n"
+            "Selecting |wYes|n spawns the NPC in your current location.\n"
+            "Selecting |wYes & Save Prototype|n spawns the NPC and saves the prototype for later use."
+        )
         options = [
             {"desc": "Yes", "goto": (_create_npc, {"register": False})},
             {"desc": "Yes & Save Prototype", "goto": (_create_npc, {"register": True})},

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -2696,6 +2696,9 @@ Notes:
       shown in each example.
     - After reviewing the summary choose |wYes|n to confirm and create or
       update the NPC.
+    - Selecting |wYes|n spawns the NPC in your current location. Choosing
+      |wYes & Save Prototype|n spawns the NPC and saves the prototype for
+      later use.
     - Use |wcnpc edit <npc>|n to modify an existing NPC.
     - At the triggers step you will see a menu to add, delete or list
       automatic reactions. Example:


### PR DESCRIPTION
## Summary
- clarify that 'Yes' spawns the NPC only and 'Yes & Save Prototype' also saves it
- document these choices in README and help file

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684830f418b4832cb299b67c16f1fcc7