### PR TITLE
Evaluate trigger conditions before executing commands

### DIFF
--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -10,3 +10,4 @@ from .mob_utils import (
     auto_calc,
     auto_calc_secondary,
 )
+from .eval_utils import eval_safe

--- a/utils/eval_utils.py
+++ b/utils/eval_utils.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+"""Helper for safely evaluating condition strings."""
+
+from typing import Any, Mapping
+from evennia.utils import logger
+from evennia.utils.utils import simple_eval
+
+__all__ = ["eval_safe"]
+
+
+def eval_safe(expr: str, context: Mapping[str, Any] | None = None) -> Any:
+    """Safely evaluate a Python expression using ``simple_eval``.
+
+    Args:
+        expr: The expression to evaluate.
+        context: Optional mapping of names to values available in the expression.
+
+    Returns:
+        The evaluated value or ``False`` if evaluation failed.
+    """
+    try:
+        return simple_eval(expr, names=dict(context or {}))
+    except Exception as err:  # pragma: no cover - log errors
+        logger.log_err(f"Condition eval failed for '{expr}': {err}")
+        return False

--- a/world/tests/test_trigger_manager.py
+++ b/world/tests/test_trigger_manager.py
@@ -50,6 +50,17 @@ class TestTriggerManager(unittest.TestCase):
         TriggerManager(self.obj).check("on_attack")
         self.obj.execute_cmd.assert_called_with("say hurt")
 
+    def test_conditions_string(self):
+        caller = object()
+        self.obj.db.triggers["on_timer"] = [
+            {"conditions": "caller is not None", "response": "say ok"}
+        ]
+        TriggerManager(self.obj).check("on_timer", caller=caller)
+        self.obj.execute_cmd.assert_called_with("say ok")
+        self.obj.execute_cmd.reset_mock()
+        TriggerManager(self.obj).check("on_timer", caller=None)
+        self.obj.execute_cmd.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add `eval_safe` helper and expose via utils
- evaluate a trigger's `conditions` string before running responses
- test new evaluation behaviour in `TriggerManager`

## Testing
- `pytest -q` *(fails: OperationalError no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68493f6cf108832cb6576d6807df4804