### PR TITLE
Scale attack damage using stats

### DIFF
--- a/combat/combat_actions.py
+++ b/combat/combat_actions.py
@@ -116,6 +116,11 @@ class AttackAction(Action):
         dtype = DamageType.BLUDGEONING
         if hasattr(target, "hp"):
             dmg = getattr(weapon, "damage", 0)
+            # scale damage using attacker stats
+            str_val = state_manager.get_effective_stat(self.actor, "STR")
+            dex_val = state_manager.get_effective_stat(self.actor, "DEX")
+            # Formula: base_damage * (1 + STR*0.012 + DEX*0.004)
+            dmg = int(round(dmg * (1 + str_val * 0.012 + dex_val * 0.004)))
             dtype = getattr(weapon, "damage_type", DamageType.BLUDGEONING)
         return CombatResult(
             actor=self.actor,

--- a/typeclasses/tests/test_combat_flow.py
+++ b/typeclasses/tests/test_combat_flow.py
@@ -67,6 +67,35 @@ class TestAttackAction(unittest.TestCase):
         self.assertEqual(defender.hp, 5)
         weapon.at_attack.assert_not_called()
 
+    def test_attack_damage_scaled_by_stats(self):
+        attacker = Dummy()
+        defender = Dummy()
+        weapon = MagicMock()
+        weapon.damage = 5
+        weapon.damage_type = DamageType.SLASHING
+        weapon.at_attack = MagicMock()
+        attacker.wielding = [weapon]
+        attacker.location = defender.location
+
+        engine = CombatEngine([attacker, defender], round_time=0)
+        engine.queue_action(attacker, AttackAction(attacker, defender))
+        with patch("combat.combat_actions.utils.inherits_from", return_value=True), \
+             patch("world.system.state_manager.apply_regen"), \
+             patch("random.randint", return_value=0), \
+             patch("world.system.state_manager.get_effective_stat") as mock_get:
+            def getter(obj, stat):
+                if obj is attacker and stat == "STR":
+                    return 10
+                if obj is attacker and stat == "DEX":
+                    return 5
+                return 0
+
+            mock_get.side_effect = getter
+            engine.start_round()
+            engine.process_round()
+
+        self.assertEqual(defender.hp, 4)
+
 
 class TestCombatVictory(unittest.TestCase):
     def test_handle_defeat_removes_participant(self):


### PR DESCRIPTION
## Summary
- scale weapon damage in `AttackAction` by attacker STR/DEX
- document scaling formula
- test that STR/DEX affect attack damage

## Testing
- `pytest typeclasses/tests/test_combat_flow.py::TestAttackAction::test_attack_damage_scaled_by_stats -q`
- `pytest typeclasses/tests/test_combat_flow.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68499a671f8c832c8842a60558ef959f