### PR TITLE
Implement mobprogs storage

### DIFF
--- a/commands/medit.py
+++ b/commands/medit.py
@@ -55,6 +55,8 @@ def _summary(caller) -> str:
             lines.append("Special: " + ", ".join(special))
         else:
             lines.append(f"Special: {special}")
+    if proto.get("mobprogs"):
+        lines.append(f"Mobprogs: {len(proto.get('mobprogs'))}")
     return "\n".join(lines)
 
 

--- a/typeclasses/tests/test_cnpc.py
+++ b/typeclasses/tests/test_cnpc.py
@@ -104,22 +104,16 @@ class TestCNPC(EvenniaTest):
         npc_builder._set_skills(self.char1, "")
         npc_builder._set_ai(self.char1, "passive")
 
-        self.char1.ndb.buildnpc["triggers"] = {
-            "on_speak": ("hello", "say Squawk!"),
-            "on_give_item": ("", "say Thanks!"),
-        }
+        self.char1.ndb.buildnpc["mobprogs"] = [
+            {"type": "on_speak", "conditions": {"match": "hello"}, "commands": ["say Squawk!"]},
+            {"type": "on_give_item", "conditions": {}, "commands": ["say Thanks!"]},
+        ]
 
         npc_builder._create_npc(self.char1, "")
 
         npc = self._find("parrot")
         self.assertIsNotNone(npc)
-        self.assertEqual(
-            npc.db.triggers,
-            {
-                "on_speak": ("hello", "say Squawk!"),
-                "on_give_item": ("", "say Thanks!"),
-            },
-        )
+        self.assertEqual(len(npc.db.mobprogs), 2)
 
         with patch.object(npc, "execute_cmd") as mock_exec:
             npc.at_say(self.char2, "hello there")
@@ -192,11 +186,12 @@ class TestCNPC(EvenniaTest):
 
         npc_builder._save_trigger(self.char1, "say hi, emote waves;jump")
 
-        triggers = self.char1.ndb.buildnpc.get("triggers")
-        self.assertIn("on_test", triggers)
-        trig = triggers["on_test"][0]
-        self.assertEqual(trig["match"], "hello")
-        self.assertEqual(trig["responses"], ["say hi", "emote waves", "jump"])
+        progs = self.char1.ndb.buildnpc.get("mobprogs")
+        self.assertEqual(len(progs), 1)
+        prog = progs[0]
+        self.assertEqual(prog["type"], "on_test")
+        self.assertEqual(prog["conditions"]["match"], "hello")
+        self.assertEqual(prog["commands"], ["say hi", "emote waves", "jump"])
 
     def test_confirm_formatting(self):
         """menunode_confirm should return a formatted table."""

--- a/utils/mob_proto.py
+++ b/utils/mob_proto.py
@@ -7,6 +7,7 @@ from typing import Optional
 from evennia.prototypes import spawner
 from world.scripts.mob_db import get_mobdb
 from .vnum_registry import get_next_vnum, register_vnum, validate_vnum
+from .mob_utils import mobprogs_to_triggers
 
 
 def register_prototype(data: dict, vnum: int | None = None) -> int:
@@ -39,6 +40,11 @@ def spawn_from_vnum(vnum: int, location=None):
         npc.location = location
     npc.db.vnum = vnum
     npc.tags.add(f"M{vnum}", category="vnum")
+
+    mobprogs = proto_data.get("mobprogs") or []
+    npc.db.mobprogs = mobprogs
+    npc.db.triggers = mobprogs_to_triggers(mobprogs)
+
     # track how often this prototype has spawned
     mob_db.increment_spawn_count(vnum)
     return npc

--- a/utils/mob_utils.py
+++ b/utils/mob_utils.py
@@ -15,6 +15,7 @@ __all__ = [
     "assign_next_vnum",
     "add_to_mlist",
     "calculate_combat_stats",
+    "mobprogs_to_triggers",
 ]
 
 
@@ -64,3 +65,17 @@ def auto_calc_secondary(primary_stats: Dict[str, int]) -> Dict[str, int]:
     for key in ("HP", "MP", "SP"):
         derived.pop(key, None)
     return derived
+
+
+def mobprogs_to_triggers(mobprogs: list[dict]) -> Dict[str, list[dict]]:
+    """Convert mobprogs to trigger format used by :class:`TriggerManager`."""
+
+    result: Dict[str, list[dict]] = {}
+    for prog in mobprogs or []:
+        event = prog.get("type")
+        if not event:
+            continue
+        entry = dict(prog.get("conditions") or {})
+        entry["responses"] = prog.get("commands") or []
+        result.setdefault(event, []).append(entry)
+    return result


### PR DESCRIPTION
## Summary
- support new mobprogs key via helper `mobprogs_to_triggers`
- include mobprogs when spawning from mob prototypes
- store mobprogs in NPC builder and convert to triggers
- show mobprog count in `medit`
- update tests for new mobprog schema

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684937a238d8832c81a9e42a6491aec8