### PR TITLE
Finalize spawned mobs

### DIFF
--- a/utils/mob_proto.py
+++ b/utils/mob_proto.py
@@ -45,6 +45,9 @@ def spawn_from_vnum(vnum: int, location=None):
     npc.db.mobprogs = mobprogs
     npc.db.triggers = mobprogs_to_triggers(mobprogs)
 
+    from commands.npc_builder import finalize_mob_prototype
+    finalize_mob_prototype(npc, npc)
+
     # track how often this prototype has spawned
     mob_db.increment_spawn_count(vnum)
     return npc


### PR DESCRIPTION
## Summary
- call `finalize_mob_prototype` from `spawn_from_vnum` so NPCs have combat stats
- ensure patched tests check the finalize call and stat generation

## Testing
- `pytest -q` *(fails: OperationalError no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68495a7305e8832ca641509361a25984