### PR TITLE
Remove auto attack setting

### DIFF
--- a/commands/account.py
+++ b/commands/account.py
@@ -12,7 +12,7 @@ class CmdSettings(MuxCommand):
         settings <option> = <on/off>
 
     Example:
-        settings ansi = on
+        settings auto prompt = on
     """
 
     key = "settings"

--- a/commands/combat.py
+++ b/commands/combat.py
@@ -90,11 +90,6 @@ class CmdAttack(Command):
         # execute the actual attack
         self.caller.attack(target, weapon)
 
-        # check if we have auto-attack in settings
-        if self.account and (settings := self.account.db.settings):
-            if settings.get("auto attack"):
-                # let the player know we'll be auto-attacking
-                self.msg(f"[ Auto-attack is ON ]")
 
     def at_post_cmd(self):
         """

--- a/typeclasses/accounts.py
+++ b/typeclasses/accounts.py
@@ -98,7 +98,7 @@ class Account(ContribChargenAccount):
     def at_account_creation(self):
         super().at_account_creation()
         # Initialize game settings
-        self.db.settings = {"auto attack": True, "auto prompt": False}
+        self.db.settings = {"auto prompt": False}
 
 
 class Guest(DefaultGuest):

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -804,10 +804,7 @@ class Character(ObjectParent, ClothedCharacter):
         if self.sessions.count():
             self.refresh_prompt()
 
-        auto = True
-        if self.account and (settings := self.account.db.settings):
-            auto = settings.get("auto attack")
-        if auto and (speed := getattr(weapon, "speed", None)):
+        if speed := getattr(weapon, "speed", None):
             delay(speed + 1, self.attack, None, weapon, persistent=True)
 
         if hasattr(self, "check_triggers"):


### PR DESCRIPTION
## Summary
- remove `auto attack` from default account settings
- drop auto-attack messages and checks
- always schedule delayed attack when a weapon has speed
- tweak settings help text example

## Testing
- `pytest -q` *(fails: django.db... etc)*

------
https://chatgpt.com/codex/tasks/task_e_6849b12f141c832c9375285ad1261fda