### PR TITLE
Add combat class selection to NPC builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ classes include `BaseNPC`, `MerchantNPC`, `BankerNPC`, `TrainerNPC`,
 `WandererNPC`, `GuildmasterNPC`, `GuildReceptionistNPC`,
 `QuestGiverNPC`, `CombatTrainerNPC` and `EventNPC` defined under
 `typeclasses.npcs`.
+After choosing the NPC class you can also assign a combat class from
+`world.scripts.classes`. This sets `npc.db.charclass` on the spawned NPC.
 
 While editing, there's a step to manage triggers using a numbered menu. Choose
 `Add trigger` to create a new reaction, `Delete trigger` to remove one, `List

--- a/commands/README.md
+++ b/commands/README.md
@@ -71,6 +71,8 @@ spawned later with `@spawnnpc`. These commands help you manage the prototypes:
 
 *A role describes what the NPC does (merchant, questgiver...),*
 *while the class selects the NPC typeclass (base, merchant, banker...).*
+*After picking the NPC class, the mob builder also lets you choose a*
+*combat class like Warrior or Mage which sets `npc.db.charclass`.*
 
 * `@mcreate <key> [copy_key]` – make a new prototype, optionally copying an
   existing one.

--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -8,6 +8,7 @@ from evennia.prototypes.prototypes import PROTOTYPE_TAG_CATEGORY
 from typeclasses.characters import NPC
 from utils.slots import SLOT_ORDER
 from utils.menu_utils import add_back_skip, add_back_next
+from world.scripts import classes
 from utils import vnum_registry
 from .command import Command
 from django.conf import settings
@@ -152,6 +153,8 @@ def format_mob_summary(data: dict) -> str:
     if "vnum" in data:
         basic.add_row("|cVNUM|n", fmt(data.get("vnum")))
     basic.add_row("|cClass|n", fmt(data.get("npc_class")))
+    if data.get("combat_class"):
+        basic.add_row("|cCombat Class|n", fmt(data.get("combat_class")))
     if data.get("race"):
         basic.add_row("|cRace|n", fmt(data.get("race")))
     if data.get("sex"):
@@ -530,7 +533,7 @@ def menunode_custom_slots(caller, raw_string="", **kwargs):
         "  back - previous step\n"
         "Example: |wadd tail|n"
     )
-    options = add_back_skip(
+    options = add_back_next(
         {"key": "_default", "goto": _edit_custom_slots}, _edit_custom_slots
     )
     return with_summary(caller, text), options
@@ -586,6 +589,40 @@ def _set_npc_class(caller, raw_string, **kwargs):
         return "menunode_npc_class"
     caller.ndb.buildnpc["npc_class"] = string
 
+    return "menunode_combat_class"
+
+
+def menunode_combat_class(caller, raw_string="", **kwargs):
+    default = caller.ndb.buildnpc.get("combat_class", "")
+    names = ", ".join(entry["name"] for entry in classes.CLASS_LIST)
+    text = f"|wCombat class|n ({names})"
+    if default:
+        text += f" [default: {default}]"
+    text += "\nExample: |wWarrior|n"
+    text += "\n(back to go back, next for default)"
+    options = add_back_next({"key": "_default", "goto": _set_combat_class}, _set_combat_class)
+    return with_summary(caller, text), options
+
+
+def _set_combat_class(caller, raw_string, **kwargs):
+    string = raw_string.strip()
+    if string.lower() == "back":
+        return "menunode_npc_class"
+    if not string or string.lower() in ("skip", "next"):
+        string = caller.ndb.buildnpc.get("combat_class", "")
+    else:
+        names = [entry["name"].lower() for entry in classes.CLASS_LIST]
+        if string.lower() not in names:
+            caller.msg(
+                "Invalid class. Choose from: "
+                + ", ".join(entry["name"] for entry in classes.CLASS_LIST)
+            )
+            return "menunode_combat_class"
+        for entry in classes.CLASS_LIST:
+            if entry["name"].lower() == string.lower():
+                string = entry["name"]
+                break
+    caller.ndb.buildnpc["combat_class"] = string
     return "menunode_roles"
 
 
@@ -1448,6 +1485,8 @@ def _create_npc(caller, raw_string, register=False, **kwargs):
     npc.db.race = data.get("race")
     npc.db.sex = data.get("sex")
     npc.db.size = data.get("size")
+    if cc := data.get("combat_class"):
+        npc.db.charclass = cc
     if vnum := data.get("vnum"):
         npc.db.vnum = vnum
         npc.tags.add(f"M{vnum}", category="vnum")
@@ -1589,6 +1628,7 @@ def _gather_npc_data(npc):
             (k for k, path in NPC_CLASS_MAP.items() if path == npc.typeclass_path),
             "base",
         ),
+        "combat_class": npc.db.charclass or "",
         "creature_type": npc.db.creature_type or "humanoid",
         "equipment_slots": npc.db.equipment_slots or list(SLOT_ORDER),
         "level": npc.db.level or 1,
@@ -1647,6 +1687,7 @@ class CmdCNPC(Command):
                 "size": "",
                 "triggers": {},
                 "npc_class": "base",
+                "combat_class": "",
                 "roles": [],
                 "skills": [],
                 "spells": [],

--- a/typeclasses/tests/test_mob_builder.py
+++ b/typeclasses/tests/test_mob_builder.py
@@ -48,6 +48,7 @@ class TestMobBuilder(EvenniaTest):
         npc_builder._set_creature_type(self.char1, "humanoid")
         npc_builder._set_role(self.char1, "")
         npc_builder._set_npc_class(self.char1, "base")
+        npc_builder._set_combat_class(self.char1, "Warrior")
         npc_builder._edit_roles(self.char1, "done")
         npc_builder._set_level(self.char1, "1")
         npc_builder._set_exp_reward(self.char1, "5")
@@ -77,6 +78,7 @@ class TestMobBuilder(EvenniaTest):
         npc = self._find("goblin")
         assert npc is not None
         assert npc.is_typeclass(BaseNPC, exact=False)
+        assert npc.db.charclass == "Warrior"
 
         self.char1.execute_cmd("@mstat mob_goblin")
         out = self.char1.msg.call_args[0][0]
@@ -151,6 +153,14 @@ class TestMobBuilder(EvenniaTest):
         """menunode_npc_class should offer a Next option."""
         self.char1.ndb.buildnpc = {}
         _text, opts = npc_builder.menunode_npc_class(self.char1)
+        labels = [o.get("desc") or o.get("key") for o in opts]
+        assert "Next" in labels
+        assert "Skip" not in labels
+
+    def test_combat_class_menu_shows_next(self):
+        """menunode_combat_class should offer a Next option."""
+        self.char1.ndb.buildnpc = {}
+        _text, opts = npc_builder.menunode_combat_class(self.char1)
         labels = [o.get("desc") or o.get("key") for o in opts]
         assert "Next" in labels
         assert "Skip" not in labels

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -2681,9 +2681,11 @@ Notes:
     - NPC classes include base, merchant, banker, trainer, wanderer,
       guildmaster, guild_receptionist, questgiver, combat_trainer and
       event_npc.
+    - After choosing the NPC class you may select a combat class like
+      Warrior or Mage.
     - The builder prompts for description, role, creature type, level,
-      experience reward, HP MP SP, primary stats, behavior, skills, spells,
-      resistances and AI type.
+      experience reward, HP MP SP, primary stats, combat class, behavior,
+      skills, spells, resistances and AI type.
     - Mob specific fields such as act flags, resistances, skills and spells can
       now be configured directly in this menu along with an optional Script
       typeclass to run when the mob spawns.


### PR DESCRIPTION
## Summary
- add combat class step to NPC builder and store on npc.db.charclass
- show combat class in mob summary and help
- document combat classes in README and help entries
- extend mob builder tests for combat class selection
- fix equipment slot menu to show "Next" instead of "Skip"

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68483b0549bc832cb13a9454ee6b0eb0