### PR TITLE
Fix combat round scheduling

### DIFF
--- a/combat/combat_engine.py
+++ b/combat/combat_engine.py
@@ -496,4 +496,4 @@ class CombatEngine:
         self.round += 1
         if not self.participants:
             return
-        delay(random.uniform(1, max(1, self.round_time)), self.process_round)
+        delay(1, self.process_round)

--- a/typeclasses/tests/test_combat_engine.py
+++ b/typeclasses/tests/test_combat_engine.py
@@ -95,7 +95,7 @@ class TestCombatEngine(unittest.TestCase):
         a.key = "dummy"
         a.tags = MagicMock()
         with patch('world.system.state_manager.apply_regen'), \
-             patch('evennia.utils.delay') as mock_delay, \
+             patch('combat.combat_engine.delay') as mock_delay, \
              patch('random.randint', return_value=0):
             engine = CombatEngine([a], round_time=0)
             engine.queue_action(a, KillAction(a, a))
@@ -103,3 +103,17 @@ class TestCombatEngine(unittest.TestCase):
             engine.process_round()
             self.assertEqual(len(engine.participants), 0)
             mock_delay.assert_not_called()
+
+    def test_schedules_next_round(self):
+        a = Dummy()
+        b = Dummy()
+        with patch('world.system.state_manager.apply_regen'), \
+             patch('world.system.state_manager.get_effective_stat', return_value=0), \
+             patch('combat.combat_actions.utils.inherits_from', return_value=False), \
+             patch('combat.combat_engine.delay') as mock_delay, \
+             patch('random.randint', return_value=0):
+            engine = CombatEngine([a, b], round_time=0)
+            engine.start_round()
+            engine.process_round()
+            self.assertEqual(len(engine.participants), 2)
+            mock_delay.assert_called_with(1, engine.process_round)


### PR DESCRIPTION
## Summary
- use a fixed one-second delay between combat rounds
- ensure next round is scheduled exactly one second later

## Testing
- `pytest typeclasses/tests/test_combat_engine.py::TestCombatEngine::test_schedules_next_round -q`

------
https://chatgpt.com/codex/tasks/task_e_6849ba65a018832c9827080efded77f7