### PR TITLE
Update AttackAction damage handling

### DIFF
--- a/combat/combat_actions.py
+++ b/combat/combat_actions.py
@@ -109,9 +109,9 @@ class AttackAction(Action):
         target = self.target
         if not target:
             return CombatResult(self.actor, self.actor, "No target.")
+        weapon = self.actor
         if utils.inherits_from(self.actor, "typeclasses.characters.Character"):
             weapon = self.actor.wielding[0] if self.actor.wielding else self.actor
-            weapon.at_attack(self.actor, target)
         dmg = 0
         dtype = DamageType.BLUDGEONING
         if hasattr(target, "hp"):


### PR DESCRIPTION
## Summary
- refactor `AttackAction.resolve` so damage is returned instead of applied
- adjust dummy class and combat flow tests for new behavior

## Testing
- `pytest -q typeclasses/tests/test_combat_flow.py::TestAttackAction::test_attack_deals_damage`
- `pytest -q typeclasses/tests/test_combat_flow.py`


------
https://chatgpt.com/codex/tasks/task_e_684992e82900832cac4b34b9ecef2364