### PR TITLE
Fix NPC builder class attribute

### DIFF
--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -1684,7 +1684,6 @@ def _create_npc(caller, raw_string, register=False, **kwargs):
     npc.db.weight = data.get("weight")
     if cc := data.get("combat_class"):
         npc.db.charclass = cc
-        npc.db.class = cc
         npc.db.combat_class = cc
     if vnum := data.get("vnum"):
         npc.db.vnum = vnum
@@ -1896,7 +1895,7 @@ def finalize_mob_prototype(caller, npc):
         caller.msg("|rCannot finalize mob. Missing level or class.|n")
         return
 
-    npc.db.class = npc.db.combat_class
+    npc.db.charclass = npc.db.combat_class
     stats = calculate_combat_stats(npc.db.combat_class, npc.db.level)
     npc.db.hp = stats["hp"]
     npc.db.mp = stats["mp"]

--- a/world/mobregistry.py
+++ b/world/mobregistry.py
@@ -12,7 +12,7 @@ def register_mob_vnum(vnum: int, prototype: Any) -> None:
         data: Dict[str, Any] = {
             "key": getattr(prototype, "key", ""),
             "level": getattr(prototype.db, "level", None),
-            "class": getattr(prototype.db, "class", None),
+            "class": getattr(prototype.db, "charclass", None),
             "proto_key": getattr(prototype.db, "prototype_key", None),
         }
     else:


### PR DESCRIPTION
## Summary
- correct invalid attribute assignments in `npc_builder`
- read charclass when registering mobs

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6849156b975c832c9428a725eada1c6b