### PR TITLE
Add builder types cnpc command

### DIFF
--- a/commands/admin.py
+++ b/commands/admin.py
@@ -52,6 +52,7 @@ from .mob_builder import (
 )
 from .cmdmobbuilder import CmdMobProto
 from .nextvnum import CmdNextVnum
+from .builder_types import CmdBuilderTypes
 
 
 def _safe_split(text):
@@ -1437,6 +1438,7 @@ class BuilderCmdSet(CmdSet):
         self.add(CmdSpawnNPC)
         self.add(CmdListNPCs)
         self.add(CmdDupNPC)
+        self.add(CmdBuilderTypes)
         self.add(CmdMobTemplate)
         self.add(CmdMSpawn)
         self.add(CmdMobPreview)

--- a/commands/builder_types.py
+++ b/commands/builder_types.py
@@ -1,0 +1,68 @@
+from evennia import create_object
+from .command import Command
+from utils import vnum_registry, mob_proto
+from world import prototypes, area_npcs
+from typeclasses.npcs import BaseNPC
+
+
+def builder_cnpc_prompt(caller, name):
+    """Interactively create an NPC."""
+    desc = yield (f"Enter a description for {name}:")
+    race = yield ("Race:")
+    combat_class = yield ("Combat class:")
+    level_in = yield ("Level:")
+    try:
+        level = int(level_in)
+    except ValueError:
+        level = 1
+    confirm = yield ("Create NPC? Yes/No")
+    if confirm.strip().lower() not in ("yes", "y"):
+        caller.msg("Cancelled.")
+        return
+    vnum = vnum_registry.get_next_vnum("npc")
+    npc = create_object(BaseNPC, key=name, location=caller.location)
+    npc.db.desc = desc
+    npc.db.race = race
+    npc.db.charclass = combat_class
+    npc.db.level = level
+    npc.db.vnum = vnum
+    npc.tags.add(f"M{vnum}", category="vnum")
+    proto = {
+        "key": name,
+        "typeclass": "typeclasses.npcs.BaseNPC",
+        "desc": desc,
+        "race": race,
+        "npc_class": "base",
+        "combat_class": combat_class,
+        "level": level,
+        "vnum": vnum,
+    }
+    prototypes.register_npc_prototype(name, proto)
+    mob_proto.register_prototype(proto, vnum=vnum)
+    if caller.location and caller.location.db.area:
+        area_npcs.add_area_npc(caller.location.db.area, name)
+    caller.msg(f"NPC {name} created with VNUM {vnum}.")
+
+
+class CmdBuilderTypes(Command):
+    """Access type-specific builder helpers."""
+
+    key = "builder"
+    locks = "cmd:perm(Builder)"
+    help_category = "Building"
+
+    def func(self):
+        args = self.args.strip()
+        if not args:
+            self.msg("Usage: builder types cnpc <name>")
+            return
+        parts = args.split(None, 2)
+        if len(parts) < 3 or parts[0].lower() != "types":
+            self.msg("Usage: builder types cnpc <name>")
+            return
+        sub = parts[1].lower()
+        name = parts[2].strip()
+        if sub == "cnpc" and name:
+            builder_cnpc_prompt(self.caller, name)
+        else:
+            self.msg("Usage: builder types cnpc <name>")

--- a/typeclasses/tests/test_builder_types_command.py
+++ b/typeclasses/tests/test_builder_types_command.py
@@ -1,0 +1,45 @@
+from unittest.mock import MagicMock, patch
+from evennia.utils.test_resources import EvenniaTest
+from django.test import override_settings
+from commands.admin import BuilderCmdSet
+from typeclasses.npcs import BaseNPC
+from world.scripts.mob_db import get_mobdb
+
+from commands import builder_types
+
+
+@override_settings(DEFAULT_HOME=None)
+class TestBuilderTypesCommand(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.char1.msg = MagicMock()
+        self.char1.cmdset.add_default(BuilderCmdSet)
+
+    def _find(self, key):
+        for obj in self.char1.location.contents:
+            if obj.key == key:
+                return obj
+        return None
+
+    def test_command_invokes_helper(self):
+        with patch.object(builder_types, "builder_cnpc_prompt") as mock_prompt:
+            self.char1.execute_cmd("builder types cnpc gob")
+        mock_prompt.assert_called_with(self.char1, "gob")
+
+    def test_prompt_creates_npc_and_vnum(self):
+        with patch("utils.vnum_registry.get_next_vnum", return_value=99):
+            gen = builder_types.builder_cnpc_prompt(self.char1, "orc")
+            next(gen)  # desc prompt
+            gen.send("A big orc")
+            gen.send("orc")
+            gen.send("Warrior")
+            gen.send("1")
+            try:
+                gen.send("yes")
+            except StopIteration:
+                pass
+        npc = self._find("orc")
+        self.assertIsNotNone(npc)
+        self.assertTrue(npc.is_typeclass(BaseNPC, exact=False))
+        self.assertEqual(npc.db.vnum, 99)
+        self.assertIsNotNone(get_mobdb().get_proto(99))

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -3482,6 +3482,18 @@ wander and scripted. Scripted AI runs the callback stored on
 """,
     },
     {
+        "key": "builder types cnpc",
+        "category": "Building",
+        "text": """Help for builder types cnpc
+
+Launch a quick NPC creation prompt. Follow the questions and a new
+NPC will appear in your location.
+
+Usage:
+    builder types cnpc <name>
+""",
+    },
+    {
         "key": "vnums",
         "category": "Building",
         "text": """Help for vnums


### PR DESCRIPTION
## Summary
- add new `CmdBuilderTypes` command with `cnpc` subcommand
- register command in builder cmdset
- document usage in help entries
- add unit tests for helper invocation and NPC creation

## Testing
- `pytest -q` *(fails: OperationalError no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6848ab32ade4832c9f45d4cfda3db378