### PR TITLE
Add final confirmation step to NPC builder

### DIFF
--- a/typeclasses/tests/test_mob_builder.py
+++ b/typeclasses/tests/test_mob_builder.py
@@ -296,9 +296,14 @@ class TestMobBuilder(EvenniaTest):
             "creature_type": "humanoid",
             "npc_type": "merchant",
         }
-        text, opts = npc_builder.menunode_confirm(self.char1)
+        text, opts = npc_builder.menunode_finalize(self.char1)
         labels = [o.get("desc") or o.get("key") for o in opts]
-        assert set(labels) == {"Yes", "Yes & Save Prototype", "No"}
+        assert set(labels) == {
+            "Yes & Save Prototype",
+            "Yes (Don't Save)",
+            "Edit Something",
+            "Cancel",
+        }
 
     def test_trigger_cancel_does_not_modify(self):
         """Back or skip should not alter trigger data."""


### PR DESCRIPTION
## Summary
- add a `menunode_finalize` step offering final creation choices
- direct the review screen to the finalize step
- mark saved prototypes and skip warning on menu exit
- update unit tests for the new finalize menu

## Testing
- `pytest -q` *(fails: OperationalError - no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6849c4f9af0c832cb44e8143fdd8ceb4