### PR TITLE
Handle unfinished VNUMs in @mspawn

### DIFF
--- a/commands/mob_builder.py
+++ b/commands/mob_builder.py
@@ -46,8 +46,14 @@ class CmdMSpawn(Command):
             vnum = int(arg[1:])
 
         if vnum is not None:
-            if not vnum_registry.validate_vnum(vnum, "npc") and not get_prototype(vnum):
-                self.msg("Invalid VNUM.")
+            proto = get_prototype(vnum)
+            if not proto:
+                if vnum_registry.validate_vnum(vnum, "npc"):
+                    self.msg(
+                        f"Prototype {vnum} not finalized. Use editnpc {vnum} and finalize with 'Yes & Save'."
+                    )
+                else:
+                    self.msg("Invalid VNUM.")
                 return
             obj = spawn_from_vnum(vnum, location=self.caller.location)
             if not obj:

--- a/typeclasses/tests/test_vnum_mobs.py
+++ b/typeclasses/tests/test_vnum_mobs.py
@@ -198,3 +198,12 @@ class TestVnumMobs(EvenniaTest):
         out = "".join(call.args[0] for call in self.char1.msg.call_args_list)
         self.assertIn(f"Mob saved and registered as VNUM {vnum}", out)
         self.assertIn(f"@mspawn M{vnum}", out)
+
+    def test_mspawn_not_finalized_message(self):
+        """Valid VNUMs without prototypes should show a helpful error."""
+        with patch("utils.mob_proto.spawn_from_vnum") as mock_spawn:
+            self.char1.execute_cmd("@mspawn 42")
+            mock_spawn.assert_not_called()
+        out = self.char1.msg.call_args[0][0]
+        self.assertIn("not finalized", out)
+        self.assertIn("editnpc 42", out)


### PR DESCRIPTION
## Summary
- check for valid but unfinished VNUMs in @mspawn
- add test covering new warning

## Testing
- `pytest -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684a7d477bfc832c9b547577798c4980