### PR TITLE
Register vnum NPC prototypes in mob DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,8 @@ Choosing **Yes & Save Prototype** will also store the entry in
 `world/prototypes/npcs.json` with the `mob_` prefix so you can reuse it with
 `@mspawn <prototype>` or ``M<number>``. The final summary now shows any mob
 specific fields such as act flags and resistances.
+If you assign a VNUM when saving, the prototype is automatically registered
+for use with ``@mspawn M<number>``.
 
 Example::
 

--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -277,7 +277,9 @@ def _set_race(caller, raw_string, **kwargs):
         try:
             NPC_RACES.from_str(string)
         except ValueError:
-            caller.msg(f"Invalid race. Choose from: {', '.join(r.value for r in NPC_RACES)}")
+            caller.msg(
+                f"Invalid race. Choose from: {', '.join(r.value for r in NPC_RACES)}"
+            )
             return "menunode_race"
     caller.ndb.buildnpc["race"] = string
     return "menunode_sex"
@@ -309,7 +311,9 @@ def _set_sex(caller, raw_string, **kwargs):
         try:
             NPC_SEXES.from_str(string)
         except ValueError:
-            caller.msg(f"Invalid sex. Choose from: {', '.join(s.value for s in NPC_SEXES)}")
+            caller.msg(
+                f"Invalid sex. Choose from: {', '.join(s.value for s in NPC_SEXES)}"
+            )
             return "menunode_sex"
     caller.ndb.buildnpc["sex"] = string
     return "menunode_size"
@@ -341,7 +345,9 @@ def _set_size(caller, raw_string, **kwargs):
         try:
             NPC_SIZES.from_str(string)
         except ValueError:
-            caller.msg(f"Invalid size. Choose from: {', '.join(s.value for s in NPC_SIZES)}")
+            caller.msg(
+                f"Invalid size. Choose from: {', '.join(s.value for s in NPC_SIZES)}"
+            )
             return "menunode_size"
     caller.ndb.buildnpc["size"] = string
     return "menunode_desc"
@@ -600,7 +606,9 @@ def menunode_combat_class(caller, raw_string="", **kwargs):
         text += f" [default: {default}]"
     text += "\nExample: |wWarrior|n"
     text += "\n(back to go back, next for default)"
-    options = add_back_next({"key": "_default", "goto": _set_combat_class}, _set_combat_class)
+    options = add_back_next(
+        {"key": "_default", "goto": _set_combat_class}, _set_combat_class
+    )
     return with_summary(caller, text), options
 
 
@@ -831,7 +839,9 @@ def menunode_loot_table(caller, raw_string="", **kwargs):
         "Commands:\n  add <proto> [chance]\n  remove <proto>\n  done - finish\n  back - previous step\n"
         "Example: |wadd RAW_MEAT 50|n"
     )
-    options = add_back_skip({"key": "_default", "goto": _edit_loot_table}, _edit_loot_table)
+    options = add_back_skip(
+        {"key": "_default", "goto": _edit_loot_table}, _edit_loot_table
+    )
     return with_summary(caller, text), options
 
 
@@ -1591,9 +1601,14 @@ def _create_npc(caller, raw_string, register=False, **kwargs):
         if data.get("script"):
             proto["scripts"] = [data["script"]]
         prototypes.register_npc_prototype(proto_key, proto)
+        if data.get("vnum") is not None:
+            from world.scripts.mob_db import get_mobdb
+
+            get_mobdb().add_proto(data["vnum"], proto)
         area = caller.location.db.area
         if area:
             from world import area_npcs
+
             area_npcs.add_area_npc(area, proto_key)
         caller.msg(f"NPC {npc.key} created and prototype saved.")
     else:

--- a/typeclasses/tests/test_vnum_mobs.py
+++ b/typeclasses/tests/test_vnum_mobs.py
@@ -134,3 +134,28 @@ class TestVnumMobs(EvenniaTest):
 
         registry = prototypes.get_npc_prototypes()
         self.assertEqual(registry["ogre"]["vnum"], 12)
+
+    def test_builder_registers_vnum_for_mspawn(self):
+        """NPCs built with a VNUM should be spawnable via @mspawn M<number>."""
+        vnum = 22
+        self.char1.ndb.buildnpc = {
+            "key": "bugbear",
+            "npc_class": "base",
+            "vnum": vnum,
+            "creature_type": "humanoid",
+        }
+        npc_builder._create_npc(self.char1, "", register=True)
+
+        mob_db = get_mobdb()
+        self.assertIsNotNone(mob_db.get_proto(vnum))
+
+        self.char1.msg.reset_mock()
+        self.char1.execute_cmd(f"@mspawn M{vnum}")
+        msg = self.char1.msg.call_args[0][0]
+        self.assertIn("Spawned", msg)
+        npcs = [
+            o
+            for o in self.char1.location.contents
+            if o.is_typeclass(BaseNPC, exact=False)
+        ]
+        self.assertGreaterEqual(len(npcs), 2)

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -3042,6 +3042,8 @@ Notes:
     - ``M<number>`` spawns a prototype by its VNUM.
     - NPCs spawned this way are tagged ``M<number>`` for easy lookup
       with ``search_tag``.
+    - Saving a prototype with a VNUM automatically registers it for
+      ``@mspawn M<number>``.
 """,
     },
     {


### PR DESCRIPTION
## Summary
- store vnum NPC prototypes in the mob database when saving through the builder
- test that vnum prototypes are registered and spawnable with `@mspawn M<number>`
- document vnum auto-registration in README and help file

## Testing
- `pytest -q` *(fails: OperationalError no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684842b5518c832cb44efab327f12127