### PR TITLE
Update mob builder docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ If you assign a VNUM when saving, the prototype is automatically registered
 for use with ``@mspawn M<number>``.
 Before launching `cnpc` or `mobbuilder` you can pre-load a baseline with `@mobtemplate <template>`. This fills the builder with default stats for the chosen template. Run `@mobtemplate list` to view the available presets such as `warrior` and `caster`.
 
+Only NPCs with `can_attack` set to `True` can be attacked. The new `CombatNPC` class (used for the `combatant` type) sets this flag automatically so mobs are immediately ready for battle.
 
 Example::
 


### PR DESCRIPTION
## Summary
- note that only NPCs with `can_attack` true can be attacked
- mention CombatNPC automatically sets this flag

## Testing
- `pytest -q` *(fails: django.db errors)*
- `scripts/setup_test_env.sh` *(fails: network access)*

------
https://chatgpt.com/codex/tasks/task_e_684a676438bc832ca0fa5b85bba2008e