### PR TITLE
Fix combat round delay

### DIFF
--- a/combat/combat_engine.py
+++ b/combat/combat_engine.py
@@ -515,4 +515,4 @@ class CombatEngine:
         self.round += 1
         if not self.participants:
             return
-        delay(1, self.process_round)
+        delay(self.round_time, self.process_round)

--- a/typeclasses/tests/test_combat_engine.py
+++ b/typeclasses/tests/test_combat_engine.py
@@ -118,7 +118,7 @@ class TestCombatEngine(unittest.TestCase):
             engine.start_round()
             engine.process_round()
             self.assertEqual(len(engine.participants), 2)
-            mock_delay.assert_called_with(1, engine.process_round)
+            mock_delay.assert_called_with(engine.round_time, engine.process_round)
 
     def test_condition_messages_broadcast(self):
         class DamageAction(Action):


### PR DESCRIPTION
## Summary
- use the configured `round_time` when scheduling next combat round
- update combat engine tests for variable delay

## Testing
- `pytest -q` *(fails: django.db.utils.OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6849d916f720832cba240d9f98c43400