### PR TITLE
Add mob utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,17 @@ These options let builders quickly create enemies that fight or roam on
 their own. The combat command set includes `attack`, `wield`, `unwield`,
 `flee`, `berserk`, `respawn`, `revive` and `status`.
 
+### Helper Utilities
+
+Convenience functions in `utils.mob_utils` provide building blocks for working
+with VNUM-based NPCs.
+
+- `assign_next_vnum(category)` – fetches and reserves the next free VNUM.
+- `add_to_mlist(vnum, proto)` – records a prototype in the mob database so it
+  appears in `@mlist`.
+- `auto_calc(stats)` and `auto_calc_secondary(stats)` – derive combat stats from
+  primary values using `world.system.stat_manager`.
+
 
 ## Running the Tests
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -4,3 +4,9 @@ from .roles import has_role, is_guildmaster, is_receptionist
 from .slots import VALID_SLOTS, normalize_slot
 from .ansi_utils import format_ansi_title
 from .menu_utils import add_back_skip
+from .mob_utils import (
+    assign_next_vnum,
+    add_to_mlist,
+    auto_calc,
+    auto_calc_secondary,
+)

--- a/utils/mob_utils.py
+++ b/utils/mob_utils.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+"""Helper utilities for NPC management and stat calculations."""
+
+from typing import Dict
+
+from utils import vnum_registry
+from utils.stats_utils import normalize_stat_key
+from world.scripts.mob_db import get_mobdb
+from world.system import stat_manager
+
+__all__ = [
+    "auto_calc",
+    "auto_calc_secondary",
+    "assign_next_vnum",
+    "add_to_mlist",
+]
+
+
+def assign_next_vnum(category: str) -> int:
+    """Return and reserve the next available VNUM for ``category``."""
+    return vnum_registry.get_next_vnum(category)
+
+
+def add_to_mlist(vnum: int, prototype: Dict) -> None:
+    """Insert ``prototype`` into the mob database under ``vnum``."""
+    get_mobdb().add_proto(int(vnum), dict(prototype))
+
+
+def auto_calc(primary_stats: Dict[str, int]) -> Dict[str, int]:
+    """Calculate derived stats from ``primary_stats`` using weight mappings."""
+    prim = {normalize_stat_key(k): int(v) for k, v in primary_stats.items()}
+    result: Dict[str, int] = {}
+    for stat, mapping in stat_manager.STAT_SCALING.items():
+        value = 0.0
+        for key, weight in mapping.items():
+            value += prim.get(key, 0) * weight
+        result[stat] = int(round(value))
+    return result
+
+
+def auto_calc_secondary(primary_stats: Dict[str, int]) -> Dict[str, int]:
+    """Return only non-resource stats from :func:`auto_calc`."""
+    derived = auto_calc(primary_stats)
+    for key in ("HP", "MP", "SP"):
+        derived.pop(key, None)
+    return derived

--- a/utils/tests/test_mob_utils.py
+++ b/utils/tests/test_mob_utils.py
@@ -1,0 +1,39 @@
+from unittest.mock import patch
+
+from evennia.utils.test_resources import EvenniaTest
+from django.test import override_settings
+
+from utils.mob_utils import (
+    assign_next_vnum,
+    add_to_mlist,
+    auto_calc,
+    auto_calc_secondary,
+)
+from world.scripts.mob_db import get_mobdb
+from world.system import stat_manager
+
+
+@override_settings(DEFAULT_HOME=None)
+class TestMobUtils(EvenniaTest):
+    def test_assign_next_vnum_delegates(self):
+        with patch("utils.vnum_registry.get_next_vnum", return_value=42) as mock:
+            val = assign_next_vnum("npc")
+            self.assertEqual(val, 42)
+            mock.assert_called_with("npc")
+
+    def test_add_to_mlist_stores_entry(self):
+        proto = {"key": "orc"}
+        add_to_mlist(5, proto)
+        mob_db = get_mobdb()
+        self.assertEqual(mob_db.get_proto(5)["key"], "orc")
+
+    def test_auto_calc_secondary(self):
+        prims = {"STR": 5, "CON": 5}
+        derived = auto_calc(prims)
+        expected_hp = int(round(
+            prims["CON"] * stat_manager.STAT_SCALING["HP"]["CON"]
+            + prims["STR"] * stat_manager.STAT_SCALING["HP"]["STR"]
+        ))
+        self.assertEqual(derived["HP"], expected_hp)
+        sec = auto_calc_secondary(prims)
+        self.assertNotIn("HP", sec)


### PR DESCRIPTION
## Summary
- implement mob helper utilities
- expose helper utilities through utils
- document helper utilities in README
- test helper utilities

## Testing
- `pytest -q` *(fails: django.db.utils.OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6848af7e0700832c8ae35e26f7479228