### PR TITLE
Add mobprog command support

### DIFF
--- a/world/mpcommands.py
+++ b/world/mpcommands.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+"""Utility for executing simple mob program commands."""
+
+from evennia import create_object
+from evennia.utils import delay
+from evennia.prototypes import spawner
+
+from utils.mob_proto import spawn_from_vnum
+from utils.prototype_manager import load_prototype
+
+__all__ = ["execute_mpcommand"]
+
+
+def execute_mpcommand(mob, command: str) -> None:
+    """Parse and execute an MP command string for ``mob``.
+
+    Only a subset of traditional mobprog commands are supported.
+    Unknown commands are executed directly on the mob.
+    """
+    if not command:
+        return
+
+    parts = command.strip().split(None, 1)
+    subcmd = parts[0].lower()
+    arg = parts[1] if len(parts) > 1 else ""
+
+    if subcmd == "echo":
+        if mob.location:
+            mob.location.msg_contents(arg)
+        return
+
+    if subcmd == "goto":
+        dest = mob.search(arg)
+        if dest:
+            mob.move_to(dest, quiet=True)
+        return
+
+    if subcmd == "purge":
+        target = mob.search(arg)
+        if target:
+            target.delete()
+        return
+
+    if subcmd == "mload":
+        try:
+            vnum = int(arg.strip())
+        except (TypeError, ValueError):
+            return
+        spawn_from_vnum(vnum, location=mob.location)
+        return
+
+    if subcmd == "oload":
+        try:
+            vnum = int(arg.strip())
+        except (TypeError, ValueError):
+            return
+        proto = load_prototype("object", vnum)
+        if proto:
+            obj = spawner.spawn(proto)[0]
+            obj.location = mob.location
+        return
+
+    if subcmd == "transfer":
+        targ_name, _, dest_name = arg.partition(" ")
+        target = mob.search(targ_name.strip())
+        dest = mob.search(dest_name.strip())
+        if target and dest:
+            target.move_to(dest, quiet=True)
+        return
+
+    if subcmd == "force":
+        targ_name, _, cmd = arg.partition(" ")
+        target = mob.search(targ_name.strip())
+        if target and cmd:
+            target.execute_cmd(cmd.strip())
+        return
+
+    if subcmd == "delay":
+        try:
+            ticks, rest = arg.split(" ", 1)
+        except ValueError:
+            return
+        try:
+            ticks = int(ticks)
+        except ValueError:
+            return
+        delay(ticks, mob.execute_cmd, rest)
+        return
+
+    # default: run raw command on mob
+    mob.execute_cmd(f"{subcmd} {arg}".strip())

--- a/world/tests/test_mpcommands.py
+++ b/world/tests/test_mpcommands.py
@@ -1,0 +1,27 @@
+from unittest.mock import MagicMock, patch
+from evennia.utils.test_resources import EvenniaTest
+from evennia import create_object
+from world.mpcommands import execute_mpcommand
+from typeclasses.npcs import BaseNPC
+
+
+class TestMPCommands(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.mob = create_object(BaseNPC, key="mob", location=self.room1)
+
+    def test_echo(self):
+        self.room1.msg_contents = MagicMock()
+        execute_mpcommand(self.mob, "echo Hello")
+        self.room1.msg_contents.assert_called_with("Hello")
+
+    def test_goto(self):
+        dest = create_object("typeclasses.rooms.Room", key="dest")
+        execute_mpcommand(self.mob, "goto dest")
+        self.assertEqual(self.mob.location, dest)
+
+    def test_mload(self):
+        with patch("utils.mob_proto.spawn_from_vnum") as mock_spawn:
+            execute_mpcommand(self.mob, "mload 5")
+            mock_spawn.assert_called_with(5, location=self.mob.location)
+

--- a/world/triggers.py
+++ b/world/triggers.py
@@ -7,6 +7,7 @@ from typing import Any
 from random import randint
 
 from evennia.utils import make_iter, logger
+from world.mpcommands import execute_mpcommand
 
 
 class TriggerManager:
@@ -63,6 +64,8 @@ class TriggerManager:
                 module, func = arg.rsplit(".", 1)
                 mod = import_module(module)
                 getattr(mod, func)(self.obj, **kwargs)
+            elif action == "mob":
+                execute_mpcommand(self.obj, arg)
             else:
                 self.obj.execute_cmd(f"{action} {arg}" if arg else action)
         except Exception as err:  # pragma: no cover - log errors


### PR DESCRIPTION
## Summary
- add minimal mpcommand execution engine
- integrate mpcommands with TriggerManager
- test mpcommands

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68492eac5abc832c9ed24cb1d87dbb7a