### PR TITLE
Validate VNUMs against area ranges

### DIFF
--- a/commands/builder_types.py
+++ b/commands/builder_types.py
@@ -19,6 +19,14 @@ def builder_cnpc_prompt(caller, name):
         caller.msg("Cancelled.")
         return
     vnum = vnum_registry.get_next_vnum("npc")
+    area = caller.location.db.area if caller.location else None
+    if area:
+        from world.areas import get_area_vnum_range
+
+        rng = get_area_vnum_range(area)
+        if rng and not (rng[0] <= vnum <= rng[1]):
+            caller.msg(f"VNUM {vnum} outside {area} range {rng[0]}-{rng[1]}")
+            return
     npc = create_object("typeclasses.npcs.BaseNPC", key=name, location=caller.location)
     npc.db.desc = desc
     npc.db.race = race
@@ -37,9 +45,9 @@ def builder_cnpc_prompt(caller, name):
         "vnum": vnum,
     }
     prototypes.register_npc_prototype(name, proto)
-    mob_proto.register_prototype(proto, vnum=vnum)
-    if caller.location and caller.location.db.area:
-        area_npcs.add_area_npc(caller.location.db.area, name)
+    mob_proto.register_prototype(proto, vnum=vnum, area=area)
+    if area:
+        area_npcs.add_area_npc(area, name)
     caller.msg(f"NPC {name} created with VNUM {vnum}.")
 
 

--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -1960,11 +1960,22 @@ def _create_npc(caller, raw_string, register=False, **kwargs):
         if data.get("script"):
             proto["scripts"] = [data["script"]]
         prototypes.register_npc_prototype(proto_key, proto)
-        if data.get("vnum") is not None:
-            from world.scripts.mob_db import get_mobdb
-
-            get_mobdb().add_proto(data["vnum"], proto)
         area = caller.location.db.area
+        if data.get("vnum") is not None:
+            try:
+                mob_proto.register_prototype(proto, vnum=data["vnum"], area=area)
+            except ValueError:
+                if area:
+                    from world.areas import get_area_vnum_range
+
+                    rng = get_area_vnum_range(area)
+                    if rng:
+                        caller.msg(
+                            f"VNUM {data['vnum']} outside {area} range {rng[0]}-{rng[1]}"
+                        )
+                        return None
+                caller.msg("Invalid VNUM for prototype.")
+                return None
         if area:
             from world import area_npcs
 

--- a/utils/mob_proto.py
+++ b/utils/mob_proto.py
@@ -8,14 +8,26 @@ from evennia.prototypes import spawner
 from world.scripts.mob_db import get_mobdb
 from .vnum_registry import get_next_vnum, register_vnum, validate_vnum
 from world import prototypes
+from world.areas import get_area_vnum_range
 
 
-def register_prototype(data: dict, vnum: int | None = None) -> int:
-    """Register ``data`` in the mob database under ``vnum``."""
+def register_prototype(data: dict, vnum: int | None = None, *, area: str | None = None) -> int:
+    """Register ``data`` in the mob database under ``vnum``.
+
+    If ``area`` is given, ``vnum`` must fall within that area's range.
+    """
     mob_db = get_mobdb()
     if vnum is None:
         vnum = get_next_vnum("npc")
+        if area:
+            rng = get_area_vnum_range(area)
+            if rng and not (rng[0] <= vnum <= rng[1]):
+                raise ValueError("VNUM outside area range")
     else:
+        if area:
+            rng = get_area_vnum_range(area)
+            if rng and not (rng[0] <= vnum <= rng[1]):
+                raise ValueError("VNUM outside area range")
         if not validate_vnum(vnum, "npc"):
             raise ValueError("Invalid or already used VNUM")
         register_vnum(vnum)

--- a/world/areas.py
+++ b/world/areas.py
@@ -95,3 +95,11 @@ def find_area(name: str) -> tuple[int, Optional[Area]]:
     return -1, None
 
 
+def get_area_vnum_range(name: str) -> Optional[tuple[int, int]]:
+    """Return the allowed VNUM range for ``name`` if the area exists."""
+    _, area = find_area(name)
+    if area:
+        return area.start, area.end
+    return None
+
+


### PR DESCRIPTION
## Summary
- add `get_area_vnum_range` helper in `world/areas`
- validate optional area range in `utils.mob_proto.register_prototype`
- check range when using `builder types` helper
- enforce area range on prototypes saved via NPC builder

## Testing
- `pytest -q` *(fails: OperationalError - no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684a837463d0832c912da6e0db38a35b