### PR TITLE
Add trigger alias support and random trigger scheduling

### DIFF
--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -11,6 +11,7 @@ from utils.menu_utils import add_back_skip, add_back_next, add_back_only
 from world.scripts import classes
 from utils import vnum_registry
 from utils.mob_utils import calculate_combat_stats, mobprogs_to_triggers
+from world.triggers import TriggerManager
 from .command import Command
 from django.conf import settings
 from importlib import import_module
@@ -1707,6 +1708,7 @@ def _create_npc(caller, raw_string, register=False, **kwargs):
     mobprogs = data.get("mobprogs") or []
     npc.db.mobprogs = mobprogs
     npc.db.triggers = mobprogs_to_triggers(mobprogs)
+    TriggerManager(npc).start_random_triggers()
     npc.db.coin_drop = data.get("coin_drop") or {}
     npc.db.loot_table = data.get("loot_table") or []
     npc.db.exp_reward = data.get("exp_reward", 0)

--- a/world/triggers.py
+++ b/world/triggers.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 from importlib import import_module
-from typing import Any
+from typing import Any, Iterable
 from random import randint
 
-from evennia.utils import make_iter, logger
+from evennia.utils import make_iter, logger, delay
 from world.mpcommands import execute_mpcommand
 
 
@@ -28,6 +28,30 @@ class TriggerManager:
     commands. Each command is split into ``action`` and ``argument`` and
     executed by the handler.
     """
+
+    ALIASES = {
+        "greet_prog": "on_enter",
+        "enter_prog": "on_enter",
+        "char_enter": "on_enter",
+        "leave_prog": "on_leave",
+        "char_leave": "on_leave",
+        "speech_prog": "on_speak",
+        "give_prog": "on_give_item",
+        "object_receive": "on_give_item",
+        "fight_prog": "on_attack",
+        "death_prog": "on_death",
+        "death": "on_death",
+        "bribe_prog": "on_bribe",
+        "random_prog": "random",
+        "rand_prog": "random",
+        "timer_prog": "on_timer",
+        "get_prog": "on_get",
+        "drop_prog": "on_drop",
+        "wear_prog": "on_wear",
+        "remove_prog": "on_remove",
+        "sac_prog": "on_sacrifice",
+        "time_prog": "hour",
+    }
 
     def __init__(self, obj: Any, attr: str = "triggers"):
         self.obj = obj
@@ -73,78 +97,106 @@ class TriggerManager:
 
     # public ----------------------------------------------------------------
 
-    def check(self, event: str, **kwargs):
-        """Evaluate triggers for ``event``."""
-        triggers = self._data.get(event)
-        if not triggers:
+    def _alias_events(self, event: str) -> list[str]:
+        """Return list of event and any aliases."""
+        events = [event]
+        if alias := self.ALIASES.get(event):
+            events.append(alias)
+        for key, val in self.ALIASES.items():
+            if val == event:
+                events.append(key)
+        return list(dict.fromkeys(events))
+
+    def _evaluate(self, trig: dict, **kwargs):
+        match = trig.get("match")
+        if match:
+            text = str(kwargs.get("message") or kwargs.get("text") or "")
+            if isinstance(match, (list, tuple)):
+                if not any(m.lower() in text.lower() for m in match):
+                    return
+            elif str(match).lower() not in text.lower():
+                return
+
+        percent = trig.get("percent")
+        if percent is not None and randint(1, 100) > int(percent):
             return
 
-        # allow legacy tuple or dict formats
-        if isinstance(triggers, tuple):
-            triglist = [{"match": triggers[0], "response": triggers[1]}]
-        else:
-            triglist = make_iter(triggers)
+        combat = trig.get("combat")
+        if combat is not None and bool(getattr(self.obj, "in_combat", False)) != bool(combat):
+            return
 
-        for trig in triglist:
-            if not isinstance(trig, dict):
-                continue
+        bribe = trig.get("bribe")
+        if bribe is not None and kwargs.get("amount", kwargs.get("bribe_amount", 0)) < bribe:
+            return
 
-            match = trig.get("match")
-            if match:
-                text = str(kwargs.get("message") or kwargs.get("text") or "")
-                if isinstance(match, (list, tuple)):
-                    if not any(m.lower() in text.lower() for m in match):
-                        continue
-                elif str(match).lower() not in text.lower():
-                    continue
+        hp_pct = trig.get("hp_pct")
+        if hp_pct is not None:
+            try:
+                cur = self.obj.traits.health.value
+                maxhp = self.obj.traits.health.max or 1
+                if (cur / maxhp) * 100 > float(hp_pct):
+                    return
+            except Exception:
+                return
 
-            # additional conditional checks
-            percent = trig.get("percent")
-            if percent is not None and randint(1, 100) > int(percent):
-                continue
+        hour = trig.get("hour")
+        if hour is not None and kwargs.get("hour") != hour:
+            return
 
-            combat = trig.get("combat")
-            if combat is not None and bool(getattr(self.obj, "in_combat", False)) != bool(combat):
-                continue
+        time_val = trig.get("time")
+        if time_val is not None and kwargs.get("time") != time_val:
+            return
 
-            bribe = trig.get("bribe")
-            if bribe is not None and kwargs.get("amount", kwargs.get("bribe_amount", 0)) < bribe:
-                continue
+        responses = (
+            trig.get("responses")
+            or trig.get("response")
+            or trig.get("reactions")
+            or trig.get("reaction")
+            or []
+        )
 
-            hp_pct = trig.get("hp_pct")
-            if hp_pct is not None:
-                try:
-                    cur = self.obj.traits.health.value
-                    maxhp = self.obj.traits.health.max or 1
-                    if (cur / maxhp) * 100 > float(hp_pct):
-                        continue
-                except Exception:
-                    continue
-
-            hour = trig.get("hour")
-            if hour is not None and kwargs.get("hour") != hour:
-                continue
-
-            time_val = trig.get("time")
-            if time_val is not None and kwargs.get("time") != time_val:
-                continue
-
-            responses = (
-                trig.get("responses")
-                or trig.get("response")
-                or trig.get("reactions")
-                or trig.get("reaction")
-                or []
-            )
-
-            for react in make_iter(responses):
-                if isinstance(react, str):
-                    if " " in react:
-                        action, arg = react.split(" ", 1)
-                    else:
-                        action, arg = react, ""
-                elif isinstance(react, dict) and len(react) == 1:
-                    action, arg = next(iter(react.items()))
+        for react in make_iter(responses):
+            if isinstance(react, str):
+                if " " in react:
+                    action, arg = react.split(" ", 1)
                 else:
-                    continue
-                self._execute(action.lower(), arg, **kwargs)
+                    action, arg = react, ""
+            elif isinstance(react, dict) and len(react) == 1:
+                action, arg = next(iter(react.items()))
+            else:
+                continue
+            self._execute(action.lower(), arg, **kwargs)
+
+    def _collect_triggers(self, events: Iterable[str]):
+        for ev in events:
+            trigdata = self._data.get(ev)
+            if not trigdata:
+                continue
+            if isinstance(trigdata, tuple):
+                yield {"match": trigdata[0], "response": trigdata[1]}
+            else:
+                for trig in make_iter(trigdata):
+                    if isinstance(trig, dict):
+                        yield trig
+
+    def check(self, event: str, **kwargs):
+        """Evaluate triggers for ``event`` (including aliases)."""
+        events = self._alias_events(event)
+        trigs = list(self._collect_triggers(events))
+        if not trigs:
+            return
+        for trig in trigs:
+            self._evaluate(trig, **kwargs)
+
+    # random trigger helpers -------------------------------------------------
+    def _run_random_trigger(self, trig: dict):
+        self._evaluate(trig)
+        interval = int(trig.get("interval", 60))
+        delay(interval, self._run_random_trigger, trig, persistent=True)
+
+    def start_random_triggers(self):
+        """Schedule callbacks for any random triggers."""
+        events = self._alias_events("random")
+        for trig in self._collect_triggers(events):
+            interval = int(trig.get("interval", 60))
+            delay(interval, self._run_random_trigger, trig, persistent=True)


### PR DESCRIPTION
## Summary
- enhance TriggerManager to understand alias trigger names
- add random trigger scheduling via delays
- hook new trigger names from character methods
- ensure NPCs launch random triggers when created or built

## Testing
- `pytest -q` *(fails: django.db...)*

------
https://chatgpt.com/codex/tasks/task_e_68493ae56358832c8b85994f69d31c3b