### PR TITLE
Add 'Next' option for NPC class menu

### DIFF
--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -7,7 +7,7 @@ from utils.mob_proto import spawn_from_vnum
 from evennia.prototypes.prototypes import PROTOTYPE_TAG_CATEGORY
 from typeclasses.characters import NPC
 from utils.slots import SLOT_ORDER
-from utils.menu_utils import add_back_skip
+from utils.menu_utils import add_back_skip, add_back_next
 from utils import vnum_registry
 from .command import Command
 from django.conf import settings
@@ -570,8 +570,8 @@ def menunode_npc_class(caller, raw_string="", **kwargs):
     text = f"|wNPC class ({example}...)|n ({classes})"
     if default:
         text += f" [default: {default}]"
-    text += "\n(back to go back, skip for default)"
-    options = add_back_skip({"key": "_default", "goto": _set_npc_class}, _set_npc_class)
+    text += "\n(back to go back, next for default)"
+    options = add_back_next({"key": "_default", "goto": _set_npc_class}, _set_npc_class)
     return with_summary(caller, text), options
 
 
@@ -579,7 +579,7 @@ def _set_npc_class(caller, raw_string, **kwargs):
     string = raw_string.strip().lower()
     if string == "back":
         return "menunode_role"
-    if not string or string == "skip":
+    if not string or string in ("skip", "next"):
         string = caller.ndb.buildnpc.get("npc_class", "base")
     if string not in NPC_CLASS_MAP:
         caller.msg(f"Invalid class. Choose from: {', '.join(NPC_CLASS_MAP)}")

--- a/typeclasses/tests/test_mob_builder.py
+++ b/typeclasses/tests/test_mob_builder.py
@@ -147,6 +147,14 @@ class TestMobBuilder(EvenniaTest):
         assert self.char1.ndb.buildnpc["vnum"] == 5
         assert result == "menunode_creature_type"
 
+    def test_npc_class_menu_shows_next(self):
+        """menunode_npc_class should offer a Next option."""
+        self.char1.ndb.buildnpc = {}
+        _text, opts = npc_builder.menunode_npc_class(self.char1)
+        labels = [o.get("desc") or o.get("key") for o in opts]
+        assert "Next" in labels
+        assert "Skip" not in labels
+
     def test_skills_menu_shows_suggestions(self):
         """menunode_skills should list suggested skills for the class."""
         self.char1.ndb.buildnpc = {"npc_class": "combat_trainer"}

--- a/utils/menu_utils.py
+++ b/utils/menu_utils.py
@@ -30,3 +30,27 @@ def add_back_skip(options: Union[Dict[str, Any], Iterable[Dict[str, Any]], None]
     opts.append({"desc": "Back", "goto": _run("back")})
     opts.append({"desc": "Skip", "goto": _run("skip")})
     return opts
+
+
+def add_back_next(
+    options: Union[Dict[str, Any], Iterable[Dict[str, Any]], None], setter: Callable
+) -> List[Dict[str, Any]]:
+    """Return ``options`` with standard Back/Next entries."""
+
+    opts: List[Dict[str, Any]]
+    if options is None:
+        opts = []
+    elif isinstance(options, dict):
+        opts = [options]
+    else:
+        opts = list(options)
+
+    def _run(value: str):
+        def _inner(caller, raw_string=None, **kwargs):
+            return setter(caller, value, **kwargs)
+
+        return _inner
+
+    opts.append({"desc": "Back", "goto": _run("back")})
+    opts.append({"desc": "Next", "goto": _run("skip")})
+    return opts


### PR DESCRIPTION
## Summary
- add `add_back_next` helper for menu options
- use new helper in NPC class menu and support 'next' synonym
- verify `Next` appears in NPC class menu test

## Testing
- `pytest -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68483987971c832c92dcf3ca41deff5b