### PR TITLE
Handle unsaved prototypes in @spawnnpc

### DIFF
--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -3,7 +3,7 @@ from evennia.utils import make_iter, dedent
 from evennia import create_object
 from evennia.objects.models import ObjectDB
 from evennia.prototypes import spawner
-from utils.mob_proto import spawn_from_vnum
+from utils.mob_proto import spawn_from_vnum, get_prototype
 from evennia.prototypes.prototypes import PROTOTYPE_TAG_CATEGORY
 from typeclasses.characters import NPC
 from utils.slots import SLOT_ORDER
@@ -2156,7 +2156,15 @@ class CmdSpawnNPC(Command):
 
         proto = None
         if arg.isdigit():
-            obj = spawn_from_vnum(int(arg), location=self.caller.location)
+            vnum = int(arg)
+            proto = get_prototype(vnum)
+            if not proto:
+                if vnum_registry.validate_vnum(vnum, "npc"):
+                    self.msg("❌ Invalid VNUM. The prototype was never finalized or saved.")
+                else:
+                    self.msg("Unknown NPC prototype.")
+                return
+            obj = spawn_from_vnum(vnum, location=self.caller.location)
             if not obj:
                 self.msg("Unknown NPC prototype.")
                 return

--- a/typeclasses/tests/test_spawnnpc.py
+++ b/typeclasses/tests/test_spawnnpc.py
@@ -62,6 +62,15 @@ class TestSpawnNPCPrototype(EvenniaTest):
         self.assertIsNotNone(npc)
         self.assertTrue(npc.tags.has("merchant", category="npc_type"))
 
+    def test_vnum_not_finalized_message(self):
+        """Numeric VNUMs without prototypes should show a specific error."""
+        with patch("utils.mob_proto.spawn_from_vnum") as mock_spawn:
+            self.char1.execute_cmd("@spawnnpc 42")
+            mock_spawn.assert_not_called()
+        out = self.char1.msg.call_args[0][0]
+        self.assertIn("Invalid VNUM", out)
+        self.assertIn("never finalized", out)
+
 
 class TestAreaSpawnerCombatStats(EvenniaTest):
     def setUp(self):


### PR DESCRIPTION
## Summary
- mark missing prototypes with a clearer error message when spawning by VNUM
- test that VNUMs with no saved prototype show the new message

## Testing
- `pytest -k vnum_not_finalized_message -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684979ad86a8832cb79b6349b0ed63d9