### PR TITLE
Add combat condition messaging

### DIFF
--- a/typeclasses/gear.py
+++ b/typeclasses/gear.py
@@ -76,6 +76,12 @@ class BareHand:
             )
             dealt = target.at_damage(wielder, damage, "bludgeon", critical=crit)
             combat_utils.apply_lifesteal(wielder, dealt)
+            hp = getattr(getattr(target, "traits", None), "health", None)
+            cur = getattr(hp, "value", getattr(target, "hp", 0))
+            max_hp = getattr(hp, "max", getattr(target, "max_hp", cur))
+            condition = combat_utils.get_condition_msg(cur, max_hp)
+            if wielder.location:
+                wielder.location.msg_contents(f"The {target.key} {condition}")
             if status := getattr(self, "status_effect", None):
                 effect, chance = status
                 if stat_manager.roll_status(wielder, target, int(chance)):
@@ -184,6 +190,12 @@ class MeleeWeapon(Object):
             )
             dealt = target.at_damage(wielder, damage, damage_type, critical=crit)
             combat_utils.apply_lifesteal(wielder, dealt)
+            hp = getattr(getattr(target, "traits", None), "health", None)
+            cur = getattr(hp, "value", getattr(target, "hp", 0))
+            max_hp = getattr(hp, "max", getattr(target, "max_hp", cur))
+            condition = combat_utils.get_condition_msg(cur, max_hp)
+            if wielder.location:
+                wielder.location.msg_contents(f"The {target.key} {condition}")
             if status := getattr(self.db, "status_effect", None):
                 effect, chance = status
                 if stat_manager.roll_status(wielder, target, int(chance)):

--- a/typeclasses/tests/test_attack_condition_messages.py
+++ b/typeclasses/tests/test_attack_condition_messages.py
@@ -1,0 +1,69 @@
+from unittest.mock import MagicMock, patch
+
+from evennia.utils.test_resources import EvenniaTest
+from evennia.utils import create
+
+from combat.combat_utils import get_condition_msg
+from typeclasses.gear import BareHand
+
+
+class TestAttackConditionMessages(EvenniaTest):
+    """Ensure condition messages broadcast after attacks."""
+
+    def setUp(self):
+        super().setUp()
+        # ensure room messages can be inspected
+        self.room1.msg_contents = MagicMock()
+        self.char1.location = self.room1
+        self.char2.location = self.room1
+
+    def _simple_damage(self, attacker, target, amount, **kwargs):
+        target.traits.health.current -= amount
+        return amount
+
+    def _expect_condition_message(self, target):
+        expected = get_condition_msg(
+            target.traits.health.current, target.traits.health.max
+        )
+        calls = [c.args[0] for c in self.room1.msg_contents.call_args_list]
+        self.assertTrue(any(f"The {target.key} {expected}" in msg for msg in calls))
+
+    def test_barehand_condition(self):
+        self.char2.at_damage = self._simple_damage
+        with patch("world.system.stat_manager.check_hit", return_value=True), patch(
+            "combat.combat_utils.roll_evade",
+            return_value=False,
+        ), patch("combat.combat_utils.roll_parry", return_value=False), patch(
+            "combat.combat_utils.roll_block",
+            return_value=False,
+        ), patch("world.system.stat_manager.roll_crit", return_value=False), patch(
+            "combat.combat_utils.apply_attack_power",
+            side_effect=lambda w, d: d,
+        ), patch("combat.combat_utils.apply_lifesteal"):
+            BareHand().at_attack(self.char1, self.char2)
+
+        self._expect_condition_message(self.char2)
+
+    def test_melee_weapon_condition(self):
+        weapon = create.create_object(
+            "typeclasses.gear.MeleeWeapon", key="sword", location=self.char1
+        )
+        weapon.tags.add("equipment", category="flag")
+        weapon.tags.add("identified", category="flag")
+        weapon.db.dmg = 1
+        self.char2.at_damage = self._simple_damage
+
+        with patch("world.system.stat_manager.check_hit", return_value=True), patch(
+            "combat.combat_utils.roll_evade",
+            return_value=False,
+        ), patch("combat.combat_utils.roll_parry", return_value=False), patch(
+            "combat.combat_utils.roll_block",
+            return_value=False,
+        ), patch("world.system.stat_manager.roll_crit", return_value=False), patch(
+            "combat.combat_utils.apply_attack_power",
+            side_effect=lambda w, d: d,
+        ), patch("combat.combat_utils.apply_lifesteal"):
+            weapon.at_attack(self.char1, self.char2)
+
+        self._expect_condition_message(self.char2)
+


### PR DESCRIPTION
## Summary
- report target condition after barehand and melee attacks
- test that condition messages broadcast correctly

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6849e5828124832cabedbcf9344cec7c