### PR TITLE
Adjust combat and AI pacing

### DIFF
--- a/scripts/npc_ai_script.py
+++ b/scripts/npc_ai_script.py
@@ -8,7 +8,7 @@ class NPCAIScript(Script):
     """Periodically call :func:`process_ai` for the attached NPC."""
 
     def at_script_creation(self):
-        self.interval = 10
+        self.interval = 1
         self.persistent = True
 
     def at_repeat(self):

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -806,7 +806,7 @@ class Character(ObjectParent, ClothedCharacter):
             self.refresh_prompt()
 
         if speed := getattr(weapon, "speed", None):
-            delay(speed + 1, self.attack, None, weapon, persistent=True)
+            delay(speed, self.attack, None, weapon, persistent=True)
 
         if hasattr(self, "check_triggers"):
             self.check_triggers("on_attack", target=target, weapon=weapon)


### PR DESCRIPTION
## Summary
- make weapon speed delays exact rather than with +1
- shorten NPC AI script interval to 1 second

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6849e411db50832c8d57f2ab500870bd