### PR TITLE
Fix attack eligibility

### DIFF
--- a/commands/combat.py
+++ b/commands/combat.py
@@ -69,9 +69,11 @@ class CmdAttack(Command):
         if not target:
             # no valid match
             return
-        if not target.db.can_attack:
+        if target.db.can_attack is False:
             # this isn't something you can attack
-            self.msg(f"You can't attack {target.get_display_name(self.caller)}.")
+            self.msg(
+                f"You can't attack {target.get_display_name(self.caller)}."
+            )
             return
 
         # if we were trying to flee, cancel that

--- a/typeclasses/tests/test_attack_command.py
+++ b/typeclasses/tests/test_attack_command.py
@@ -1,0 +1,21 @@
+from unittest.mock import MagicMock
+from django.test import override_settings
+from evennia.utils import create
+from evennia.utils.test_resources import EvenniaTest
+from typeclasses.npcs import BaseNPC
+from commands.combat import CombatCmdSet
+
+
+@override_settings(DEFAULT_HOME=None)
+class TestAttackCommand(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.char1.msg = MagicMock()
+        self.char1.attack = MagicMock()
+        self.char1.cmdset.add_default(CombatCmdSet)
+
+    def test_attack_without_can_attack(self):
+        mob = create.create_object(BaseNPC, key="mob", location=self.room1)
+        self.char1.execute_cmd("attack mob")
+        self.assertEqual(self.char1.db.combat_target, mob)
+        self.char1.attack.assert_called()


### PR DESCRIPTION
## Summary
- let missing `can_attack` attribute default to allow attacks
- test that `attack` works without `can_attack`

## Testing
- `evennia migrate --noinput`
- `pytest -q` *(fails: 71 failed, 56 passed, 14 warnings, 1 error)*

------
https://chatgpt.com/codex/tasks/task_e_684a638f656c832c8a3ec50249209347