### PR TITLE
Fix finalization of armor and initiative

### DIFF
--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -1935,8 +1935,10 @@ def finalize_mob_prototype(caller, npc):
         if not value:
             value = stats[attr]
         setattr(npc.db, attr, value)
-    npc.db.armor = stats["armor"]
-    npc.db.initiative = stats["initiative"]
+    if npc.db.armor is None:
+        npc.db.armor = stats["armor"]
+    if npc.db.initiative is None:
+        npc.db.initiative = stats["initiative"]
 
     from world.mobregistry import register_mob_vnum
 


### PR DESCRIPTION
## Summary
- don't overwrite armor or initiative when finalizing NPCs unless they aren't already defined

## Testing
- `pytest -q` *(fails: OperationalError - no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68496948a074832cafdd3be44fb53fc8