### PR TITLE
Implement auto attack combat hook

### DIFF
--- a/typeclasses/npcs/combat.py
+++ b/typeclasses/npcs/combat.py
@@ -10,3 +10,15 @@ class CombatNPC(BaseNPC):
         super().at_object_creation()
         self.db.can_attack = True
 
+    def at_combat_turn(self, target):
+        """Hook called each combat round by the combat engine."""
+        if not getattr(self.db, "auto_attack_enabled", False):
+            return
+        if not target:
+            return
+        engine = getattr(getattr(self, "ndb", None), "combat_engine", None)
+        if engine:
+            from combat.combat_actions import AttackAction
+
+            engine.queue_action(self, AttackAction(self, target))
+


### PR DESCRIPTION
## Summary
- add an `at_combat_turn` hook for NPC combat behavior
- track combat engine on participants
- call `at_combat_turn` before actions resolve
- test automatic attack queuing

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684a699b770c832c95bee9d06ba2f70e