### PR TITLE
Improve cnpc builder finalization

### DIFF
--- a/utils/mob_utils.py
+++ b/utils/mob_utils.py
@@ -14,6 +14,7 @@ __all__ = [
     "auto_calc_secondary",
     "assign_next_vnum",
     "add_to_mlist",
+    "calculate_combat_stats",
 ]
 
 
@@ -25,6 +26,24 @@ def assign_next_vnum(category: str) -> int:
 def add_to_mlist(vnum: int, prototype: Dict) -> None:
     """Insert ``prototype`` into the mob database under ``vnum``."""
     get_mobdb().add_proto(int(vnum), dict(prototype))
+
+
+def calculate_combat_stats(combat_class: str, level: int) -> Dict[str, int]:
+    """Return base combat stats for ``combat_class`` at ``level``."""
+    base = int(level) * 10
+    return {
+        "hp": base,
+        "mp": base // 2
+        if combat_class.lower() in ("wizard", "sorcerer", "mage", "necromancer")
+        else base // 4,
+        "sp": base // 2
+        if combat_class.lower() in ("warrior", "rogue", "swashbuckler")
+        else base // 3,
+        "armor": level * 2
+        if combat_class.lower() in ("warrior", "paladin")
+        else level,
+        "initiative": 10 + level // 2,
+    }
 
 
 def auto_calc(primary_stats: Dict[str, int]) -> Dict[str, int]:

--- a/world/mobregistry.py
+++ b/world/mobregistry.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+"""Utilities for registering mobs to the global mob list."""
+
+from typing import Any, Dict
+from utils.mob_utils import add_to_mlist
+
+
+def register_mob_vnum(vnum: int, prototype: Any) -> None:
+    """Record ``prototype`` in the mob database under ``vnum``."""
+    if hasattr(prototype, "db"):
+        data: Dict[str, Any] = {
+            "key": getattr(prototype, "key", ""),
+            "level": getattr(prototype.db, "level", None),
+            "class": getattr(prototype.db, "class", None),
+            "proto_key": getattr(prototype.db, "prototype_key", None),
+        }
+    else:
+        data = dict(prototype)
+    add_to_mlist(int(vnum), data)


### PR DESCRIPTION
## Summary
- compute default combat stats when a class and level are chosen
- store combat class on `npc.db.class` as well as `npc.db.combat_class`
- finalize created mobs with default stats and register them
- expose `calculate_combat_stats` util and provide a mob registry helper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6848b5265bbc832cbcdba1fc7d8d52ed