### PR TITLE
Add base stat helper

### DIFF
--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -27,7 +27,7 @@ from utils.menu_utils import (
 )
 from world.scripts import classes
 from utils import vnum_registry
-from utils.mob_utils import calculate_combat_stats, mobprogs_to_triggers
+from utils.mob_utils import generate_base_stats, mobprogs_to_triggers
 from world.triggers import TriggerManager
 from .command import Command
 from django.conf import settings
@@ -84,7 +84,7 @@ def _auto_fill_combat_stats(data: dict) -> None:
     level = data.get("level")
     if not combat_class or not level:
         return
-    stats = calculate_combat_stats(combat_class, level)
+    stats = generate_base_stats(combat_class, level)
     for field in ("hp", "mp", "sp", "armor", "initiative"):
         data.setdefault(field, stats[field])
 
@@ -2026,7 +2026,7 @@ def finalize_mob_prototype(caller, npc):
         return
 
     npc.db.charclass = npc.db.combat_class
-    stats = calculate_combat_stats(npc.db.combat_class, npc.db.level)
+    stats = generate_base_stats(npc.db.combat_class, npc.db.level)
     for attr, trait in (("hp", "health"), ("mp", "mana"), ("sp", "stamina")):
         value = getattr(npc.traits.get(trait), "base", 0)
         if not value:

--- a/typeclasses/tests/test_cnpc.py
+++ b/typeclasses/tests/test_cnpc.py
@@ -228,7 +228,7 @@ class TestCNPC(EvenniaTest):
         npc.traits.mana.base = 0
         npc.traits.stamina.base = 0
         npc_builder.finalize_mob_prototype(self.char1, npc)
-        stats = npc_builder.calculate_combat_stats("Warrior", 3)
+        stats = npc_builder.generate_base_stats("Warrior", 3)
         self.assertEqual(npc.db.hp, stats["hp"])
         self.assertEqual(npc.db.mp, stats["mp"])
         self.assertEqual(npc.db.sp, stats["sp"])

--- a/typeclasses/tests/test_mob_builder.py
+++ b/typeclasses/tests/test_mob_builder.py
@@ -84,7 +84,7 @@ class TestMobBuilder(EvenniaTest):
         assert npc is not None
         assert npc.is_typeclass(BaseNPC, exact=False)
         assert npc.db.charclass == "Warrior"
-        stats = npc_builder.calculate_combat_stats("Warrior", 1)
+        stats = npc_builder.generate_base_stats("Warrior", 1)
         assert npc.db.hp == 10
         assert npc.db.mp == stats["mp"]
         assert npc.db.sp == stats["sp"]

--- a/typeclasses/tests/test_vnum_mobs.py
+++ b/typeclasses/tests/test_vnum_mobs.py
@@ -65,7 +65,7 @@ class TestVnumMobs(EvenniaTest):
         }
         vnum = register_prototype(proto, vnum=3)
         npc = spawn_from_vnum(vnum, location=self.char1.location)
-        stats = npc_builder.calculate_combat_stats("Warrior", 2)
+        stats = npc_builder.generate_base_stats("Warrior", 2)
         self.assertEqual(npc.db.hp, stats["hp"])
         self.assertEqual(npc.db.mp, stats["mp"])
         self.assertEqual(npc.db.sp, stats["sp"])

--- a/utils/mob_utils.py
+++ b/utils/mob_utils.py
@@ -14,6 +14,7 @@ __all__ = [
     "auto_calc_secondary",
     "assign_next_vnum",
     "add_to_mlist",
+    "generate_base_stats",
     "calculate_combat_stats",
     "mobprogs_to_triggers",
 ]
@@ -29,22 +30,23 @@ def add_to_mlist(vnum: int, prototype: Dict) -> None:
     get_mobdb().add_proto(int(vnum), dict(prototype))
 
 
-def calculate_combat_stats(combat_class: str, level: int) -> Dict[str, int]:
-    """Return base combat stats for ``combat_class`` at ``level``."""
+def generate_base_stats(class_name: str, level: int) -> Dict[str, int]:
+    """Return default combat stats for ``class_name`` at ``level``."""
+
     base = int(level) * 10
+    lower = class_name.lower()
     return {
         "hp": base,
-        "mp": base // 2
-        if combat_class.lower() in ("wizard", "sorcerer", "mage", "necromancer")
-        else base // 4,
-        "sp": base // 2
-        if combat_class.lower() in ("warrior", "rogue", "swashbuckler")
-        else base // 3,
-        "armor": level * 2
-        if combat_class.lower() in ("warrior", "paladin")
-        else level,
+        "mp": base // 2 if lower in ("wizard", "sorcerer", "mage", "necromancer") else base // 4,
+        "sp": base // 2 if lower in ("warrior", "rogue", "swashbuckler") else base // 3,
+        "armor": level * 2 if lower in ("warrior", "paladin") else level,
         "initiative": 10 + level // 2,
     }
+
+
+def calculate_combat_stats(combat_class: str, level: int) -> Dict[str, int]:
+    """Return base combat stats for ``combat_class`` at ``level``."""
+    return generate_base_stats(combat_class, level)
 
 
 def auto_calc(primary_stats: Dict[str, int]) -> Dict[str, int]:


### PR DESCRIPTION
## Summary
- implement `generate_base_stats` in utils
- call new helper in npc builder code
- update tests for new helper

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684a6f17df88832c9fbec1bdec528086