### PR TITLE
Add combat class selection to NPC builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ classes include `BaseNPC`, `MerchantNPC`, `BankerNPC`, `TrainerNPC`,
 `WandererNPC`, `GuildmasterNPC`, `GuildReceptionistNPC`,
 `QuestGiverNPC`, `CombatTrainerNPC` and `EventNPC` defined under
 `typeclasses.npcs`.
+After choosing the NPC class you can also assign a combat class from
+`world.scripts.classes`. This sets `npc.db.charclass` on the spawned NPC.
 
 While editing, there's a step to manage triggers using a numbered menu. Choose
 `Add trigger` to create a new reaction, `Delete trigger` to remove one, `List

--- a/commands/README.md
+++ b/commands/README.md
@@ -71,6 +71,8 @@ spawned later with `@spawnnpc`. These commands help you manage the prototypes:
 
 *A role describes what the NPC does (merchant, questgiver...),*
 *while the class selects the NPC typeclass (base, merchant, banker...).*
+*After picking the NPC class, the mob builder also lets you choose a*
+*combat class like Warrior or Mage which sets `npc.db.charclass`.*
 
 * `@mcreate <key> [copy_key]` – make a new prototype, optionally copying an
   existing one.

--- a/typeclasses/tests/test_mob_builder.py
+++ b/typeclasses/tests/test_mob_builder.py
@@ -48,6 +48,7 @@ class TestMobBuilder(EvenniaTest):
         npc_builder._set_creature_type(self.char1, "humanoid")
         npc_builder._set_role(self.char1, "")
         npc_builder._set_npc_class(self.char1, "base")
+        npc_builder._set_combat_class(self.char1, "Warrior")
         npc_builder._edit_roles(self.char1, "done")
         npc_builder._set_level(self.char1, "1")
         npc_builder._set_exp_reward(self.char1, "5")
@@ -77,6 +78,7 @@ class TestMobBuilder(EvenniaTest):
         npc = self._find("goblin")
         assert npc is not None
         assert npc.is_typeclass(BaseNPC, exact=False)
+        assert npc.db.charclass == "Warrior"
 
         self.char1.execute_cmd("@mstat mob_goblin")
         out = self.char1.msg.call_args[0][0]
@@ -151,6 +153,14 @@ class TestMobBuilder(EvenniaTest):
         """menunode_npc_class should offer a Next option."""
         self.char1.ndb.buildnpc = {}
         _text, opts = npc_builder.menunode_npc_class(self.char1)
+        labels = [o.get("desc") or o.get("key") for o in opts]
+        assert "Next" in labels
+        assert "Skip" not in labels
+
+    def test_combat_class_menu_shows_next(self):
+        """menunode_combat_class should offer a Next option."""
+        self.char1.ndb.buildnpc = {}
+        _text, opts = npc_builder.menunode_combat_class(self.char1)
         labels = [o.get("desc") or o.get("key") for o in opts]
         assert "Next" in labels
         assert "Skip" not in labels

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -2681,9 +2681,11 @@ Notes:
     - NPC classes include base, merchant, banker, trainer, wanderer,
       guildmaster, guild_receptionist, questgiver, combat_trainer and
       event_npc.
+    - After choosing the NPC class you may select a combat class like
+      Warrior or Mage.
     - The builder prompts for description, role, creature type, level,
-      experience reward, HP MP SP, primary stats, behavior, skills, spells,
-      resistances and AI type.
+      experience reward, HP MP SP, primary stats, combat class, behavior,
+      skills, spells, resistances and AI type.
     - Mob specific fields such as act flags, resistances, skills and spells can
       now be configured directly in this menu along with an optional Script
       typeclass to run when the mob spawns.


### PR DESCRIPTION
## Summary
- add combat class step to NPC builder and store on npc.db.charclass
- show combat class in mob summary and help
- document combat classes in README and help entries
- extend mob builder tests for combat class selection

## Testing
- `pytest -q` *(fails: no such table accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68483b0549bc832cb13a9454ee6b0eb0