### PR TITLE
Add Quick Mob command

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,18 @@ Example::
     @mspawn mob_goblin
     @mspawn M200001
 
+### Quick Mob
+
+`@quickmob <key> [template]` creates and registers a new mob from a predefined
+template in a single step. Templates are defined in
+`world.templates.mob_templates` and default to `warrior`. The command assigns
+the next free VNUM automatically so you can respawn the mob later with
+``@mspawn M<number>``.
+
+Example::
+
+    @quickmob goblin warrior
+
 ## Mob Prototype Manager
 
 `@mobproto` works with numeric VNUMs to store and spawn NPCs. Newly

--- a/commands/admin.py
+++ b/commands/admin.py
@@ -49,6 +49,7 @@ from .mob_builder import (
     CmdMStat,
     CmdMList,
     CmdMobTemplate,
+    CmdQuickMob,
 )
 from .medit import CmdMEdit
 from .cmdmobbuilder import CmdMobProto
@@ -1442,6 +1443,7 @@ class BuilderCmdSet(CmdSet):
         self.add(CmdDupNPC)
         self.add(CmdBuilderTypes)
         self.add(CmdMobTemplate)
+        self.add(CmdQuickMob)
         self.add(CmdMSpawn)
         self.add(CmdMobPreview)
         self.add(CmdMEdit)

--- a/commands/mob_builder.py
+++ b/commands/mob_builder.py
@@ -158,3 +158,36 @@ class CmdMobTemplate(Command):
         self.caller.ndb.buildnpc = self.caller.ndb.buildnpc or {}
         self.caller.ndb.buildnpc.update(data)
         self.msg(f"Template '{arg}' loaded into builder.")
+
+
+class CmdQuickMob(Command):
+    """Spawn and register a mob from a template in one step."""
+
+    key = "@quickmob"
+    locks = "cmd:perm(Builder)"
+    help_category = "Building"
+
+    def func(self):
+        from world.templates.mob_templates import get_template
+        from utils.mob_utils import assign_next_vnum
+
+        args = self.args.strip()
+        if not args:
+            self.msg("Usage: @quickmob <key> [template]")
+            return
+
+        parts = args.split(None, 1)
+        key = parts[0]
+        template = parts[1] if len(parts) > 1 else "warrior"
+
+        data = get_template(template)
+        if not data:
+            self.msg("Unknown template.")
+            return
+
+        vnum = assign_next_vnum("npc")
+
+        data = dict(data)
+        data.update({"key": key, "vnum": vnum, "use_mob": True})
+        self.caller.ndb.buildnpc = data
+        npc_builder._create_npc(self.caller, "", register=True)

--- a/typeclasses/tests/test_quickmob_command.py
+++ b/typeclasses/tests/test_quickmob_command.py
@@ -1,0 +1,54 @@
+from unittest.mock import MagicMock, patch
+from tempfile import TemporaryDirectory
+from pathlib import Path
+from unittest import mock
+
+from django.test import override_settings
+from django.conf import settings
+from evennia.utils.test_resources import EvenniaTest
+
+from commands.admin import BuilderCmdSet
+from world import prototypes
+from typeclasses.npcs import BaseNPC
+
+
+@override_settings(DEFAULT_HOME=None)
+class TestQuickMobCommand(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.char1.msg = MagicMock()
+        self.char1.cmdset.add_default(BuilderCmdSet)
+        self.tmp = TemporaryDirectory()
+        patcher1 = mock.patch.object(
+            settings,
+            "PROTOTYPE_NPC_FILE",
+            Path(self.tmp.name) / "npcs.json",
+        )
+        patcher2 = mock.patch.object(
+            settings,
+            "VNUM_REGISTRY_FILE",
+            Path(self.tmp.name) / "vnums.json",
+        )
+        self.addCleanup(self.tmp.cleanup)
+        self.addCleanup(patcher1.stop)
+        self.addCleanup(patcher2.stop)
+        patcher1.start()
+        patcher2.start()
+        if not hasattr(prototypes, "_normalize_proto"):
+            prototypes._normalize_proto = prototypes._legacy._normalize_proto
+
+    def test_quickmob_creates_and_spawns(self):
+        with patch("utils.mob_utils.assign_next_vnum", return_value=101) as mock_vnum:
+            self.char1.execute_cmd("@quickmob goblin")
+        mock_vnum.assert_called_with("npc")
+        reg = prototypes.get_npc_prototypes()
+        assert "mob_goblin" in reg
+        assert reg["mob_goblin"]["vnum"] == 101
+        npc = [o for o in self.char1.location.contents if o.is_typeclass(BaseNPC, exact=False)][0]
+        assert npc.key == "goblin"
+        assert npc.db.vnum == 101
+        self.char1.msg.reset_mock()
+        self.char1.execute_cmd("@mspawn M101")
+        msg = self.char1.msg.call_args[0][0]
+        assert "Spawned" in msg
+        assert any(o.db.vnum == 101 for o in self.char1.location.contents)

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -3049,6 +3049,25 @@ Notes:
 """,
     },
     {
+        "key": "@quickmob",
+        "category": "Building",
+        "text": """Help for @quickmob
+
+Create and register a simple mob using a predefined template. The mob is
+assigned the next free VNUM so it can be respawned later with
+``@mspawn M<number>``.
+
+Usage:
+    @quickmob <key> [template]
+
+Example:
+    @quickmob goblin warrior
+
+Notes:
+    - Templates are defined in ``world.templates.mob_templates``.
+""",
+    },
+    {
         "key": "@mobpreview",
         "category": "Building",
         "text": """Help for @mobpreview


### PR DESCRIPTION
## Summary
- implement `CmdQuickMob` for one-step mob creation
- register `CmdQuickMob` in the Builder cmdset
- document the new command in README and help entries
- test creating and spawning a quick mob

## Testing
- `evennia migrate --noinput`
- `pytest -q typeclasses/tests/test_quickmob_command.py`
- `pytest -q` *(fails: 131 failed, 78 passed)*

------
https://chatgpt.com/codex/tasks/task_e_684981112250832ca0854bf295aa7a0d