### PR TITLE
Unify resistance attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ system is designed to plug into Evennia characters and rooms for dynamic fights.
 ### Damage Types and Resistances
 
 Damage dealt in combat is categorized by `DamageType`. Characters may hold
-resistance flags in their `db.ris` attribute. During damage resolution the
+resistance flags in their `db.resistances` attribute. During damage resolution the
 engine consults a resistance matrix to modify incoming damage. For example:
 
 ```python

--- a/commands/mob_builder_commands.py
+++ b/commands/mob_builder_commands.py
@@ -71,7 +71,7 @@ class CmdMStat(Command):
             "saving_throws",
             "attack_types",
             "defense_types",
-            "ris",
+            "resistances",
             "languages",
         }
 
@@ -110,7 +110,7 @@ class CmdMStat(Command):
         )
         table.add_row(
             "|cResists|n",
-            ", ".join(data.get("ris", [])) if data.get("ris") else "--",
+            ", ".join(data.get("resistances", [])) if data.get("resistances") else "--",
         )
         table.add_row(
             "|cLanguages|n",
@@ -193,7 +193,6 @@ class CmdMSet(Command):
         "languages": lambda s: [f.value for f in parse_flag_list(s, LANGUAGES)],
         "bodyparts": lambda s: [f.value for f in parse_flag_list(s, BODYPARTS)],
         "saving_throws": lambda s: [f.value for f in parse_flag_list(s, SAVING_THROWS)],
-        "ris": lambda s: [f.value for f in parse_flag_list(s, RIS_TYPES)],
         "resistances": lambda s: [f.value for f in parse_flag_list(s, RIS_TYPES)],
         "attack_types": lambda s: [f.value for f in parse_flag_list(s, ATTACK_TYPES)],
         "defense_types": lambda s: [f.value for f in parse_flag_list(s, DEFENSE_TYPES)],

--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -247,7 +247,7 @@ def format_mob_summary(data: dict) -> str:
     flags = EvTable(border="cells")
     add_row(flags, "|cAct Flags|n", "actflags")
     add_row(flags, "|cAffects|n", "affected_by")
-    add_row(flags, "|cResists|n", "ris")
+    add_row(flags, "|cResists|n", "resistances")
     if data.get("attack_types"):
         flags.add_row("|cAttacks|n", fmt(data.get("attack_types")))
     if data.get("defense_types"):
@@ -1323,7 +1323,7 @@ def _set_affects(caller, raw_string, **kwargs):
 
 
 def menunode_resists(caller, raw_string="", **kwargs):
-    default = caller.ndb.buildnpc.get("ris", [])
+    default = caller.ndb.buildnpc.get("resistances", [])
     choices = ", ".join(r.value for r in RIS_TYPES)
     text = "|wResistances|n (space separated)"
     if default:
@@ -1340,14 +1340,14 @@ def _set_resists(caller, raw_string, **kwargs):
     if string.lower() == "back":
         return "menunode_affects"
     if not string or string.lower() == "skip":
-        val = caller.ndb.buildnpc.get("ris", [])
+        val = caller.ndb.buildnpc.get("resistances", [])
     else:
         try:
             val = [f.value for f in parse_flag_list(string, RIS_TYPES)]
         except Exception:
             caller.msg("Invalid type.")
             return "menunode_resists"
-    caller.ndb.buildnpc["ris"] = val
+    caller.ndb.buildnpc["resistances"] = val
     return "menunode_bodyparts"
 
 
@@ -1732,7 +1732,7 @@ def _create_npc(caller, raw_string, register=False, **kwargs):
     npc.db.spells = data.get("spells")
     npc.db.actflags = data.get("actflags")
     npc.db.affected_by = data.get("affected_by")
-    npc.db.ris = data.get("ris")
+    npc.db.resistances = data.get("resistances")
     npc.db.bodyparts = data.get("bodyparts")
     npc.db.attack_types = data.get("attack_types")
     npc.db.defense_types = data.get("defense_types")
@@ -1896,7 +1896,7 @@ def _gather_npc_data(npc):
         "ai_type": npc.db.ai_type or "",
         "actflags": npc.db.actflags or [],
         "affected_by": npc.db.affected_by or [],
-        "ris": npc.db.ris or [],
+        "resistances": npc.db.resistances or [],
         "bodyparts": npc.db.bodyparts or [],
         "attack_types": npc.db.attack_types or [],
         "defense_types": npc.db.defense_types or [],
@@ -1975,7 +1975,7 @@ class CmdCNPC(Command):
                 "roles": [],
                 "skills": [],
                 "spells": [],
-                "ris": [],
+                "resistances": [],
                 "coin_drop": {},
                 "loot_table": [],
                 "exp_reward": 0,

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -346,7 +346,7 @@ class Character(ObjectParent, ClothedCharacter):
                 dt = None
 
         if dt:
-            resist_values = getattr(self.db, "ris", []) or []
+            resist_values = getattr(self.db, "resistances", []) or []
             resistances = [
                 ResistanceType(r)
                 for r in resist_values

--- a/typeclasses/tests/test_mob_builder.py
+++ b/typeclasses/tests/test_mob_builder.py
@@ -116,7 +116,7 @@ class TestMobBuilder(EvenniaTest):
             "primary_stats": {"STR": 1, "CON": 1},
             "actflags": ["aggressive"],
             "affected_by": ["invisible"],
-            "ris": ["fire"],
+            "resistances": ["fire"],
             "exp_reward": 5,
             "coin_drop": {"gold": 1},
             "loot_table": [{"proto": "RAW_MEAT", "chance": 50}],


### PR DESCRIPTION
## Summary
- rename NPC builder `ris` field to `resistances`
- use `resistances` when saving or loading prototypes
- update character damage handling
- fix tests and docs for new field

## Testing
- `pytest -q` *(fails: django.db.*)*

------
https://chatgpt.com/codex/tasks/task_e_68495be71ed0832c87eb2b35ccc6e228