### PR TITLE
Add NPC corpse drops

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -1,7 +1,7 @@
 from random import randint, choice
 from string import punctuation
 from evennia import AttributeProperty
-from evennia.utils import lazy_property, iter_to_str, delay, logger
+from evennia.utils import lazy_property, iter_to_str, delay, logger, create
 from evennia.contrib.rpg.traits import TraitHandler
 from evennia.contrib.game_systems.clothing.clothing import (
     ClothedCharacter,
@@ -1003,9 +1003,16 @@ class NPC(Character):
                     else:
                         entry["_count"] = count + 1
 
+            corpse = create.create_object(
+                "typeclasses.objects.Corpse",
+                key=f"{self.key} corpse",
+                location=self.location,
+            )
+            corpse.db.corpse_of = self.key
+
             objs = spawn(*drops)
             for obj in objs:
-                obj.location = self.location
+                obj.location = corpse
             # delete ourself
             self.delete()
             return dmg

--- a/typeclasses/objects.py
+++ b/typeclasses/objects.py
@@ -424,3 +424,17 @@ class CoinPile(Object):
         """Delete after being picked up if already deposited."""
         if self.db._deposited:
             self.delete()
+
+
+class Corpse(Object):
+    """A dead body left behind after a character dies."""
+
+    def at_object_creation(self):
+        super().at_object_creation()
+        self.locks.add("get:false()")
+        self.db.display_priority = "corpse"
+
+    def get_display_name(self, looker, **kwargs):
+        name = self.db.corpse_of or self.key or "corpse"
+        return f"the corpse of {name}"
+

--- a/typeclasses/tests/test_loot_table.py
+++ b/typeclasses/tests/test_loot_table.py
@@ -11,8 +11,17 @@ class TestNPCLootTable(EvenniaTest):
         npc.db.loot_table = [{"proto": "RAW_MEAT", "chance": 100}]
         npc.traits.health.current = 1
         with patch("evennia.prototypes.spawner.spawn", return_value=[MagicMock()]) as mock_spawn:
+            room = npc.location
             npc.at_damage(self.char1, 2)
             mock_spawn.assert_called_with("RAW_MEAT")
+
+            corpse = next(
+                obj
+                for obj in room.contents
+                if obj.is_typeclass("typeclasses.objects.Corpse", exact=False)
+            )
+            item = mock_spawn.return_value[0]
+            self.assertIs(item.location, corpse)
 
     def test_loot_table_guaranteed_after(self):
         from typeclasses.characters import NPC
@@ -30,4 +39,9 @@ class TestNPCLootTable(EvenniaTest):
             npc.traits.health.current = 1
             npc.at_damage(self.char1, 2)  # third kill, guaranteed drop
             mock_spawn.assert_called_with("RAW_MEAT")
+
+            item = mock_spawn.return_value[0]
+            self.assertTrue(
+                item.location.is_typeclass("typeclasses.objects.Corpse", exact=False)
+            )
 


### PR DESCRIPTION
## Summary
- create new `objects.Corpse` typeclass for storing loot from dead NPCs
- spawn a Corpse in NPC `at_damage` and move loot into the corpse
- update loot table tests to expect items inside the corpse

## Testing
- `pytest -q` *(fails: OperationalError no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6849b8ecfcd0832c918209c3caec0dee