### PR TITLE
Update combat round handling

### DIFF
--- a/combat/combat_engine.py
+++ b/combat/combat_engine.py
@@ -28,7 +28,7 @@ class CombatEngine:
     def __init__(
         self,
         participants: Iterable[object] | None = None,
-        round_time: int = 2,
+        round_time: int = 0,
         use_initiative: bool = True,
     ):
         """Create a new combat engine instance.
@@ -38,7 +38,8 @@ class CombatEngine:
         participants
             Optional iterable of initial combatants.
         round_time
-            Seconds between each combat round.
+            Delay between combat rounds in seconds. Defaults to ``0`` which
+            immediately begins the next round after the previous one resolves.
         use_initiative
             If ``True`` initiative rolls determine action order.
         """
@@ -517,4 +518,4 @@ class CombatEngine:
         self.round += 1
         if not self.participants:
             return
-        delay(self.round_time, self.process_round)
+        delay(0, self.process_round)

--- a/typeclasses/tests/test_combat_engine.py
+++ b/typeclasses/tests/test_combat_engine.py
@@ -126,7 +126,7 @@ class TestCombatEngine(unittest.TestCase):
             engine.start_round()
             engine.process_round()
             self.assertEqual(len(engine.participants), 2)
-            mock_delay.assert_called_with(engine.round_time, engine.process_round)
+            mock_delay.assert_called_with(0, engine.process_round)
 
     def test_condition_messages_broadcast(self):
         class DamageAction(Action):


### PR DESCRIPTION
## Summary
- begin the next combat round immediately
- test updated to check for zero-delay scheduling

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6849e8e74f4c832c9b313efeb44bf266