### PR TITLE
Improve hunger drain percentage

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,12 @@ stats or restrict actions. Use the `affects` command or `status` to view
 your current buffs and conditions. Effects expire automatically when
 their duration reaches zero.
 
+### Hunger & Thirst
+
+If a character's `sated` value reaches zero they gain the `hungry_thirsty`
+status effect. Each tick removes 5% of their maximum health, mana and stamina
+while this status is active, rather than a single point from each resource.
+
 ### AI Settings
 
 NPC behavior is configured by an AI type during `cnpc` or `mobbuilder`.

--- a/typeclasses/tests/test_state_manager.py
+++ b/typeclasses/tests/test_state_manager.py
@@ -53,9 +53,10 @@ class TestStateManager(EvenniaTest):
         state_manager.tick_character(char)
         self.assertEqual(char.db.sated, 0)
         self.assertTrue(char.tags.has("hungry_thirsty", category="status"))
-        self.assertEqual(char.traits.health.current, hp - 1)
-        self.assertEqual(char.traits.mana.current, mp - 1)
-        self.assertEqual(char.traits.stamina.current, sp - 1)
+        loss = int(round(char.traits.health.max * 0.05))
+        self.assertEqual(char.traits.health.current, hp - loss)
+        self.assertEqual(char.traits.mana.current, mp - loss)
+        self.assertEqual(char.traits.stamina.current, sp - loss)
 
     def test_hunger_ticks_reduce_sated(self):
         char = self.char1
@@ -69,9 +70,10 @@ class TestStateManager(EvenniaTest):
         state_manager.tick_character(char)
         self.assertEqual(char.db.sated, 0)
         self.assertTrue(char.tags.has("hungry_thirsty", category="status"))
-        self.assertEqual(char.traits.health.current, hp - 1)
-        self.assertEqual(char.traits.mana.current, mp - 1)
-        self.assertEqual(char.traits.stamina.current, sp - 1)
+        loss = int(round(char.traits.health.max * 0.05))
+        self.assertEqual(char.traits.health.current, hp - loss)
+        self.assertEqual(char.traits.mana.current, mp - loss)
+        self.assertEqual(char.traits.stamina.current, sp - loss)
 
     def test_hunger_cap(self):
         char = self.char1
@@ -96,9 +98,10 @@ class TestStateManager(EvenniaTest):
         mp = char.traits.mana.current
         sp = char.traits.stamina.current
         state_manager.tick_character(char)
-        self.assertEqual(char.traits.health.current, hp - 1)
-        self.assertEqual(char.traits.mana.current, mp - 1)
-        self.assertEqual(char.traits.stamina.current, sp - 1)
+        loss = int(round(char.traits.health.max * 0.05))
+        self.assertEqual(char.traits.health.current, hp - loss)
+        self.assertEqual(char.traits.mana.current, mp - loss)
+        self.assertEqual(char.traits.stamina.current, sp - loss)
 
     def test_apply_regen_uses_derived_stats(self):
         char = self.char1

--- a/world/system/state_manager.py
+++ b/world/system/state_manager.py
@@ -267,11 +267,13 @@ def tick_character(chara):
         if chara.db.sated <= 0:
             chara.db.sated = 0
             add_effect(chara, "hungry_thirsty", 1)
-            if (hp := chara.traits.get("health")):
-                hp.current = max(hp.current - 1, 0)
-            for res in ("mana", "stamina"):
-                if (trait := chara.traits.get(res)):
-                    trait.current = max(trait.current - 1, 0)
+            drain_pct = 5  # percent of each resource to lose
+            for key in ("health", "mana", "stamina"):
+                if not (trait := chara.traits.get(key)):
+                    continue
+                max_val = trait.max or trait.current
+                loss = max(1, int(round(max_val * drain_pct / 100)))
+                trait.current = max(trait.current - loss, 0)
 
 
 def tick_all():


### PR DESCRIPTION
## Summary
- hunger effect now drains 5% of each resource
- update tests for percentage drain
- document hunger drain mechanic

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684834312dc8832cb8b3d67aaf2eacbf