### PR TITLE
Display spawn hint after saving NPC prototypes

### DIFF
--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -1861,6 +1861,10 @@ def _create_npc(caller, raw_string, register=False, **kwargs):
     else:
         caller.msg(f"NPC {npc.key} created.")
     finalize_mob_prototype(caller, npc)
+    if register and npc.db.vnum is not None:
+        caller.msg(
+            f"✅ Mob saved and registered as VNUM {npc.db.vnum}. Spawn with: @mspawn M{npc.db.vnum}"
+        )
     caller.ndb.buildnpc = None
     return None
 

--- a/typeclasses/tests/test_vnum_mobs.py
+++ b/typeclasses/tests/test_vnum_mobs.py
@@ -181,3 +181,20 @@ class TestVnumMobs(EvenniaTest):
             if o.is_typeclass(BaseNPC, exact=False)
         ]
         self.assertGreaterEqual(len(npcs), 2)
+
+    def test_saved_vnum_message(self):
+        """Building with Yes & Save Prototype should show spawn instructions."""
+        vnum = 30
+        self.char1.ndb.buildnpc = {
+            "key": "kobold",
+            "npc_type": "base",
+            "vnum": vnum,
+            "creature_type": "humanoid",
+            "combat_class": "Warrior",
+            "level": 1,
+        }
+        npc_builder._create_npc(self.char1, "", register=True)
+
+        out = "".join(call.args[0] for call in self.char1.msg.call_args_list)
+        self.assertIn(f"Mob saved and registered as VNUM {vnum}", out)
+        self.assertIn(f"@mspawn M{vnum}", out)


### PR DESCRIPTION
## Summary
- show a hint to spawn built NPCs after finalizing and saving
- test the new confirmation text when saving with a VNUM

## Testing
- `pytest -q` *(fails: OperationalError - no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6849757012bc832ca1bf1a773f984988