### PR TITLE
Remove missing tailoring module

### DIFF
--- a/server/conf/settings.py
+++ b/server/conf/settings.py
@@ -107,7 +107,6 @@ CLOTHING_TYPE_LIMIT = {
 # Crafting - https://www.evennia.com/docs/latest/Contribs/Contrib-Crafting.html
 CRAFT_RECIPE_MODULES = [
     "world.recipes.smithing",
-    "world.recipes.tailoring",
     "world.recipes.cooking",
 ]
 


### PR DESCRIPTION
## Summary
- remove reference to nonexistent tailoring recipes module

## Testing
- `pytest -k smithing -q` *(fails: OperationalError - no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684931a0ffb0832cb4ec7356586e263b