### PR TITLE
Fix AttackAction.resolve indentation

### DIFF
--- a/combat/combat_actions.py
+++ b/combat/combat_actions.py
@@ -104,45 +104,45 @@ class AttackAction(Action):
 
     priority = 1
 
-def resolve(self) -> CombatResult:
-    """Carry out a basic weapon attack."""
-    target = self.target
-    if not target:
-        return CombatResult(self.actor, self.actor, "No target.")
+    def resolve(self) -> CombatResult:
+        """Carry out a basic weapon attack."""
+        target = self.target
+        if not target:
+            return CombatResult(self.actor, self.actor, "No target.")
     
-    weapon = self.actor
-    if utils.inherits_from(self.actor, "typeclasses.characters.Character"):
-        if self.actor.wielding:
-            weapon = self.actor.wielding[0]
-        elif getattr(self.actor.db, "natural_weapon", None):
-            # Use natural weapon stats when unarmed
-            weapon = self.actor.db.natural_weapon
-        else:
-            weapon = self.actor
+        weapon = self.actor
+        if utils.inherits_from(self.actor, "typeclasses.characters.Character"):
+            if self.actor.wielding:
+                weapon = self.actor.wielding[0]
+            elif getattr(self.actor.db, "natural_weapon", None):
+                # Use natural weapon stats when unarmed
+                weapon = self.actor.db.natural_weapon
+            else:
+                weapon = self.actor
 
-    dmg = 0
-    dtype = DamageType.BLUDGEONING
+        dmg = 0
+        dtype = DamageType.BLUDGEONING
 
-    if hasattr(target, "hp"):
-        if isinstance(weapon, dict):
-            dmg = weapon.get("damage", 0)
-            dtype = weapon.get("damage_type", DamageType.BLUDGEONING)
-        else:
-            dmg = getattr(weapon, "damage", 0)
-            dtype = getattr(weapon, "damage_type", DamageType.BLUDGEONING)
+        if hasattr(target, "hp"):
+            if isinstance(weapon, dict):
+                dmg = weapon.get("damage", 0)
+                dtype = weapon.get("damage_type", DamageType.BLUDGEONING)
+            else:
+                dmg = getattr(weapon, "damage", 0)
+                dtype = getattr(weapon, "damage_type", DamageType.BLUDGEONING)
 
-        # Scale damage using attacker's stats
-        str_val = state_manager.get_effective_stat(self.actor, "STR")
-        dex_val = state_manager.get_effective_stat(self.actor, "DEX")
-        dmg = int(round(dmg * (1 + str_val * 0.012 + dex_val * 0.004)))
+            # Scale damage using attacker's stats
+            str_val = state_manager.get_effective_stat(self.actor, "STR")
+            dex_val = state_manager.get_effective_stat(self.actor, "DEX")
+            dmg = int(round(dmg * (1 + str_val * 0.012 + dex_val * 0.004)))
 
-    return CombatResult(
-        actor=self.actor,
-        target=target,
-        message=f"{self.actor.key} strikes {target.key} for {dmg} damage!",
-        damage=dmg,
-        damage_type=dtype,
-    )
+        return CombatResult(
+            actor=self.actor,
+            target=target,
+            message=f"{self.actor.key} strikes {target.key} for {dmg} damage!",
+            damage=dmg,
+            damage_type=dtype,
+        )
 
 
 


### PR DESCRIPTION
## Summary
- indent AttackAction.resolve correctly so it overrides Action.resolve

## Testing
- `pytest typeclasses/tests/test_combat_flow.py::TestAttackAction::test_attack_deals_damage -q`
- `pytest typeclasses/tests/test_combat_flow.py -q` *(fails: fixture 'self' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849a3864a54832cbbfad7697e35d121