### PR TITLE
Refine finalize message for NPC builder

### DIFF
--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -1936,9 +1936,11 @@ def finalize_mob_prototype(caller, npc):
     if npc.db.vnum:
         register_mob_vnum(vnum=npc.db.vnum, prototype=npc)
 
-    caller.msg(
-        f"|gMob '{npc.key}' finalized with VNUM {npc.db.vnum} and added to mob list.|n"
-    )
+    msg = f"|gMob '{npc.key}' finalized"
+    if npc.db.vnum is not None:
+        msg += f" with VNUM {npc.db.vnum}"
+    msg += " and added to mob list.|n"
+    caller.msg(msg)
 
 
 class CmdCNPC(Command):

--- a/typeclasses/tests/test_cnpc.py
+++ b/typeclasses/tests/test_cnpc.py
@@ -232,3 +232,28 @@ class TestCNPC(EvenniaTest):
         self.assertEqual(npc.db.hp, stats["hp"])
         self.assertEqual(npc.db.mp, stats["mp"])
         self.assertEqual(npc.db.sp, stats["sp"])
+
+    def test_finalize_message_without_vnum(self):
+        npc = create.create_object("typeclasses.npcs.BaseNPC", key="dummy3", location=self.room1)
+        npc.db.level = 1
+        npc.db.combat_class = "Warrior"
+        npc.db.vnum = None
+        with patch("world.mobregistry.register_mob_vnum") as mock_reg:
+            npc_builder.finalize_mob_prototype(self.char1, npc)
+        mock_reg.assert_not_called()
+        msg = self.char1.msg.call_args[0][0]
+        self.assertIn("finalized", msg)
+        self.assertIn("added to mob list", msg)
+        self.assertNotIn("VNUM", msg)
+
+    def test_finalize_message_with_vnum(self):
+        npc = create.create_object("typeclasses.npcs.BaseNPC", key="dummy4", location=self.room1)
+        npc.db.level = 1
+        npc.db.combat_class = "Warrior"
+        npc.db.vnum = 5
+        with patch("world.mobregistry.register_mob_vnum") as mock_reg:
+            npc_builder.finalize_mob_prototype(self.char1, npc)
+        mock_reg.assert_called_with(vnum=5, prototype=npc)
+        msg = self.char1.msg.call_args[0][0]
+        self.assertIn("with VNUM 5", msg)
+        self.assertIn("added to mob list", msg)


### PR DESCRIPTION
## Summary
- adjust finalize message in npc builder to only show the VNUM when present
- expand CNPC tests for finalize messages

## Testing
- `pytest typeclasses/tests/test_cnpc.py::TestCNPC::test_finalize_message_with_vnum -q` *(fails: OperationalError no such table)*

------
https://chatgpt.com/codex/tasks/task_e_684958f02d14832cad39bb5f46e63de4