### PR TITLE
Update mob summary formatting

### DIFF
--- a/typeclasses/tests/test_mob_builder.py
+++ b/typeclasses/tests/test_mob_builder.py
@@ -96,6 +96,9 @@ class TestMobBuilder(EvenniaTest):
         data = {
             "key": "goblin",
             "desc": "A nasty goblin",
+            "npc_type": "combatant",
+            "combat_class": "Warrior",
+            "roles": ["fighter", "trainer", "fighter"],
             "race": "orc",
             "sex": "male",
             "weight": "small",
@@ -128,6 +131,10 @@ class TestMobBuilder(EvenniaTest):
             assert text in out
         for stat in ["Damage", "Armor", "Initiative"]:
             assert stat in out
+        assert "NPC Type" in out
+        assert "Combat Class" in out
+        assert out.count("fighter") == 1
+        assert "trainer" in out
         assert "slash" in out
         assert "gold" in out
         assert "RAW_MEAT" in out


### PR DESCRIPTION
## Summary
- tweak `format_mob_summary` so empty values are skipped
- show the NPC type and combat class (when set)
- deduplicate roles in NPC summaries
- update mob builder tests for the changed summary

## Testing
- `pytest -q` *(fails: OperationalError - no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68494cdef0a0832caf49c117c8399eb2