### PR TITLE
Ensure condition messages broadcast on misses

### DIFF
--- a/combat/combat_engine.py
+++ b/combat/combat_engine.py
@@ -485,6 +485,8 @@ class CombatEngine:
                 damage_done = self.apply_damage(actor, result.target, result.damage, dt)
                 if not result.message:
                     self.dam_message(actor, result.target, damage_done)
+
+            if result.target:
                 hp = getattr(getattr(result.target, "traits", None), "health", None)
                 cur = getattr(hp, "value", getattr(result.target, "hp", 0))
                 max_hp = getattr(hp, "max", getattr(result.target, "max_hp", cur))


### PR DESCRIPTION
## Summary
- broadcast current condition even if attacks miss
- test for message broadcasts on hit and miss

## Testing
- `pytest typeclasses/tests/test_combat_engine.py::TestCombatEngine::test_condition_messages_broadcast -q`
- `pytest -q` *(fails: utils/tests/test_parse_stat_mods.py::TestParseStatMods::test_invalid_mod_format, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6849dfca9a20832caa172354f6a6b930