### PR TITLE
Fix auto attack default in combat engine

### DIFF
--- a/combat/combat_engine.py
+++ b/combat/combat_engine.py
@@ -442,7 +442,11 @@ class CombatEngine:
             actor = participant.actor
             if not hasattr(actor, "hp") or actor.hp <= 0:
                 continue
-            action = participant.next_action or AttackAction(actor, None)
+            if participant.next_action:
+                action = participant.next_action
+            else:
+                target = getattr(getattr(actor, "db", None), "combat_target", None)
+                action = AttackAction(actor, target)
             actions.append(
                 (
                     participant.initiative,

--- a/typeclasses/tests/test_combat_flow.py
+++ b/typeclasses/tests/test_combat_flow.py
@@ -154,3 +154,25 @@ class TestSpellExample(unittest.TestCase):
             engine.process_round()
         caster.cast_spell.assert_called_with("fireball", target)
 
+
+def test_auto_attack_uses_combat_target():
+    attacker = Dummy()
+    defender = Dummy(hp=2)
+    attacker.location = defender.location
+    attacker.db.natural_weapon = {"damage": 1, "damage_type": DamageType.BLUDGEONING}
+    attacker.db.combat_target = defender
+
+    engine = CombatEngine([attacker, defender], round_time=0)
+
+    with patch("combat.combat_actions.utils.inherits_from", return_value=True), \
+         patch("world.system.state_manager.apply_regen"), \
+         patch("world.system.state_manager.get_effective_stat", return_value=0), \
+         patch("evennia.utils.delay"), \
+         patch("random.randint", return_value=0):
+        engine.start_round()
+        engine.process_round()
+        assert defender.hp == 1
+
+        engine.process_round()
+        assert defender.hp == 0
+


### PR DESCRIPTION
## Summary
- queue AttackAction using db.combat_target when no action queued
- add combat test for NPC auto attack

## Testing
- `pytest -q typeclasses/tests/test_combat_flow.py::test_auto_attack_uses_combat_target`

------
https://chatgpt.com/codex/tasks/task_e_6849a4a38e98832c84864c7e16848db7