### PR TITLE
Add area editing commands

### DIFF
--- a/commands/aedit.py
+++ b/commands/aedit.py
@@ -1,0 +1,176 @@
+from evennia.utils.evtable import EvTable
+from evennia import CmdSet
+from .command import Command
+from world.areas import Area, get_areas, save_area, update_area, find_area
+
+
+class CmdAList(Command):
+    """List defined areas."""
+
+    key = "alist"
+    locks = "cmd:perm(Builder)"
+    help_category = "Building"
+
+    def func(self):
+        areas = get_areas()
+        if not areas:
+            self.msg("No areas defined.")
+            return
+        table = EvTable("Name", "Range", "Builders", "Flags", "Age", border="cells")
+        for area in areas:
+            table.add_row(
+                area.key,
+                f"{area.start}-{area.end}",
+                ", ".join(area.builders),
+                ", ".join(area.flags),
+                str(area.age),
+            )
+        self.msg(str(table))
+
+
+class CmdASave(Command):
+    """Save changed areas."""
+
+    key = "asave"
+    locks = "cmd:perm(Builder)"
+    help_category = "Building"
+
+    def func(self):
+        if self.args.strip().lower() != "changed":
+            self.msg("Usage: asave changed")
+            return
+        # prototypes are written immediately on edit, so nothing to do
+        self.msg("All areas saved.")
+
+
+class CmdAEdit(Command):
+    """Edit or create area metadata."""
+
+    key = "aedit"
+    locks = "cmd:perm(Builder)"
+    help_category = "Building"
+
+    def func(self):
+        if not self.args:
+            self.msg(
+                "Usage: aedit create <name> <start> <end> | "
+                "aedit range <name> <start> <end> | "
+                "aedit builders <name> <list> | aedit flags <name> <list>"
+            )
+            return
+        parts = self.args.split(None, 1)
+        sub = parts[0].lower()
+        rest = parts[1].strip() if len(parts) > 1 else ""
+        if sub == "create":
+            args = rest.split()
+            if len(args) != 3 or not args[1].isdigit() or not args[2].isdigit():
+                self.msg("Usage: aedit create <name> <start> <end>")
+                return
+            name = args[0]
+            start, end = int(args[1]), int(args[2])
+            if find_area(name)[1]:
+                self.msg("Area already exists.")
+                return
+            area = Area(key=name, start=min(start, end), end=max(start, end))
+            save_area(area)
+            self.msg(f"Area {name} created.")
+            return
+        if sub == "range":
+            args = rest.split()
+            if len(args) != 3 or not args[1].isdigit() or not args[2].isdigit():
+                self.msg("Usage: aedit range <name> <start> <end>")
+                return
+            name = args[0]
+            idx, area = find_area(name)
+            if area is None:
+                self.msg("Unknown area.")
+                return
+            area.start, area.end = min(int(args[1]), int(args[2])), max(int(args[1]), int(args[2]))
+            update_area(idx, area)
+            self.msg("Range updated.")
+            return
+        if sub == "builders":
+            args = rest.split(None, 1)
+            if len(args) != 2:
+                self.msg("Usage: aedit builders <name> <builders>")
+                return
+            name, builders = args[0], args[1]
+            idx, area = find_area(name)
+            if area is None:
+                self.msg("Unknown area.")
+                return
+            area.builders = [b.strip() for b in builders.split(',') if b.strip()]
+            update_area(idx, area)
+            self.msg("Builders updated.")
+            return
+        if sub == "flags":
+            args = rest.split(None, 1)
+            if len(args) != 2:
+                self.msg("Usage: aedit flags <name> <flags>")
+                return
+            name, flags = args[0], args[1]
+            idx, area = find_area(name)
+            if area is None:
+                self.msg("Unknown area.")
+                return
+            area.flags = [f.strip().lower() for f in flags.split(',') if f.strip()]
+            update_area(idx, area)
+            self.msg("Flags updated.")
+            return
+        self.msg("Unknown subcommand.")
+
+
+class CmdAreaReset(Command):
+    """Reset an area's age."""
+
+    key = "reset"
+    locks = "cmd:perm(Builder)"
+    help_category = "Building"
+
+    def func(self):
+        if not self.args:
+            self.msg("Usage: reset <area>")
+            return
+        idx, area = find_area(self.args.strip())
+        if area is None:
+            self.msg("Unknown area.")
+            return
+        area.age = 0
+        update_area(idx, area)
+        self.msg(f"{area.key} reset.")
+
+
+class CmdAreaAge(Command):
+    """Show an area's age."""
+
+    key = "age"
+    locks = "cmd:perm(Builder)"
+    help_category = "Building"
+
+    def func(self):
+        target = self.args.strip()
+        if not target and self.caller.location:
+            target = self.caller.location.db.area or ""
+        if not target:
+            self.msg("Usage: age <area>")
+            return
+        _, area = find_area(target)
+        if area is None:
+            self.msg("Unknown area.")
+            return
+        self.msg(f"{area.key} age: {area.age}")
+
+
+class AreaEditCmdSet(CmdSet):
+    """CmdSet adding area editing commands."""
+
+    key = "AreaEditCmdSet"
+
+    def at_cmdset_creation(self):
+        super().at_cmdset_creation()
+        self.add(CmdAList)
+        self.add(CmdASave)
+        self.add(CmdAEdit)
+        self.add(CmdAreaReset)
+        self.add(CmdAreaAge)
+

--- a/commands/areas.py
+++ b/commands/areas.py
@@ -5,6 +5,7 @@ from evennia import CmdSet, create_object
 from .command import Command
 from scripts.area_spawner import AreaSpawner
 from world.areas import Area, get_areas, save_area, update_area, find_area
+from .aedit import CmdAEdit, CmdAList, CmdASave, CmdAreaReset, CmdAreaAge
 from typeclasses.rooms import Room
 
 
@@ -394,7 +395,11 @@ class AreaCmdSet(CmdSet):
 
     def at_cmdset_creation(self):
         super().at_cmdset_creation()
-        self.add(CmdAreas)
+        self.add(CmdAList)
+        self.add(CmdASave)
+        self.add(CmdAEdit)
+        self.add(CmdAreaReset)
+        self.add(CmdAreaAge)
         self.add(CmdAMake)
         self.add(CmdASet)
         self.add(CmdRooms)

--- a/world/areas.py
+++ b/world/areas.py
@@ -1,7 +1,9 @@
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass, asdict, field
 from typing import List, Dict, Optional
 
-from evennia.server.models import ServerConfig
+from pathlib import Path
+import json
+from django.conf import settings
 
 
 @dataclass
@@ -12,6 +14,9 @@ class Area:
     start: int
     end: int
     desc: str = ""
+    builders: List[str] = field(default_factory=list)
+    flags: List[str] = field(default_factory=list)
+    age: int = 0
 
     @classmethod
     def from_dict(cls, data: Dict) -> "Area":
@@ -20,45 +25,69 @@ class Area:
             start=int(data.get("start", 0)),
             end=int(data.get("end", 0)),
             desc=data.get("desc", ""),
+            builders=data.get("builders", []),
+            flags=data.get("flags", []),
+            age=int(data.get("age", 0)),
         )
 
     def to_dict(self) -> Dict:
         return asdict(self)
 
 
-_REGISTRY_KEY = "area_registry"
+_BASE_PATH = Path(settings.GAME_DIR) / "world" / "prototypes" / "areas"
 
 
-def _load_registry() -> List[Dict]:
-    return ServerConfig.objects.conf(_REGISTRY_KEY, default=list)
+def _file_path(name: str) -> Path:
+    """Return path for area ``name``."""
+    slug = name.lower().replace(" ", "_")
+    return _BASE_PATH / f"{slug}.json"
 
 
-def _save_registry(registry: List[Dict]):
-    ServerConfig.objects.conf(_REGISTRY_KEY, value=registry)
+def _load_registry() -> tuple[List[Dict], List[Path]]:
+    """Return list of area dicts and their file paths."""
+    areas: List[Dict] = []
+    files: List[Path] = []
+    if _BASE_PATH.exists():
+        for file in sorted(_BASE_PATH.glob("*.json")):
+            try:
+                with file.open("r") as f:
+                    data = json.load(f)
+                areas.append(data)
+                files.append(file)
+            except json.JSONDecodeError:
+                continue
+    return areas, files
 
 
 def get_areas() -> List[Area]:
     """Return all stored areas."""
-    return [Area.from_dict(data) for data in _load_registry()]
+    registry, _ = _load_registry()
+    return [Area.from_dict(data) for data in registry]
 
 
 def save_area(area: Area):
-    """Add a new area to the registry."""
-    registry = _load_registry()
-    registry.append(area.to_dict())
-    _save_registry(registry)
+    """Add a new area."""
+    _BASE_PATH.mkdir(parents=True, exist_ok=True)
+    path = _file_path(area.key)
+    with path.open("w") as f:
+        json.dump(area.to_dict(), f, indent=4)
 
 
 def update_area(index: int, area: Area):
-    """Update area at index."""
-    registry = _load_registry()
-    registry[index] = area.to_dict()
-    _save_registry(registry)
+    """Update area at ``index``."""
+    _, files = _load_registry()
+    if 0 <= index < len(files):
+        path = files[index]
+    else:
+        path = _file_path(area.key)
+    _BASE_PATH.mkdir(parents=True, exist_ok=True)
+    with path.open("w") as f:
+        json.dump(area.to_dict(), f, indent=4)
 
 
 def find_area(name: str) -> tuple[int, Optional[Area]]:
-    """Return index and area matching name (case-insensitive)."""
-    registry = _load_registry()
+    """Return index and area matching ``name`` (case-insensitive)."""
+    registry, _ = _load_registry()
     for i, data in enumerate(registry):
         area = Area.from_dict(data)
         if area.key.lower() == name.lower():


### PR DESCRIPTION
## Summary
- store area definitions in JSON under `world/prototypes/areas`
- add `aedit.py` command module for editing area metadata
- extend `Area` dataclass to include builders, flags and age
- integrate area editing commands into builder command set

## Testing
- `pytest -q` *(fails: django.db.utils.OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684929401550832c9fc810530f0cce74