### PR TITLE
Remove roles option from NPC review menu

### DIFF
--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -143,7 +143,6 @@ REVIEW_SECTIONS = [
     ("VNUM", "menunode_vnum"),
     ("Creature Type", "menunode_creature_type"),
     ("Combat Class", "menunode_combat_class"),
-    ("Roles", "menunode_roles"),
     ("Role Details", "menunode_role_details"),
     ("EXP Reward", "menunode_exp_reward"),
     ("Coin Drop", "menunode_coin_drop"),

--- a/typeclasses/tests/test_mob_builder.py
+++ b/typeclasses/tests/test_mob_builder.py
@@ -333,6 +333,7 @@ class TestMobBuilder(EvenniaTest):
         assert "Mob Prototype" in text
         desc_opt = next(o for o in opts if o.get("desc") == "Description")
         assert desc_opt["goto"] == "menunode_desc"
+        assert not any(o.get("desc") == "Roles" for o in opts)
 
         npc_builder._set_desc(self.char1, "A scary goblin")
         text, _ = npc_builder.menunode_review(self.char1)


### PR DESCRIPTION
## Summary
- simplify review options in NPC builder
- adjust tests for new menu

## Testing
- `pytest typeclasses/tests/test_mob_builder.py::TestMobBuilder::test_review_menu_and_edit -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68495febd318832ca8276c91b83c6f71