### PR TITLE
Add unique NPC race

### DIFF
--- a/typeclasses/tests/test_mob_builder.py
+++ b/typeclasses/tests/test_mob_builder.py
@@ -298,3 +298,10 @@ class TestMobBuilder(EvenniaTest):
         assert result == "menunode_trigger_add"
         assert not hasattr(self.char1.ndb, "trigger_event")
 
+    def test_set_race_accepts_unique(self):
+        """_set_race should accept the 'unique' race value."""
+        self.char1.ndb.buildnpc = {}
+        result = npc_builder._set_race(self.char1, "unique")
+        assert result == "menunode_npc_class"
+        assert self.char1.ndb.buildnpc["race"] == "unique"
+

--- a/typeclasses/tests/test_mset_command.py
+++ b/typeclasses/tests/test_mset_command.py
@@ -47,3 +47,9 @@ class TestMSetCommand(EvenniaTest):
         reg = prototypes.get_npc_prototypes()
         table = reg["boar"]["loot_table"]
         assert table[0]["guaranteed_after"] == 3
+
+    def test_mset_race_unique(self):
+        prototypes.register_npc_prototype("beast", {"key": "beast"})
+        self.char1.execute_cmd("@mset beast race unique")
+        reg = prototypes.get_npc_prototypes()
+        assert reg["beast"]["race"] == "unique"

--- a/world/mob_constants.py
+++ b/world/mob_constants.py
@@ -31,6 +31,7 @@ class NPC_RACES(_StrEnum):
     PIXIE = "pixie"
     MINOTAUR = "minotaur"
     SATYR = "satyr"
+    UNIQUE = "unique"
 
 
 class NPC_SEXES(_StrEnum):


### PR DESCRIPTION
## Summary
- add `UNIQUE` race constant to `NPC_RACES`
- accept `unique` via `_set_race`
- document new behaviour in tests

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*
- `pytest typeclasses/tests/test_mob_builder.py::TestMobBuilder::test_set_race_accepts_unique -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68494755fa58832ca1c8c4d0be8f0367