### PR TITLE
Fix guard patrol random exit usage

### DIFF
--- a/scripts/guard_patrol.py
+++ b/scripts/guard_patrol.py
@@ -30,4 +30,5 @@ class GuardPatrol(Script):
         else:
             exits = npc.location.contents_get(content_type="exit")
             if exits:
-                choice(exits).at_traverse(npc, exits[0].destination)
+                exit_obj = choice(exits)
+                exit_obj.at_traverse(npc, exit_obj.destination)


### PR DESCRIPTION
## Summary
- ensure `GuardPatrol` script uses the destination from the chosen exit when roaming randomly

## Testing
- `pytest -q` *(fails: django.db errors)*

------
https://chatgpt.com/codex/tasks/task_e_6849eb819598832cb20ff90bd216ffa8