### PR TITLE
Fix prototype helper exports

### DIFF
--- a/world/prototypes/__init__.py
+++ b/world/prototypes/__init__.py
@@ -12,7 +12,12 @@ spec = spec_from_file_location("world._legacy_prototypes", _legacy_path)
 _legacy = module_from_spec(spec)
 spec.loader.exec_module(_legacy)
 
+if hasattr(_legacy, "_normalize_proto"):
+    _normalize_proto = _legacy._normalize_proto
+
 for _name in [n for n in dir(_legacy) if not n.startswith("_")]:
     globals()[_name] = getattr(_legacy, _name)
 
 __all__ = [n for n in globals() if not n.startswith("_")]
+if "_normalize_proto" in globals():
+    __all__.append("_normalize_proto")


### PR DESCRIPTION
## Summary
- export `_normalize_proto` from the legacy prototype module
- expose the helper in `__all__`

## Testing
- `pytest typeclasses/tests/test_quickmob_command.py::TestQuickMobCommand::test_quickmob_creates_and_spawns -q` *(fails: OperationalError: no such table)*

------
https://chatgpt.com/codex/tasks/task_e_6849886d5c2c832c9e1a7df5349086e2