### PR TITLE
Add mobtemplate help entry and usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,8 @@ Choosing **Yes & Save Prototype** will also store the entry in
 specific fields such as act flags and resistances.
 If you assign a VNUM when saving, the prototype is automatically registered
 for use with ``@mspawn M<number>``.
+Before launching `cnpc` or `mobbuilder` you can pre-load a baseline with `@mobtemplate <template>`. This fills the builder with default stats for the chosen template. Run `@mobtemplate list` to view the available presets such as `warrior` and `caster`.
+
 
 Example::
 

--- a/typeclasses/tests/test_mobtemplate_command.py
+++ b/typeclasses/tests/test_mobtemplate_command.py
@@ -29,7 +29,9 @@ class TestMobTemplateCommand(EvenniaTest):
     def test_list_and_apply_template(self):
         self.char1.execute_cmd("@mobtemplate list")
         out = self.char1.msg.call_args[0][0]
+        assert "Available templates" in out
         assert "warrior" in out
+        assert "caster" in out
         self.char1.msg.reset_mock()
 
         self.char1.execute_cmd("@mobtemplate warrior")

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -3068,6 +3068,25 @@ Notes:
 """,
     },
     {
+        "key": "@mobtemplate",
+        "category": "Building",
+        "text": """Help for @mobtemplate
+
+Load a predefined mob template into the current build session.
+
+Usage:
+    @mobtemplate list
+    @mobtemplate <template>
+
+Example:
+    @mobtemplate warrior
+
+Notes:
+    - Templates are defined in ``world.templates.mob_templates``.
+    - Available templates include: warrior, caster.
+""",
+    },
+    {
         "key": "@mobpreview",
         "category": "Building",
         "text": """Help for @mobpreview


### PR DESCRIPTION
## Summary
- document how to preload NPC templates before running the mob builder
- add `@mobtemplate` help entry covering warrior and caster
- extend mobtemplate command test to verify help text listing

## Testing
- `pytest typeclasses/tests/test_mobtemplate_command.py::TestMobTemplateCommand::test_list_and_apply_template -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684984e8fcdc832cb40757847c643ccb