### PR TITLE
Add cooldown validation to attack actions

### DIFF
--- a/combat/combat_actions.py
+++ b/combat/combat_actions.py
@@ -104,6 +104,12 @@ class AttackAction(Action):
 
     priority = 1
 
+    def validate(self) -> tuple[bool, str]:
+        """Check if the actor can attack this round."""
+        if hasattr(self.actor, "cooldowns") and not self.actor.cooldowns.ready("attack"):
+            return False, "Still recovering."
+        return super().validate()
+
     def resolve(self) -> CombatResult:
         """Carry out a basic weapon attack."""
         target = self.target

--- a/typeclasses/tests/test_action_cooldowns.py
+++ b/typeclasses/tests/test_action_cooldowns.py
@@ -1,0 +1,31 @@
+from evennia.utils import create
+from evennia.utils.test_resources import EvenniaTest
+
+from combat.combat_actions import AttackAction
+from typeclasses.npcs import BaseNPC
+from world.system import state_manager
+
+
+class TestAttackCooldowns(EvenniaTest):
+    def test_player_attack_respects_cooldown(self):
+        attacker = self.char1
+        defender = self.char2
+        attacker.location = self.room1
+        defender.location = self.room1
+        attacker.cooldowns.add("attack", 5)
+
+        action = AttackAction(attacker, defender)
+        valid, err = action.validate()
+        assert not valid
+        assert "recovering" in err.lower()
+
+    def test_npc_attack_respects_cooldown(self):
+        npc = create.create_object(BaseNPC, key="mob", location=self.room1)
+        target = self.char1
+        npc.cooldowns.add("attack", 5)
+
+        action = AttackAction(npc, target)
+        valid, err = action.validate()
+        assert not valid
+        assert "recovering" in err.lower()
+


### PR DESCRIPTION
## Summary
- ensure AttackAction.validate checks the actor's attack cooldown
- add tests verifying player and NPC attacks fail while recovering

## Testing
- `pytest -q` *(fails: django.db...)*

------
https://chatgpt.com/codex/tasks/task_e_6849a9c177bc832cb89ee33114912615