### PR TITLE
Implement on_death for NPCs

### DIFF
--- a/combat/combat_engine.py
+++ b/combat/combat_engine.py
@@ -360,6 +360,8 @@ class CombatEngine:
             target.on_exit_combat()
         if hasattr(target, "at_defeat"):
             target.at_defeat(attacker)
+        if hasattr(target, "on_death"):
+            target.on_death(attacker)
         self.update_pos(target)
         if attacker and attacker.location:
             attacker.location.msg_contents(


### PR DESCRIPTION
## Summary
- add on_death hooks for NPC characters to drop loot and award XP
- invoke target.on_death() from CombatEngine.handle_defeat
- unit test: killing an NPC via CombatEngine spawns corpse and grants experience

## Testing
- `pytest typeclasses/tests/test_combat_engine.py::TestCombatDeath::test_npc_death_creates_corpse_and_awards_xp -q` *(fails: django.db.utils.OperationalError: no such table)*
- `pytest typeclasses/tests/test_loot_table.py::TestNPCLootTable::test_loot_table_spawn -q` *(fails: django.db.utils.OperationalError: no such table)*

------
https://chatgpt.com/codex/tasks/task_e_6849cbd1980c832cbcf5e294e7ae84a7