### PR TITLE
Add test for custom slot menu

### DIFF
--- a/typeclasses/tests/test_mob_builder.py
+++ b/typeclasses/tests/test_mob_builder.py
@@ -165,6 +165,14 @@ class TestMobBuilder(EvenniaTest):
         assert "Next" in labels
         assert "Skip" not in labels
 
+    def test_custom_slots_menu_shows_next(self):
+        """menunode_custom_slots should offer a Next option."""
+        self.char1.ndb.buildnpc = {}
+        _text, opts = npc_builder.menunode_custom_slots(self.char1)
+        labels = [o.get("desc") or o.get("key") for o in opts]
+        assert "Next" in labels
+        assert "Skip" not in labels
+
     def test_skills_menu_shows_suggestions(self):
         """menunode_skills should list suggested skills for the class."""
         self.char1.ndb.buildnpc = {"npc_class": "combat_trainer"}


### PR DESCRIPTION
## Summary
- test that the custom equipment slots menu offers a `Next` option

## Testing
- `evennia migrate`
- `pytest -q typeclasses/tests/test_mob_builder.py::TestMobBuilder::test_custom_slots_menu_shows_next`


------
https://chatgpt.com/codex/tasks/task_e_68484079a6c8832cb5d52e69102b9195