### PR TITLE
Check for empty participants before scheduling next combat round

### DIFF
--- a/combat/combat_engine.py
+++ b/combat/combat_engine.py
@@ -483,4 +483,6 @@ class CombatEngine:
             self.track_aggro(result.target, actor)
         self.cleanup_environment()
         self.round += 1
+        if not self.participants:
+            return
         delay(random.uniform(1, max(1, self.round_time)), self.process_round)

--- a/typeclasses/tests/test_combat_engine.py
+++ b/typeclasses/tests/test_combat_engine.py
@@ -88,3 +88,18 @@ class TestCombatEngine(unittest.TestCase):
             self.assertEqual(b.db.exp, 4)
             msg_a.assert_called()
             msg_b.assert_called()
+
+    def test_engine_stops_when_empty(self):
+        a = Dummy()
+        a.traits.health = MagicMock(value=a.hp)
+        a.key = "dummy"
+        a.tags = MagicMock()
+        with patch('world.system.state_manager.apply_regen'), \
+             patch('evennia.utils.delay') as mock_delay, \
+             patch('random.randint', return_value=0):
+            engine = CombatEngine([a], round_time=0)
+            engine.queue_action(a, KillAction(a, a))
+            engine.start_round()
+            engine.process_round()
+            self.assertEqual(len(engine.participants), 0)
+            mock_delay.assert_not_called()


### PR DESCRIPTION
## Summary
- stop scheduling new combat rounds when no participants remain
- test that combat engine shuts down when empty

## Testing
- `pytest typeclasses/tests/test_combat_engine.py::TestCombatEngine::test_engine_stops_when_empty -q`
- `pytest -q` *(fails: 289 failed, 8 passed)*

------
https://chatgpt.com/codex/tasks/task_e_684997efa7c0832c9c14d7af24f555e5