### PR TITLE
Add combat class entries to mob templates

### DIFF
--- a/typeclasses/tests/test_quickmob_command.py
+++ b/typeclasses/tests/test_quickmob_command.py
@@ -47,6 +47,8 @@ class TestQuickMobCommand(EvenniaTest):
         npc = [o for o in self.char1.location.contents if o.is_typeclass(BaseNPC, exact=False)][0]
         assert npc.key == "goblin"
         assert npc.db.vnum == 101
+        assert npc.db.charclass == "Warrior"
+        assert npc.db.hp > 0
         self.char1.msg.reset_mock()
         self.char1.execute_cmd("@mspawn M101")
         msg = self.char1.msg.call_args[0][0]

--- a/world/templates/mob_templates.py
+++ b/world/templates/mob_templates.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 MOB_TEMPLATES = {
     "warrior": {
         "level": 1,
+        "combat_class": "Warrior",
         "hp": 30,
         "mp": 0,
         "sp": 10,
@@ -14,6 +15,7 @@ MOB_TEMPLATES = {
     },
     "caster": {
         "level": 1,
+        "combat_class": "Mage",
         "hp": 20,
         "mp": 30,
         "sp": 5,


### PR DESCRIPTION
## Summary
- add combat class information to default mob templates
- extend quickmob test to ensure spawned mobs get combat stats

## Testing
- `evennia migrate`
- `pytest -k quickmob -q`

------
https://chatgpt.com/codex/tasks/task_e_684986e37598832c8d99d9774dc5def5