### PR TITLE
Fix back navigation in mob builder exp reward

### DIFF
--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -774,7 +774,7 @@ def menunode_exp_reward(caller, raw_string="", **kwargs):
 def _set_exp_reward(caller, raw_string, **kwargs):
     string = raw_string.strip()
     if string.lower() == "back":
-        return "menunode_resources_prompt"
+        return "menunode_level"
     if not string or string.lower() == "skip":
         level = caller.ndb.buildnpc.get("level", 1)
         val = caller.ndb.buildnpc.get(

--- a/typeclasses/tests/test_mob_builder.py
+++ b/typeclasses/tests/test_mob_builder.py
@@ -194,6 +194,12 @@ class TestMobBuilder(EvenniaTest):
         result = npc_builder._edit_loot_table(self.char1, "done")
         assert result == "menunode_resources_prompt"
 
+    def test_exp_reward_back_returns_to_level(self):
+        """Entering back at exp reward should return to level menu."""
+        self.char1.ndb.buildnpc = {"level": 1}
+        result = npc_builder._set_exp_reward(self.char1, "back")
+        assert result == "menunode_level"
+
     def test_summary_shows_coin_and_loot(self):
         data = {
             "key": "orc",


### PR DESCRIPTION
## Summary
- fix `_set_exp_reward` back navigation
- test that exp reward step goes back to level prompt

## Testing
- `pytest -k test_exp_reward_back_returns_to_level -q` *(fails: no such table accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684896e08228832cbf7244c15d44d4d2