### PR TITLE
Fix back option in resources menu

### DIFF
--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -926,7 +926,7 @@ def menunode_resources(caller, raw_string="", **kwargs):
 def _set_resources(caller, raw_string, **kwargs):
     string = raw_string.strip()
     if string.lower() == "back":
-        return "menunode_level"
+        return "menunode_resources_prompt"
     if not string or string.lower() == "skip":
         caller.ndb.buildnpc["hp"] = caller.ndb.buildnpc.get("hp", 0)
         caller.ndb.buildnpc["mp"] = caller.ndb.buildnpc.get("mp", 0)

--- a/typeclasses/tests/test_mob_builder.py
+++ b/typeclasses/tests/test_mob_builder.py
@@ -200,6 +200,12 @@ class TestMobBuilder(EvenniaTest):
         result = npc_builder._set_exp_reward(self.char1, "back")
         assert result == "menunode_level"
 
+    def test_resources_back_returns_to_prompt(self):
+        """Entering back at resources should return to resources prompt."""
+        self.char1.ndb.buildnpc = {}
+        result = npc_builder._set_resources(self.char1, "back")
+        assert result == "menunode_resources_prompt"
+
     def test_summary_shows_coin_and_loot(self):
         data = {
             "key": "orc",


### PR DESCRIPTION
## Summary
- fix `_set_resources` back option to go to resources prompt
- test that entering back returns to the resources prompt

## Testing
- `pytest -q` *(fails: django.db.utils.OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684899076508832c8daadeeb5765fda4