### PR TITLE
Improve NPC listing and edit feedback

### DIFF
--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -3011,7 +3011,9 @@ List NPC prototypes or counts of spawned NPCs. Prototypes are read from
 You may filter results with ``class=<name>``, ``race=<name>``,
 ``role=<name>``, ``tag=<tag>`` or ``zone=<area>``. Use ``/room`` to count
 NPCs present in your current room or ``/area`` for the entire area. The
-table shows columns for VNUM, Key, Level, Class, Roles and Count.
+table shows columns for VNUM, Key, Status, Level, Class, Primary Role,
+Roles and Count. Finalized prototypes display a ``✅`` in the Status
+column.
 
 Usage:
     @mlist [area] [/room|/area] [filters]


### PR DESCRIPTION
## Summary
- show finalized status in `@mlist`
- display primary role and finalization info in `@editnpc`
- document table column changes

## Testing
- `black commands/mob_builder_commands.py commands/npc_builder.py world/help_entries.py`
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684a7f0a35d4832ca741ab3ba35dc7f0