### PR TITLE
Add cast and kill mpcommands

### DIFF
--- a/world/mpcommands.py
+++ b/world/mpcommands.py
@@ -88,5 +88,24 @@ def execute_mpcommand(mob, command: str) -> None:
         delay(ticks, mob.execute_cmd, rest)
         return
 
+    if subcmd == "cast":
+        spell = arg
+        target_name = None
+        if " on " in arg:
+            spell, target_name = arg.split(" on ", 1)
+        elif " " in arg:
+            spell, target_name = arg.split(" ", 1)
+        spell = spell.strip().strip("'\"")
+        target = mob.search(target_name.strip()) if target_name else None
+        if hasattr(mob, "cast_spell") and spell:
+            mob.cast_spell(spell.lower(), target=target)
+        return
+
+    if subcmd == "kill":
+        target = mob.search(arg)
+        if target and hasattr(mob, "enter_combat"):
+            mob.enter_combat(target)
+        return
+
     # default: run raw command on mob
     mob.execute_cmd(f"{subcmd} {arg}".strip())

--- a/world/tests/test_mpcommands.py
+++ b/world/tests/test_mpcommands.py
@@ -25,3 +25,15 @@ class TestMPCommands(EvenniaTest):
             execute_mpcommand(self.mob, "mload 5")
             mock_spawn.assert_called_with(5, location=self.mob.location)
 
+    def test_cast(self):
+        target = create_object(BaseNPC, key="target", location=self.room1)
+        self.mob.cast_spell = MagicMock()
+        execute_mpcommand(self.mob, "cast fireball target")
+        self.mob.cast_spell.assert_called_with("fireball", target)
+
+    def test_kill(self):
+        enemy = create_object(BaseNPC, key="enemy", location=self.room1)
+        self.mob.enter_combat = MagicMock()
+        execute_mpcommand(self.mob, "kill enemy")
+        self.mob.enter_combat.assert_called_with(enemy)
+


### PR DESCRIPTION
## Summary
- extend MP command parser with `cast` and `kill`
- unit tests for cast and kill mpcommands

## Testing
- `pytest -q` *(fails: django.db.utils.OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684941be4328832c92b8237c2484233b