### PR TITLE
Fix prototype helper exports

### DIFF
--- a/commands/medit.py
+++ b/commands/medit.py
@@ -2,6 +2,7 @@ from evennia.utils.evmenu import EvMenu
 from utils.prototype_manager import load_prototype
 from utils.vnum_registry import validate_vnum, register_vnum
 from .command import Command
+from . import npc_builder
 
 
 class CmdMEdit(Command):

--- a/world/prototypes/__init__.py
+++ b/world/prototypes/__init__.py
@@ -12,7 +12,12 @@ spec = spec_from_file_location("world._legacy_prototypes", _legacy_path)
 _legacy = module_from_spec(spec)
 spec.loader.exec_module(_legacy)
 
+if hasattr(_legacy, "_normalize_proto"):
+    _normalize_proto = _legacy._normalize_proto
+
 for _name in [n for n in dir(_legacy) if not n.startswith("_")]:
     globals()[_name] = getattr(_legacy, _name)
 
 __all__ = [n for n in globals() if not n.startswith("_")]
+if "_normalize_proto" in globals():
+    __all__.append("_normalize_proto")


### PR DESCRIPTION
## Summary
- export `_normalize_proto` from the legacy prototype module
- expose the helper in `__all__`
- import `npc_builder` in the `medit` command

## Testing
- `pytest typeclasses/tests/test_medit_command.py::TestMEditCommand::test_medit_opens_builder_with_proto -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6849886d5c2c832c9e1a7df5349086e2