### PR TITLE
Handle melee damage dice

### DIFF
--- a/typeclasses/gear.py
+++ b/typeclasses/gear.py
@@ -124,7 +124,17 @@ class MeleeWeapon(Object):
         Use this weapon in an attack against a target.
         """
         # get the weapon's damage bonus
-        damage = self.db.dmg
+        damage = 0
+        if dice := getattr(self.db, "damage_dice", None):
+            try:
+                dice_num, dice_sides = map(int, str(dice).lower().split("d"))
+            except (TypeError, ValueError):
+                logger.log_err(f"Invalid damage_dice '{dice}' on {self}")
+                damage = int(self.db.dmg or 0)
+            else:
+                damage = combat_utils.roll_damage((dice_num, dice_sides))
+        else:
+            damage = int(self.db.dmg or 0)
         # pick a random option from our possible damage types
         damage_type = None
         if damage_types := self.tags.get(category="damage_type", return_list=True):

--- a/typeclasses/tests/test_objects_basic.py
+++ b/typeclasses/tests/test_objects_basic.py
@@ -199,3 +199,20 @@ class TestRoomHeaders(EvenniaTest):
         header = room.get_display_header(self.char1)
         self.assertIn("(2, 3, zone)", header)
 
+
+class TestMeleeWeaponAtAttack(EvenniaTest):
+    def test_damage_dice_only(self):
+        weapon = create_object(
+            "typeclasses.gear.MeleeWeapon", key="sword", location=self.char1
+        )
+        weapon.tags.add("equipment", category="flag")
+        weapon.tags.add("identified", category="flag")
+        weapon.db.damage_dice = "1d4"
+
+        self.char1.at_emote = MagicMock()
+        with patch("world.system.stat_manager.check_hit", return_value=False), patch(
+            "combat.combat_utils.roll_damage", return_value=2
+        ) as mock_roll:
+            weapon.at_attack(self.char1, self.char2)
+            mock_roll.assert_called_with((1, 4))
+


### PR DESCRIPTION
## Summary
- fix weapon damage when only `damage_dice` is set
- test: attack with damage_dice-only weapon no longer errors

## Testing
- `python -m py_compile typeclasses/gear.py typeclasses/tests/test_objects_basic.py`
- `pytest typeclasses/tests/test_objects_basic.py::TestMeleeWeaponAtAttack::test_damage_dice_only -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6849afe7f6f0832c9dc02e23de7a1059