### PR TITLE
Require NPC builder fields

### DIFF
--- a/typeclasses/tests/test_mob_builder.py
+++ b/typeclasses/tests/test_mob_builder.py
@@ -203,20 +203,29 @@ class TestMobBuilder(EvenniaTest):
         assert "gold" in out
         assert "RAW_MEAT" in out
 
-    def test_confirm_fills_missing_fields(self):
-        self.char1.ndb.buildnpc = {"key": "orc"}
-        with patch("utils.vnum_registry.get_next_vnum", return_value=99):
-            text, opts = npc_builder.menunode_confirm(self.char1)
-        data = self.char1.ndb.buildnpc
-        assert data["desc"] == "Orc"
-        assert data["level"] == 1
-        assert data["vnum"] == 99
-        labels = [o.get("desc") or o.get("key") for o in opts]
-        assert "Confirm" in labels
-        assert "Back" in labels
+    def test_confirm_requires_missing_fields(self):
+        self.char1.msg = MagicMock()
+        self.char1.ndb.buildnpc = {
+            "key": "orc",
+            "level": 1,
+            "vnum": 5,
+            "creature_type": "humanoid",
+            "role": "merchant",
+        }
+        result = npc_builder.menunode_confirm(self.char1)
+        self.assertEqual(result, "menunode_desc")
+        msg = self.char1.msg.call_args[0][0]
+        self.assertIn("Description is required", msg)
 
     def test_confirm_full_data_options(self):
-        self.char1.ndb.buildnpc = {"key": "orc", "desc": "mean orc", "level": 2, "vnum": 7}
+        self.char1.ndb.buildnpc = {
+            "key": "orc",
+            "desc": "mean orc",
+            "level": 2,
+            "vnum": 7,
+            "creature_type": "humanoid",
+            "role": "merchant",
+        }
         text, opts = npc_builder.menunode_confirm(self.char1)
         labels = [o.get("desc") or o.get("key") for o in opts]
         assert set(labels) == {"Yes", "Yes & Save Prototype", "No"}

--- a/utils/menu_utils.py
+++ b/utils/menu_utils.py
@@ -32,6 +32,38 @@ def add_back_skip(options: Union[Dict[str, Any], Iterable[Dict[str, Any]], None]
     return opts
 
 
+def add_back_only(
+    options: Union[Dict[str, Any], Iterable[Dict[str, Any]], None], setter: Callable
+) -> List[Dict[str, Any]]:
+    """Return ``options`` with only a Back entry.
+
+    Parameters
+    ----------
+    options
+        Base option or list of options for the menu node.
+    setter
+        Callback to execute for the back selection. It will be called
+        with ``raw_string`` set to ``"back"``.
+    """
+
+    opts: List[Dict[str, Any]]
+    if options is None:
+        opts = []
+    elif isinstance(options, dict):
+        opts = [options]
+    else:
+        opts = list(options)
+
+    def _run(value: str):
+        def _inner(caller, raw_string=None, **kwargs):
+            return setter(caller, value, **kwargs)
+
+        return _inner
+
+    opts.append({"desc": "Back", "goto": _run("back")})
+    return opts
+
+
 def add_back_next(
     options: Union[Dict[str, Any], Iterable[Dict[str, Any]], None], setter: Callable
 ) -> List[Dict[str, Any]]:

--- a/utils/tests/test_menu_utils.py
+++ b/utils/tests/test_menu_utils.py
@@ -1,5 +1,5 @@
 from evennia.utils.test_resources import EvenniaTest
-from utils.menu_utils import add_back_skip
+from utils.menu_utils import add_back_skip, add_back_only
 
 
 class TestMenuUtils(EvenniaTest):
@@ -14,6 +14,16 @@ class TestMenuUtils(EvenniaTest):
         self.assertEqual(opts[2]["desc"], "Skip")
         self.assertEqual(opts[1]["goto"](self.char1, ""), "back")
         self.assertEqual(opts[2]["goto"](self.char1, ""), "skip")
+
+    def test_add_back_only(self):
+        def handler(caller, raw_string, **kwargs):
+            return raw_string
+
+        opts = add_back_only({"key": "_default", "goto": handler}, handler)
+        self.assertEqual(len(opts), 2)
+        self.assertEqual(opts[0]["key"], "_default")
+        self.assertEqual(opts[1]["desc"], "Back")
+        self.assertEqual(opts[1]["goto"](self.char1, ""), "back")
 
     def test_add_back_skip_from_list(self):
         def handler(caller, raw_string, **kwargs):

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -2692,7 +2692,7 @@ Notes:
     - Humanoid body type grants the standard equipment slots automatically.
       Quadrupeds receive head, body, front_legs and hind_legs and lack weapon
       slots. Unique lets you add or remove any slots in the next step.
-    - Prompts accept |wback|n to return or |wskip|n to keep defaults.
+    - Prompts accept |wback|n to return to the previous step.
     - The skills prompt lists suggested abilities for the chosen class.
     - When multiple values are allowed, use comma or space separated lists as
       shown in each example.


### PR DESCRIPTION
## Summary
- add add_back_only helper for EvMenu nodes
- use add_back_only for mandatory NPC builder steps
- validate required fields in `menunode_confirm`
- update help entry regarding skip option
- adjust unit tests

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68484681977c832ca2e75602066c3efe