### PR TITLE
Fix finalize_mob_prototype to respect custom stats

### DIFF
--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -1873,9 +1873,11 @@ def finalize_mob_prototype(caller, npc):
 
     npc.db.charclass = npc.db.combat_class
     stats = calculate_combat_stats(npc.db.combat_class, npc.db.level)
-    npc.db.hp = stats["hp"]
-    npc.db.mp = stats["mp"]
-    npc.db.sp = stats["sp"]
+    for attr, trait in (("hp", "health"), ("mp", "mana"), ("sp", "stamina")):
+        value = getattr(npc.traits.get(trait), "base", 0)
+        if not value:
+            value = stats[attr]
+        setattr(npc.db, attr, value)
     npc.db.armor = stats["armor"]
     npc.db.initiative = stats["initiative"]
 

--- a/typeclasses/tests/test_cnpc.py
+++ b/typeclasses/tests/test_cnpc.py
@@ -207,3 +207,28 @@ class TestCNPC(EvenniaTest):
         self.assertIn("Goblin", text)
         self.assertIn("Field", text)
         self.assertIn("Primary Stats", text)
+
+    def test_finalize_preserves_custom_resources(self):
+        npc = create.create_object("typeclasses.npcs.BaseNPC", key="dummy", location=self.room1)
+        npc.db.level = 2
+        npc.db.combat_class = "Warrior"
+        npc.traits.health.base = 30
+        npc.traits.mana.base = 10
+        npc.traits.stamina.base = 5
+        npc_builder.finalize_mob_prototype(self.char1, npc)
+        self.assertEqual(npc.db.hp, 30)
+        self.assertEqual(npc.db.mp, 10)
+        self.assertEqual(npc.db.sp, 5)
+
+    def test_finalize_fills_missing_resources(self):
+        npc = create.create_object("typeclasses.npcs.BaseNPC", key="dummy2", location=self.room1)
+        npc.db.level = 3
+        npc.db.combat_class = "Warrior"
+        npc.traits.health.base = 0
+        npc.traits.mana.base = 0
+        npc.traits.stamina.base = 0
+        npc_builder.finalize_mob_prototype(self.char1, npc)
+        stats = npc_builder.calculate_combat_stats("Warrior", 3)
+        self.assertEqual(npc.db.hp, stats["hp"])
+        self.assertEqual(npc.db.mp, stats["mp"])
+        self.assertEqual(npc.db.sp, stats["sp"])

--- a/typeclasses/tests/test_mob_builder.py
+++ b/typeclasses/tests/test_mob_builder.py
@@ -81,6 +81,10 @@ class TestMobBuilder(EvenniaTest):
         assert npc is not None
         assert npc.is_typeclass(BaseNPC, exact=False)
         assert npc.db.charclass == "Warrior"
+        stats = npc_builder.calculate_combat_stats("Warrior", 1)
+        assert npc.db.hp == 10
+        assert npc.db.mp == stats["mp"]
+        assert npc.db.sp == stats["sp"]
 
         self.char1.execute_cmd("@mstat mob_goblin")
         out = self.char1.msg.call_args[0][0]


### PR DESCRIPTION
## Summary
- preserve custom HP/MP/SP in `finalize_mob_prototype`
- compute HP/MP/SP only when zero or missing
- extend mob builder tests for hp/mp/sp defaults
- add direct tests for finalize_mob_prototype

## Testing
- `pytest -q` *(fails: django.db errors)*

------
https://chatgpt.com/codex/tasks/task_e_68494ec91618832ca89925e7252e46a0