### PR TITLE
Add finalized VNUMs list to @mlist

### DIFF
--- a/commands/README.md
+++ b/commands/README.md
@@ -82,7 +82,9 @@ spawned later with `@spawnnpc`. These commands help you manage the prototypes:
 * `@mlist [/room|/area] [filters]` – list prototypes or spawned NPCs. Results
   include a VNUM column when one is registered. Filters can include
   `class=<val>`, `race=<val>`, `role=<val>`, `tag=<val>`, `zone=<name>`, an area
-  name or a numeric/letter range.
+  name or a numeric/letter range. When called with no arguments the command
+  also displays a **Finalized VNUMs** section showing every VNUM stored in the
+  mob database.
 
 Example:
 

--- a/commands/mob_builder_commands.py
+++ b/commands/mob_builder_commands.py
@@ -403,7 +403,16 @@ class CmdMList(Command):
                 str(counts.get(key, 0)),
             )
 
-        self.msg(str(table))
+        lines = [str(table)]
+        if not (area or filter_by or rangestr or show_room or show_area):
+            finalized = sorted(mob_db.db.vnums)
+            lines.append("\n|wFinalized VNUMs|n")
+            if finalized:
+                lines.append(", ".join(str(v) for v in finalized))
+            else:
+                lines.append("None")
+
+        self.msg("\n".join(lines))
 
 
 class CmdMakeShop(Command):

--- a/typeclasses/tests/test_mlist_command.py
+++ b/typeclasses/tests/test_mlist_command.py
@@ -95,3 +95,24 @@ class TestMListCommand(EvenniaTest):
         out = self.char1.msg.call_args[0][0]
         assert "VNUM" in out
         assert "5" in out
+
+    def test_mlist_finalized_vnums_display(self):
+        from world.scripts.mob_db import get_mobdb
+
+        mob_db = get_mobdb()
+        mob_db.add_proto(12, {"key": "troll"})
+
+        self.char1.execute_cmd("@mlist")
+        out = self.char1.msg.call_args[0][0]
+        assert "Finalized VNUMs" in out
+        assert "12" in out
+
+    def test_finalized_vnums_hidden_with_args(self):
+        from world.scripts.mob_db import get_mobdb
+
+        mob_db = get_mobdb()
+        mob_db.add_proto(15, {"key": "troll"})
+
+        self.char1.execute_cmd("@mlist /room")
+        out = self.char1.msg.call_args[0][0]
+        assert "Finalized VNUMs" not in out


### PR DESCRIPTION
## Summary
- list finalized vnums when running `@mlist` with no arguments
- update command docs
- test that the new list appears only with no arguments

## Testing
- `pytest typeclasses/tests/test_mlist_command.py::TestMListCommand::test_mlist_finalized_vnums_display -q` *(fails: django.db.utils.OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68497bd91f78832cb8f1b8c547f52e43