### PR TITLE
Refactor NPC builder fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,13 +124,11 @@ and confirm to create your NPC. You can later update them with `cnpc edit
 
 See the `cnpc` help entry for a full breakdown of every menu option.
 
-The builder also lets you choose which NPC class to use. Available
-classes include `BaseNPC`, `MerchantNPC`, `BankerNPC`, `TrainerNPC`,
-`WandererNPC`, `GuildmasterNPC`, `GuildReceptionistNPC`,
-`QuestGiverNPC`, `CombatTrainerNPC` and `EventNPC` defined under
-`typeclasses.npcs`.
-After choosing the NPC class you can also assign a combat class from
-`world.scripts.classes`. This sets `npc.db.charclass` on the spawned NPC.
+The builder lets you choose an NPC type such as `merchant`, `banker`,
+`trainer`, `wanderer` or `combatant`. These map to the typeclasses under
+`typeclasses.npcs`. When you select the `combatant` type you'll be asked
+for a combat class from `world.scripts.classes`; this sets
+`npc.db.charclass` on the spawned NPC.
 
 While editing, there's a step to manage triggers using a numbered menu. Choose
 `Add trigger` to create a new reaction, `Delete trigger` to remove one, `List
@@ -141,7 +139,7 @@ commands with commas or semicolons to store them as multiple responses. See the
 
 ### NPC Roles and AI
 
-The builder now supports assigning extra roles and basic AI scripts. Roles are
+The builder lets you assign one or more roles and basic AI scripts. Roles are
 mixins found under `world.npc_roles`:
 
 - **merchant** – sells items to players.

--- a/commands/builder_types.py
+++ b/commands/builder_types.py
@@ -31,7 +31,7 @@ def builder_cnpc_prompt(caller, name):
         "typeclass": "typeclasses.npcs.BaseNPC",
         "desc": desc,
         "race": race,
-        "npc_class": "base",
+        "npc_type": "base",
         "combat_class": combat_class,
         "level": level,
         "vnum": vnum,

--- a/commands/mob_builder.py
+++ b/commands/mob_builder.py
@@ -69,7 +69,7 @@ class CmdMSpawn(Command):
                     self.msg("Prototype not found.")
                     return
                 tclass_path = npc_builder.NPC_CLASS_MAP.get(
-                    proto.get("npc_class", "base"), "typeclasses.npcs.BaseNPC"
+                    proto.get("npc_type", "base"), "typeclasses.npcs.BaseNPC"
                 )
                 proto = dict(proto)
                 proto.setdefault("typeclass", tclass_path)
@@ -117,7 +117,7 @@ class CmdMobPreview(Command):
                 self.msg("Prototype not found.")
                 return
             tclass_path = npc_builder.NPC_CLASS_MAP.get(
-                proto.get("npc_class", "base"), "typeclasses.npcs.BaseNPC"
+                proto.get("npc_type", "base"), "typeclasses.npcs.BaseNPC"
             )
             proto = dict(proto)
             proto.setdefault("typeclass", tclass_path)

--- a/commands/mob_builder_commands.py
+++ b/commands/mob_builder_commands.py
@@ -64,7 +64,7 @@ class CmdMStat(Command):
             data = npc_builder._gather_npc_data(target)
         table = evtable.EvTable("|cAttribute|n", "|cValue|n", border="cells")
 
-        highlight = {"key", "level", "npc_class"}
+        highlight = {"key", "level", "npc_type"}
         special = {
             "actflags",
             "affected_by",
@@ -187,7 +187,7 @@ class CmdMSet(Command):
     _FIELD_CASTS = {
         "level": int,
         "race": lambda s: NPC_RACES.from_str(s).value,
-        "npc_class": lambda s: NPC_CLASSES.from_str(s).value,
+        "npc_type": lambda s: NPC_CLASSES.from_str(s).value,
         "actflags": lambda s: [f.value for f in parse_flag_list(s, ACTFLAGS)],
         "affected_by": lambda s: [f.value for f in parse_flag_list(s, AFFECTED_BY)],
         "languages": lambda s: [f.value for f in parse_flag_list(s, LANGUAGES)],
@@ -399,7 +399,7 @@ class CmdMList(Command):
                 str(vnum) if vnum is not None else "-",
                 key,
                 str(proto.get("level", "-")),
-                proto.get("npc_class", "-"),
+                proto.get("npc_type", "-"),
                 ", ".join(roles) if roles else "-",
                 str(counts.get(key, 0)),
             )

--- a/typeclasses/tests/test_cnpc.py
+++ b/typeclasses/tests/test_cnpc.py
@@ -27,8 +27,8 @@ class TestCNPC(EvenniaTest):
             self.char1.execute_cmd("cnpc start goblin")
 
         npc_builder._set_desc(self.char1, "A nasty goblin")
+        npc_builder._set_npc_type(self.char1, "merchant")
         npc_builder._set_creature_type(self.char1, "humanoid")
-        npc_builder._set_role(self.char1, "merchant")
         npc_builder._edit_roles(self.char1, "add merchant")
         npc_builder._edit_roles(self.char1, "done")
         npc_builder._set_merchant_pricing(self.char1, "1.5")
@@ -71,8 +71,8 @@ class TestCNPC(EvenniaTest):
             self.char1.execute_cmd("cnpc start ogre")
 
         npc_builder._set_desc(self.char1, "A big ogre")
+        npc_builder._set_npc_type(self.char1, "questgiver")
         npc_builder._set_creature_type(self.char1, "humanoid")
-        npc_builder._set_role(self.char1, "questgiver")
         npc_builder._set_level(self.char1, "1")
         npc_builder._set_resources(self.char1, "20 5 5")
         npc_builder._set_stats(self.char1, "5 5 5 5 5 5")
@@ -95,8 +95,8 @@ class TestCNPC(EvenniaTest):
             self.char1.execute_cmd("cnpc start parrot")
 
         npc_builder._set_desc(self.char1, "A colorful parrot")
+        npc_builder._set_npc_type(self.char1, "trainer")
         npc_builder._set_creature_type(self.char1, "humanoid")
-        npc_builder._set_role(self.char1, "trainer")
         npc_builder._set_level(self.char1, "1")
         npc_builder._set_resources(self.char1, "10 0 0")
         npc_builder._set_stats(self.char1, "1 1 1 1 1 1")
@@ -125,11 +125,11 @@ class TestCNPC(EvenniaTest):
             self.char1.execute_cmd("cnpc start chimera")
 
         npc_builder._set_desc(self.char1, "A weird beast")
+        npc_builder._set_npc_type(self.char1, "questgiver")
         npc_builder._set_creature_type(self.char1, "unique")
         npc_builder._edit_custom_slots(self.char1, "remove offhand")
         npc_builder._edit_custom_slots(self.char1, "add tail")
         npc_builder._edit_custom_slots(self.char1, "done")
-        npc_builder._set_role(self.char1, "questgiver")
         npc_builder._set_level(self.char1, "1")
         npc_builder._set_resources(self.char1, "5 0 0")
         npc_builder._set_stats(self.char1, "1 1 1 1 1 1")
@@ -147,8 +147,8 @@ class TestCNPC(EvenniaTest):
             self.char1.execute_cmd("cnpc start clerk")
 
         npc_builder._set_desc(self.char1, "A helpful clerk")
+        npc_builder._set_npc_type(self.char1, "wanderer")
         npc_builder._set_creature_type(self.char1, "humanoid")
-        npc_builder._set_role(self.char1, "wanderer")
         npc_builder._edit_roles(self.char1, "add guild_receptionist")
         npc_builder._edit_roles(self.char1, "done")
         npc_builder._set_guild_affiliation(self.char1, "myguild")
@@ -198,7 +198,7 @@ class TestCNPC(EvenniaTest):
         self.char1.ndb.buildnpc = {
             "key": "goblin",
             "desc": "",
-            "npc_class": "base",
+            "npc_type": "base",
             "level": 1,
             "primary_stats": {"STR": 1},
         }

--- a/typeclasses/tests/test_mlist_command.py
+++ b/typeclasses/tests/test_mlist_command.py
@@ -40,13 +40,13 @@ class TestMListCommand(EvenniaTest):
     def test_prototype_filtering(self):
         prototypes.register_npc_prototype(
             "orc_warrior",
-            {"key": "orc warrior", "npc_class": "warrior", "race": "orc", "roles": ["guard"]},
+            {"key": "orc warrior", "npc_type": "warrior", "race": "orc", "roles": ["guard"]},
         )
         prototypes.register_npc_prototype(
             "elf_mage",
             {
                 "key": "elf mage",
-                "npc_class": "mage",
+                "npc_type": "mage",
                 "race": "elf",
                 "roles": ["questgiver"],
                 "tags": ["caster"],
@@ -65,7 +65,7 @@ class TestMListCommand(EvenniaTest):
     def test_mlist_room_and_area(self):
         proto = {
             "key": "goblin",
-            "npc_class": "warrior",
+            "npc_type": "warrior",
             "level": 1,
             "typeclass": "typeclasses.npcs.BaseNPC",
         }

--- a/typeclasses/tests/test_mob_builder.py
+++ b/typeclasses/tests/test_mob_builder.py
@@ -43,13 +43,12 @@ class TestMobBuilder(EvenniaTest):
         npc_builder._set_key(self.char1, "goblin")
         npc_builder._set_desc(self.char1, "A small goblin")
         npc_builder._set_race(self.char1, "human")
-        npc_builder._set_npc_class(self.char1, "base")
+        npc_builder._set_npc_type(self.char1, "base")
         npc_builder._set_sex(self.char1, "male")
         npc_builder._set_weight(self.char1, "medium")
         npc_builder._set_level(self.char1, "1")
         npc_builder._set_vnum(self.char1, "auto")
         npc_builder._set_creature_type(self.char1, "humanoid")
-        npc_builder._set_role(self.char1, "")
         npc_builder._set_combat_class(self.char1, "Warrior")
         npc_builder._edit_roles(self.char1, "done")
         npc_builder._set_exp_reward(self.char1, "5")
@@ -157,10 +156,10 @@ class TestMobBuilder(EvenniaTest):
         assert self.char1.ndb.buildnpc["vnum"] == 5
         assert result == "menunode_creature_type"
 
-    def test_npc_class_menu_shows_next(self):
-        """menunode_npc_class should offer a Next option."""
+    def test_npc_type_menu_shows_next(self):
+        """menunode_npc_type should offer a Next option."""
         self.char1.ndb.buildnpc = {}
-        _text, opts = npc_builder.menunode_npc_class(self.char1)
+        _text, opts = npc_builder.menunode_npc_type(self.char1)
         labels = [o.get("desc") or o.get("key") for o in opts]
         assert "Next" in labels
         assert "Skip" not in labels
@@ -183,7 +182,7 @@ class TestMobBuilder(EvenniaTest):
 
     def test_skills_menu_shows_suggestions(self):
         """menunode_skills should list suggested skills for the class."""
-        self.char1.ndb.buildnpc = {"npc_class": "combat_trainer"}
+        self.char1.ndb.buildnpc = {"npc_type": "combat_trainer"}
         text, _ = npc_builder.menunode_skills(self.char1)
         for skill in npc_builder.DEFAULT_SKILLS:
             assert skill in text
@@ -258,7 +257,7 @@ class TestMobBuilder(EvenniaTest):
             "level": 1,
             "vnum": 5,
             "creature_type": "humanoid",
-            "role": "merchant",
+            "npc_type": "merchant",
         }
         result = npc_builder.menunode_confirm(self.char1)
         self.assertEqual(result, "menunode_desc")
@@ -272,7 +271,7 @@ class TestMobBuilder(EvenniaTest):
             "level": 2,
             "vnum": 7,
             "creature_type": "humanoid",
-            "role": "merchant",
+            "npc_type": "merchant",
         }
         text, opts = npc_builder.menunode_confirm(self.char1)
         labels = [o.get("desc") or o.get("key") for o in opts]
@@ -302,6 +301,6 @@ class TestMobBuilder(EvenniaTest):
         """_set_race should accept the 'unique' race value."""
         self.char1.ndb.buildnpc = {}
         result = npc_builder._set_race(self.char1, "unique")
-        assert result == "menunode_npc_class"
+        assert result == "menunode_npc_type"
         assert self.char1.ndb.buildnpc["race"] == "unique"
 

--- a/typeclasses/tests/test_spawnnpc.py
+++ b/typeclasses/tests/test_spawnnpc.py
@@ -50,7 +50,7 @@ class TestSpawnNPCPrototype(EvenniaTest):
 
         prototypes.register_npc_prototype(
             "legacy_proto",
-            {"key": "legacy", "npc_type": "merchant", "npc_class": "merchant"},
+            {"key": "legacy", "npc_type": "merchant"},
         )
 
         self.char1.execute_cmd("@spawnnpc legacy_proto")

--- a/typeclasses/tests/test_vnum_mobs.py
+++ b/typeclasses/tests/test_vnum_mobs.py
@@ -122,7 +122,7 @@ class TestVnumMobs(EvenniaTest):
 
         self.char1.ndb.buildnpc = {
             "key": "ogre",
-            "npc_class": "base",
+            "npc_type": "base",
             "vnum": 12,
             "creature_type": "humanoid",
         }
@@ -140,7 +140,7 @@ class TestVnumMobs(EvenniaTest):
         vnum = 22
         self.char1.ndb.buildnpc = {
             "key": "bugbear",
-            "npc_class": "base",
+            "npc_type": "base",
             "vnum": vnum,
             "creature_type": "humanoid",
         }

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -2678,12 +2678,11 @@ Notes:
     - createnpc
     - NPC roles include merchant, questgiver, guildmaster,
       guild_receptionist, banker, trainer and wanderer.
-    - NPC classes include base, merchant, banker, trainer, wanderer,
-      guildmaster, guild_receptionist, questgiver, combat_trainer and
-      event_npc.
-    - After choosing the NPC class you may select a combat class like
-      Warrior or Mage.
-    - The builder prompts for description, weight category, role,
+    - NPC types include merchant, banker, trainer, wanderer,
+      combatant and others.
+    - Selecting the combatant type allows you to choose a combat class
+      like Warrior or Mage.
+    - The builder prompts for description, weight category,
       creature type, level, experience reward, optional HP MP SP values,
       primary stats, modifiers or buffs, combat class, behavior, skills,
       spells, resistances and AI type.
@@ -2754,8 +2753,7 @@ Related:
         "category": "Building",
         "text": """Help for npc roles
 
-NPC roles grant extra behavior to an NPC. They are selected during the
-`cnpc` builder at the roles step. Available roles are:
+NPC roles grant extra behavior to an NPC. Available roles are:
     merchant - sells items to players
     banker - stores currency for players
     trainer - teaches skills

--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -547,7 +547,7 @@ def get_npc_prototypes(filter_by: Optional[dict] = None) -> Dict[str, dict]:
 
     result: Dict[str, dict] = {}
     for key, proto in registry.items():
-        if "class" in filter_by and proto.get("npc_class") != filter_by["class"]:
+        if "class" in filter_by and proto.get("npc_type") != filter_by["class"]:
             continue
         if "race" in filter_by and proto.get("race") != filter_by["race"]:
             continue
@@ -613,7 +613,7 @@ def filter_npc_prototypes(protos: dict, filters: dict) -> list[tuple[str, dict]]
 
     result: list[tuple[str, dict]] = []
     for key, proto in protos.items():
-        if "class" in filters and proto.get("npc_class") != filters["class"]:
+        if "class" in filters and proto.get("npc_type") != filters["class"]:
             continue
         if "race" in filters and proto.get("race") != filters["race"]:
             continue

--- a/world/prototypes/npcs.json
+++ b/world/prototypes/npcs.json
@@ -2,8 +2,8 @@
     "basic_merchant": {
         "key": "merchant",
         "desc": "A traveling merchant ready to trade goods.",
-        "npc_class": "merchant",
-        "role": "merchant",
+        "npc_type": "merchant",
+        "roles": ["merchant"],
         "ai_type": "passive",
         "level": 1,
         "actflags": ["call_for_help"],
@@ -13,8 +13,8 @@
     "basic_questgiver": {
         "key": "quest giver",
         "desc": "A local seeking brave adventurers for help.",
-        "npc_class": "questgiver",
-        "role": "questgiver",
+        "npc_type": "questgiver",
+        "roles": ["questgiver"],
         "ai_type": "passive",
         "level": 1,
         "actflags": ["call_for_help"],
@@ -24,8 +24,8 @@
     "basic_guard": {
         "key": "town guard",
         "desc": "A vigilant guard keeping watch over the streets.",
-        "npc_class": "base",
-        "role": "guard",
+        "npc_type": "base",
+        "roles": ["guard"],
         "ai_type": "defensive",
         "level": 1,
         "actflags": ["assist", "call_for_help"],


### PR DESCRIPTION
## Summary
- rename npc_class to npc_type throughout
- simplify menu flow by removing menunode_role
- merge roles into a single list
- tag NPCs by npc_type and roles when spawning
- update docs, help and tests for new terminology

## Testing
- `pytest -q` *(fails: django.db...)*

------
https://chatgpt.com/codex/tasks/task_e_684949442690832cb0a9c5f5618345c1