### PR TITLE
Add NPCType enum

### DIFF
--- a/commands/mob_builder.py
+++ b/commands/mob_builder.py
@@ -68,11 +68,14 @@ class CmdMSpawn(Command):
                 if not proto:
                     self.msg("Prototype not found.")
                     return
-                tclass_path = npc_builder.NPC_TYPE_MAP.get(
-                    proto.get("npc_type", "base"), "typeclasses.npcs.BaseNPC"
+                tclass = npc_builder.NPC_TYPE_MAP.get(
+                    npc_builder.NPCType.from_str(proto.get("npc_type", "base")),
+                    npc_builder.BaseNPC,
                 )
                 proto = dict(proto)
-                proto.setdefault("typeclass", tclass_path)
+                proto.setdefault(
+                    "typeclass", f"{tclass.__module__}.{tclass.__name__}"
+                )
                 obj = spawner.spawn(proto)[0]
                 obj.move_to(self.caller.location, quiet=True)
                 if proto.get("vnum"):
@@ -116,11 +119,14 @@ class CmdMobPreview(Command):
             if not proto:
                 self.msg("Prototype not found.")
                 return
-            tclass_path = npc_builder.NPC_TYPE_MAP.get(
-                proto.get("npc_type", "base"), "typeclasses.npcs.BaseNPC"
+            tclass = npc_builder.NPC_TYPE_MAP.get(
+                npc_builder.NPCType.from_str(proto.get("npc_type", "base")),
+                npc_builder.BaseNPC,
             )
             proto = dict(proto)
-            proto.setdefault("typeclass", tclass_path)
+            proto.setdefault(
+                "typeclass", f"{tclass.__module__}.{tclass.__name__}"
+            )
             obj = spawner.spawn(proto)[0]
             obj.move_to(self.caller.location, quiet=True)
         delay(30, obj.delete)

--- a/world/mob_constants.py
+++ b/world/mob_constants.py
@@ -41,6 +41,22 @@ class NPC_SIZES(_StrEnum):
     LARGE = "large"
 
 
+class NPCType(_StrEnum):
+    """Archetype identifiers for NPCs."""
+
+    BASE = "base"
+    MERCHANT = "merchant"
+    BANKER = "banker"
+    TRAINER = "trainer"
+    WANDERER = "wanderer"
+    GUILDMASTER = "guildmaster"
+    GUILD_RECEPTIONIST = "guild_receptionist"
+    QUESTGIVER = "questgiver"
+    COMBATANT = "combatant"
+    COMBAT_TRAINER = "combat_trainer"
+    EVENT_NPC = "event_npc"
+
+
 
 
 
@@ -168,6 +184,7 @@ __all__ = [
     "NPC_GENDERS",
     "NPC_SEXES",
     "NPC_SIZES",
+    "NPCType",
     "NPC_CLASSES",
     "ACTFLAGS",
     "AFFECTED_BY",


### PR DESCRIPTION
## Summary
- define `NPCType` enum for available NPC types
- use `NPCType` in `NPC_TYPE_MAP` and builder logic
- update mob builder to parse prototype types with the new enum

## Testing
- `pytest -q` *(fails: django.db errors and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_684a73d47dbc832c93c5e57eca99f254