### PR TITLE
Fix CombatScript team handling

### DIFF
--- a/typeclasses/tests/test_combat_script.py
+++ b/typeclasses/tests/test_combat_script.py
@@ -1,0 +1,23 @@
+from unittest.mock import MagicMock
+from evennia.utils.test_resources import EvenniaTest
+
+
+class TestCombatVictory(EvenniaTest):
+    def test_victory_handles_missing_teams(self):
+        from typeclasses.scripts import CombatScript
+
+        self.room1.scripts.add(CombatScript, key="combat")
+        script = self.room1.scripts.get("combat")[0]
+        script.add_combatant(self.char1, enemy=self.char2)
+
+        # mark target as defeated
+        self.char2.tags.add("dead", category="status")
+
+        # corrupt the team data
+        script.db.teams = None
+        script.ndb.teams = None
+        script.delete = MagicMock()
+
+        # should not raise and should attempt to delete the script
+        script.check_victory()
+        script.delete.assert_called()


### PR DESCRIPTION
## Summary
- ensure CombatScript always has two team lists
- protect against missing team data in victory checks
- test CombatScript victory handling when teams missing

## Testing
- `pytest -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6849a617f494832c87298c1a7a15d9c5