### PR TITLE
Add exit warning for unfinished NPC builder sessions

### DIFF
--- a/commands/cmdmobbuilder.py
+++ b/commands/cmdmobbuilder.py
@@ -163,7 +163,12 @@ class CmdMobProto(Command):
             return
         caller.ndb.buildnpc = dict(proto)
         caller.ndb.mob_vnum = vnum
-        EvMenu(caller, "commands.npc_builder", startnode="menunode_desc")
+        EvMenu(
+            caller,
+            "commands.npc_builder",
+            startnode="menunode_desc",
+            cmd_on_exit=npc_builder._on_menu_exit,
+        )
 
     def _sub_diff(self, rest: str):
         caller = self.caller

--- a/commands/medit.py
+++ b/commands/medit.py
@@ -26,4 +26,9 @@ class CmdMEdit(Command):
             proto = {"key": f"mob_{vnum}", "level": 1}
         caller.ndb.mob_vnum = vnum
         caller.ndb.buildnpc = dict(proto)
-        EvMenu(caller, "commands.npc_builder", startnode="menunode_desc")
+        EvMenu(
+            caller,
+            "commands.npc_builder",
+            startnode="menunode_desc",
+            cmd_on_exit=npc_builder._on_menu_exit,
+        )

--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -1871,6 +1871,15 @@ def _cancel(caller, raw_string, **kwargs):
     return None
 
 
+def _on_menu_exit(caller, menu):
+    """Warn user if menu exits with unsaved data."""
+    if getattr(caller.ndb, "buildnpc", None):
+        caller.msg(
+            "\u26A0\uFE0F You must choose ‘Yes & Save Prototype’ to make this NPC spawnable with @mspawn."
+        )
+        caller.ndb.buildnpc = None
+
+
 def _gather_npc_data(npc):
     """Return a dict of editable NPC attributes."""
     return {
@@ -1999,7 +2008,12 @@ class CmdCNPC(Command):
             }
             if use_mob:
                 self.caller.ndb.buildnpc["use_mob"] = True
-            EvMenu(self.caller, "commands.npc_builder", startnode="menunode_desc")
+            EvMenu(
+                self.caller,
+                "commands.npc_builder",
+                startnode="menunode_desc",
+                cmd_on_exit=_on_menu_exit,
+            )
             return
         if sub == "edit":
             if not rest:
@@ -2013,7 +2027,12 @@ class CmdCNPC(Command):
             self.caller.ndb.buildnpc = data
             if use_mob:
                 self.caller.ndb.buildnpc["use_mob"] = True
-            EvMenu(self.caller, "commands.npc_builder", startnode="menunode_desc")
+            EvMenu(
+                self.caller,
+                "commands.npc_builder",
+                startnode="menunode_desc",
+                cmd_on_exit=_on_menu_exit,
+            )
             return
         if sub == "dev_spawn":
             if not self.caller.check_permstring("Developer"):
@@ -2056,7 +2075,12 @@ class CmdEditNPC(Command):
             self.msg("Invalid NPC.")
             return
         self.caller.ndb.buildnpc = _gather_npc_data(npc)
-        EvMenu(self.caller, "commands.npc_builder", startnode="menunode_desc")
+        EvMenu(
+            self.caller,
+            "commands.npc_builder",
+            startnode="menunode_desc",
+            cmd_on_exit=_on_menu_exit,
+        )
 
 
 class CmdDeleteNPC(Command):

--- a/typeclasses/tests/test_editnpc_command.py
+++ b/typeclasses/tests/test_editnpc_command.py
@@ -17,7 +17,12 @@ class TestEditNPCCommand(EvenniaTest):
         npc = create.create_object(BaseNPC, key="orc", location=self.room1)
         with patch("commands.npc_builder.EvMenu") as mock_menu:
             self.char1.execute_cmd(f"@editnpc {npc.key}")
-            mock_menu.assert_called_with(self.char1, "commands.npc_builder", startnode="menunode_desc")
+            mock_menu.assert_called_with(
+                self.char1,
+                "commands.npc_builder",
+                startnode="menunode_desc",
+                cmd_on_exit=npc_builder._on_menu_exit,
+            )
             data = self.char1.ndb.buildnpc
             assert data["key"] == "orc"
 

--- a/typeclasses/tests/test_medit_command.py
+++ b/typeclasses/tests/test_medit_command.py
@@ -35,7 +35,10 @@ class TestMEditCommand(EvenniaTest):
         with patch("commands.npc_builder.EvMenu") as mock_menu:
             self.char1.execute_cmd("medit 5")
             mock_menu.assert_called_with(
-                self.char1, "commands.npc_builder", startnode="menunode_desc"
+                self.char1,
+                "commands.npc_builder",
+                startnode="menunode_desc",
+                cmd_on_exit=npc_builder._on_menu_exit,
             )
         data = self.char1.ndb.buildnpc
         assert data["key"] == "orc"

--- a/typeclasses/tests/test_mob_builder.py
+++ b/typeclasses/tests/test_mob_builder.py
@@ -38,7 +38,10 @@ class TestMobBuilder(EvenniaTest):
         with patch("commands.npc_builder.EvMenu") as mock_menu:
             self.char1.execute_cmd("mobbuilder start goblin")
         mock_menu.assert_called_with(
-            self.char1, "commands.npc_builder", startnode="menunode_desc"
+            self.char1,
+            "commands.npc_builder",
+            startnode="menunode_desc",
+            cmd_on_exit=npc_builder._on_menu_exit,
         )
         npc_builder._set_key(self.char1, "goblin")
         npc_builder._set_desc(self.char1, "A small goblin")
@@ -93,6 +96,15 @@ class TestMobBuilder(EvenniaTest):
     def test_cancel_then_back(self):
         """Cancellation should clear build data."""
         npc_builder._cancel(self.char1, "")
+        assert self.char1.ndb.buildnpc is None
+
+    def test_on_exit_warns_if_unsaved(self):
+        """_on_menu_exit should warn if build data remains."""
+        self.char1.ndb.buildnpc = {}
+        npc_builder._on_menu_exit(self.char1, None)
+        self.char1.msg.assert_called_with(
+            "\u26A0\uFE0F You must choose ‘Yes & Save Prototype’ to make this NPC spawnable with @mspawn."
+        )
         assert self.char1.ndb.buildnpc is None
 
     def test_summary_contains_sections(self):

--- a/typeclasses/tests/test_vnum_mobs.py
+++ b/typeclasses/tests/test_vnum_mobs.py
@@ -85,7 +85,10 @@ class TestVnumMobs(EvenniaTest):
         with patch("commands.cmdmobbuilder.EvMenu") as mock_menu:
             self.char1.execute_cmd("@mobproto edit 1")
         mock_menu.assert_called_with(
-            self.char1, "commands.npc_builder", startnode="menunode_desc"
+            self.char1,
+            "commands.npc_builder",
+            startnode="menunode_desc",
+            cmd_on_exit=npc_builder._on_menu_exit,
         )
         self.assertEqual(self.char1.ndb.mob_vnum, 1)
         self.assertEqual(self.char1.ndb.buildnpc["key"], "gob")


### PR DESCRIPTION
## Summary
- notify builders if they quit the NPC builder without saving
- pass `cmd_on_exit` into `EvMenu` calls to check for leftover data
- update tests for the new callback and add a test for the warning message

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684973484d98832cae8052089d97069d