### PR TITLE
Fix needle recipe duplication

### DIFF
--- a/world/recipes/smithing.py
+++ b/world/recipes/smithing.py
@@ -322,20 +322,8 @@ class HeavyIronNeedle(SkillRecipe):
             "desc": "A thick, strong needle for sewing tough materials.",
             "tags": [("heavy needle", "crafting_tool")],
             "value": 3,
-        },
-        {
-            "key": "heavy iron needle",
-            "desc": "A thick, strong needle for sewing tough materials.",
-            "tags": [("heavy needle", "crafting_tool")],
-            "value": 3,
-        },
-        {
-            "key": "heavy iron needle",
-            "desc": "A thick, strong needle for sewing tough materials.",
-            "tags": [("heavy needle", "crafting_tool")],
-            "value": 3,
-        },
-    ]
+        }
+    ] * 3
 
 
 class HeavyCopperNeedle(SkillRecipe):
@@ -355,17 +343,5 @@ class HeavyCopperNeedle(SkillRecipe):
             "desc": "A thick, strong needle for sewing tough materials.",
             "tags": [("heavy needle", "crafting_tool")],
             "value": 3,
-        },
-        {
-            "key": "heavy copper needle",
-            "desc": "A thick, strong needle for sewing tough materials.",
-            "tags": [("heavy needle", "crafting_tool")],
-            "value": 3,
-        },
-        {
-            "key": "heavy copper needle",
-            "desc": "A thick, strong needle for sewing tough materials.",
-            "tags": [("heavy needle", "crafting_tool")],
-            "value": 3,
-        },
-    ]
+        }
+    ] * 3


### PR DESCRIPTION
## Summary
- simplify repeated output prototypes in the smithing recipes

## Testing
- `pytest world/recipes/tests/test_smithing.py::TestSmithingRecipes::test_ingot -q` *(fails: ImproperlyConfigured)*

------
https://chatgpt.com/codex/tasks/task_e_68493351657c832ca032702993bc6ac6