### PR TITLE
Add contributor test setup instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,24 @@
+# Contributing
+
+Thank you for your interest in contributing!
+
+## Running the Test Suite
+
+Tests are executed with [`pytest`](https://docs.pytest.org/). They depend on
+[Django](https://www.djangoproject.com/) and the [Evennia](https://www.evennia.com/) framework.
+A helper requirements file is provided to install compatible versions of these
+packages.
+
+```bash
+python -m pip install --upgrade pip
+pip install -r requirements-test.txt
+pip install -e .
+```
+
+You can run `scripts/setup_test_env.sh` to perform these commands
+automatically. Once everything is installed, run the tests with:
+
+```bash
+pytest -q
+```
+

--- a/README.md
+++ b/README.md
@@ -368,7 +368,11 @@ three:
 ```bash
 python -m pip install --upgrade pip
 pip install -r requirements-test.txt
+# Install the project itself so tests can import it
+pip install -e .
 ```
+
+You can also run `scripts/setup_test_env.sh` to automate the above steps.
 
 After installing the dependencies, execute the tests with:
 

--- a/scripts/setup_test_env.sh
+++ b/scripts/setup_test_env.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Simple helper to install packages required for running the test suite.
+python -m pip install --upgrade pip
+pip install -r requirements-test.txt
+# Install this project in editable mode so tests can import it
+pip install -e .


### PR DESCRIPTION
## Summary
- document test dependencies in README
- describe test setup in CONTRIBUTING guide
- add setup script to quickly install packages for tests

## Testing
- `pytest -q` *(fails: Test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6849bcf7f5a8832ca3e1ba21ddb4b26b