### PR TITLE
Fix team cleanup after combatant removal

### DIFF
--- a/typeclasses/scripts.py
+++ b/typeclasses/scripts.py
@@ -142,9 +142,18 @@ class CombatScript(Script):
             teams = teams.deserialize()
         if 0 <= team < len(teams) and combatant in teams[team]:
             teams[team].remove(combatant)
-            self.db.teams = teams
-            # reset the cache
-            del self.ndb.teams
+
+        # ensure two proper list entries remain after the removal
+        if not isinstance(teams, list):
+            teams = [[], []]
+        else:
+            teams = [list(make_iter(t)) if t else [] for t in teams]
+            while len(teams) < 2:
+                teams.append([])
+
+        self.db.teams = teams
+        # reset the cache
+        del self.ndb.teams
 
         # grant exp to the other team, if relevant
         if exp := combatant.db.exp_reward:

--- a/typeclasses/tests/test_combat_script.py
+++ b/typeclasses/tests/test_combat_script.py
@@ -21,3 +21,19 @@ class TestCombatVictory(EvenniaTest):
         # should not raise and should attempt to delete the script
         script.check_victory()
         script.delete.assert_called()
+
+    def test_remove_all_combatants_preserves_team_structure(self):
+        """Removing everyone should leave two empty team lists."""
+        from typeclasses.scripts import CombatScript
+
+        self.room1.scripts.add(CombatScript, key="combat")
+        script = self.room1.scripts.get("combat")[0]
+        script.add_combatant(self.char1, enemy=self.char2)
+
+        script.delete = MagicMock()
+
+        for fighter in list(script.fighters):
+            script.remove_combatant(fighter)
+
+        self.assertEqual(script.db.teams, [[], []])
+        script.check_victory()


### PR DESCRIPTION
## Summary
- preserve combat team structure when removing fighters
- add regression test for removing all combatants

## Testing
- `pytest typeclasses/tests/test_combat_script.py::TestCombatVictory::test_remove_all_combatants_preserves_team_structure -vv --maxfail=1` *(fails: settings.DEFAULT_HOME does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6849a743b1a0832ca1fc398fe73d9c4e