### PR TITLE
Send condition messages each combat round

### DIFF
--- a/combat/combat_engine.py
+++ b/combat/combat_engine.py
@@ -493,6 +493,20 @@ class CombatEngine:
                 self.award_experience(actor, result.target)
             self.track_aggro(result.target, actor)
         self.cleanup_environment()
+
+        if self.round_output:
+            msg = "\n".join(self.round_output)
+            room = None
+            if self.participants:
+                room = getattr(self.participants[0].actor, "location", None)
+            if room:
+                room.msg_contents(msg)
+            else:
+                for participant in self.participants:
+                    actor = participant.actor
+                    if hasattr(actor, "msg"):
+                        actor.msg(msg)
+
         self.round += 1
         if not self.participants:
             return


### PR DESCRIPTION
## Summary
- show condition messages to the room at the end of each round
- test that combat engine outputs the condition messages

## Testing
- `pytest -q` *(fails: OperationalError no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6849bb6759a4832c8a3b65e2ef53bbfb