### PR TITLE
Update condition ranges

### DIFF
--- a/combat/combat_utils.py
+++ b/combat/combat_utils.py
@@ -142,16 +142,16 @@ def get_condition_msg(hp: int, max_hp: int) -> str:
     """Return a short description of current health."""
 
     percent = hp * 100 // max_hp if max_hp else 0
-    if percent >= 100:
+    if percent >= 95:
         return "is in excellent condition."
-    if percent >= 75:
-        return "is slightly wounded."
-    if percent >= 50:
-        return "is wounded."
-    if percent >= 25:
-        return "is covered in blood."
-    if percent >= 10:
-        return "is badly injured."
+    if percent >= 80:
+        return "has a few scratches."
+    if percent >= 60:
+        return "has some wounds."
+    if percent >= 40:
+        return "has nasty wounds."
+    if percent >= 20:
+        return "is bleeding badly."
     if percent > 0:
-        return "is mortally wounded."
+        return "is in awful condition."
     return "is dead."

--- a/utils/tests/test_combat_utils.py
+++ b/utils/tests/test_combat_utils.py
@@ -101,10 +101,10 @@ class TestCombatUtils(EvenniaTest):
         from combat.combat_utils import get_condition_msg
 
         self.assertEqual(get_condition_msg(10, 10), "is in excellent condition.")
-        self.assertEqual(get_condition_msg(9, 10), "is slightly wounded.")
-        self.assertEqual(get_condition_msg(7, 10), "is wounded.")
-        self.assertEqual(get_condition_msg(5, 10), "is covered in blood.")
-        self.assertEqual(get_condition_msg(3, 10), "is badly injured.")
-        self.assertEqual(get_condition_msg(1, 10), "is mortally wounded.")
+        self.assertEqual(get_condition_msg(9, 10), "has a few scratches.")
+        self.assertEqual(get_condition_msg(7, 10), "has some wounds.")
+        self.assertEqual(get_condition_msg(5, 10), "has nasty wounds.")
+        self.assertEqual(get_condition_msg(3, 10), "is bleeding badly.")
+        self.assertEqual(get_condition_msg(1, 10), "is in awful condition.")
         self.assertEqual(get_condition_msg(0, 10), "is dead.")
 


### PR DESCRIPTION
## Summary
- change health description ranges in `get_condition_msg`
- update combat utils tests for new messages

## Testing
- `pytest -q` *(fails: OperationalError - no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6849da480b70832c88a1f871eea9c782