### PR TITLE
Add CombatNPC typeclass

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,9 @@ The builder lets you choose an NPC type such as `merchant`, `banker`,
 `trainer`, `wanderer` or `combatant`. These map to the typeclasses under
 `typeclasses.npcs`. When you select the `combatant` type you'll be asked
 for a combat class from `world.scripts.classes`; this sets
-`npc.db.charclass` on the spawned NPC.
+`npc.db.charclass` on the spawned NPC. Combatants use the
+`typeclasses.npcs.combat.CombatNPC` class which automatically sets
+`npc.db.can_attack = True`.
 
 While editing, there's a step to manage triggers using a numbered menu. Choose
 `Add trigger` to create a new reaction, `Delete trigger` to remove one, `List

--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -95,6 +95,7 @@ NPC_TYPE_MAP = {
     "guildmaster": "typeclasses.npcs.guildmaster.GuildmasterNPC",
     "guild_receptionist": "typeclasses.npcs.guild_receptionist.GuildReceptionistNPC",
     "questgiver": "typeclasses.npcs.questgiver.QuestGiverNPC",
+    "combatant": "typeclasses.npcs.combat.CombatNPC",
     "combat_trainer": "typeclasses.npcs.combat_trainer.CombatTrainerNPC",
     "event_npc": "typeclasses.npcs.event_npc.EventNPC",
 }

--- a/typeclasses/npcs/__init__.py
+++ b/typeclasses/npcs/__init__.py
@@ -21,6 +21,7 @@ from .wanderer import WandererNPC  # noqa: E402
 from .guildmaster import GuildmasterNPC  # noqa: E402
 from .guild_receptionist import GuildReceptionistNPC  # noqa: E402
 from .questgiver import QuestGiverNPC  # noqa: E402
+from .combat import CombatNPC  # noqa: E402
 from .combat_trainer import CombatTrainerNPC  # noqa: E402
 from .event_npc import EventNPC  # noqa: E402
 
@@ -33,6 +34,7 @@ __all__ = [
     "GuildmasterNPC",
     "GuildReceptionistNPC",
     "QuestGiverNPC",
+    "CombatNPC",
     "CombatTrainerNPC",
     "EventNPC",
 ]

--- a/typeclasses/npcs/combat.py
+++ b/typeclasses/npcs/combat.py
@@ -1,0 +1,12 @@
+"""Combat-ready NPC typeclass."""
+
+from . import BaseNPC
+
+
+class CombatNPC(BaseNPC):
+    """NPC that can engage in combat by default."""
+
+    def at_object_creation(self):
+        super().at_object_creation()
+        self.db.can_attack = True
+


### PR DESCRIPTION
## Summary
- implement `CombatNPC` typeclass that enables attacking
- expose CombatNPC in `typeclasses.npcs`
- update npc builder to use CombatNPC for combatants
- document combatant NPCs in README

## Testing
- `scripts/setup_test_env.sh` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: 397 failed, 1 error)*

------
https://chatgpt.com/codex/tasks/task_e_684a65bb5ac4832cbb4d92bce856b11e