### PR TITLE
Fix NPC type mapping in mob builder

### DIFF
--- a/commands/mob_builder.py
+++ b/commands/mob_builder.py
@@ -68,7 +68,7 @@ class CmdMSpawn(Command):
                 if not proto:
                     self.msg("Prototype not found.")
                     return
-                tclass_path = npc_builder.NPC_CLASS_MAP.get(
+                tclass_path = npc_builder.NPC_TYPE_MAP.get(
                     proto.get("npc_type", "base"), "typeclasses.npcs.BaseNPC"
                 )
                 proto = dict(proto)
@@ -116,7 +116,7 @@ class CmdMobPreview(Command):
             if not proto:
                 self.msg("Prototype not found.")
                 return
-            tclass_path = npc_builder.NPC_CLASS_MAP.get(
+            tclass_path = npc_builder.NPC_TYPE_MAP.get(
                 proto.get("npc_type", "base"), "typeclasses.npcs.BaseNPC"
             )
             proto = dict(proto)


### PR DESCRIPTION
## Summary
- fix NPC type mapping for spawning and previewing mobs

## Testing
- `pytest -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684967db7fa8832c8b0c911b4a8c0ed0