### PR TITLE
Fix NPC type selection menu

### DIFF
--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -707,8 +707,7 @@ def _set_npc_type(caller, raw_string, **kwargs):
             npc_type = NPCType.from_str(string)
         except ValueError:
             caller.msg(
-                "Invalid class. Choose from: "
-                + ", ".join(t.value for t in NPC_TYPE_MAP)
+                f"Invalid NPC type. Choose from: {', '.join(t.value for t in NPCType)}"
             )
             return "menunode_npc_type"
     if npc_type not in NPC_TYPE_MAP:


### PR DESCRIPTION
## Summary
- correct NPC type prompt in the builder

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684a760227c0832c9972883b773f42fd