### PR TITLE
Fix trigger menu back & skip handling

### DIFF
--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -1537,6 +1537,8 @@ def menunode_trigger_custom(caller, raw_string="", **kwargs):
 
 def _set_custom_event(caller, raw_string, **kwargs):
     event = raw_string.strip()
+    if event.lower() in ("back", "skip"):
+        return "menunode_trigger_add"
     if not event:
         caller.msg("Enter a valid event name.")
         return "menunode_trigger_custom"
@@ -1557,7 +1559,10 @@ def menunode_trigger_match(caller, raw_string="", **kwargs):
 
 
 def _set_trigger_match(caller, raw_string, **kwargs):
-    caller.ndb.trigger_match = raw_string.strip()
+    string = raw_string.strip()
+    if string.lower() in ("back", "skip"):
+        return "menunode_trigger_add"
+    caller.ndb.trigger_match = string
     return "menunode_trigger_react"
 
 
@@ -1569,6 +1574,11 @@ def menunode_trigger_react(caller, raw_string="", **kwargs):
 
 def _save_trigger(caller, raw_string, **kwargs):
     reaction = raw_string.strip()
+    if reaction.lower() in ("back", "skip"):
+        caller.ndb.trigger_event = None
+        caller.ndb.trigger_match = None
+        return "menunode_trigger_match"
+
     event = caller.ndb.trigger_event
     match = caller.ndb.trigger_match
     mobprogs = caller.ndb.buildnpc.setdefault("mobprogs", [])

--- a/typeclasses/tests/test_mob_builder.py
+++ b/typeclasses/tests/test_mob_builder.py
@@ -278,3 +278,23 @@ class TestMobBuilder(EvenniaTest):
         labels = [o.get("desc") or o.get("key") for o in opts]
         assert set(labels) == {"Yes", "Yes & Save Prototype", "No"}
 
+    def test_trigger_cancel_does_not_modify(self):
+        """Back or skip should not alter trigger data."""
+        self.char1.ndb.buildnpc = {}
+        npc_builder._set_trigger_event(self.char1, None, event="on_attack")
+        result = npc_builder._set_trigger_match(self.char1, "back")
+        assert result == "menunode_trigger_add"
+        assert "mobprogs" not in self.char1.ndb.buildnpc
+
+        npc_builder._set_trigger_event(self.char1, None, event="on_attack")
+        npc_builder._set_trigger_match(self.char1, "hello")
+        result = npc_builder._save_trigger(self.char1, "skip")
+        assert result == "menunode_trigger_match"
+        assert "mobprogs" not in self.char1.ndb.buildnpc
+
+    def test_custom_event_back(self):
+        """Back from custom event should not set event."""
+        result = npc_builder._set_custom_event(self.char1, "back")
+        assert result == "menunode_trigger_add"
+        assert not hasattr(self.char1.ndb, "trigger_event")
+


### PR DESCRIPTION
## Summary
- handle `back`/`skip` in trigger creation steps
- test backing out of trigger creation

## Testing
- `pytest -q` *(fails: no such table `accounts_accountdb`)*

------
https://chatgpt.com/codex/tasks/task_e_6849433c7a44832c96812e2e8857ff09