### PR TITLE
Area-aware VNUM allocation

### DIFF
--- a/commands/mob_builder.py
+++ b/commands/mob_builder.py
@@ -181,7 +181,7 @@ class CmdQuickMob(Command):
 
     def func(self):
         from world.templates.mob_templates import get_template
-        from utils.mob_utils import assign_next_vnum
+        from utils import vnum_registry
 
         args = self.args.strip()
         if not args:
@@ -197,7 +197,14 @@ class CmdQuickMob(Command):
             self.msg("Unknown template.")
             return
 
-        vnum = assign_next_vnum("npc")
+        area = self.caller.location.db.area if self.caller.location else None
+        if area:
+            try:
+                vnum = vnum_registry.get_next_vnum_for_area(area, "npc")
+            except Exception:
+                vnum = vnum_registry.get_next_vnum("npc")
+        else:
+            vnum = vnum_registry.get_next_vnum("npc")
 
         data = dict(data)
         data.update({"key": key, "vnum": vnum, "use_mob": True})

--- a/commands/mob_builder_commands.py
+++ b/commands/mob_builder_commands.py
@@ -167,7 +167,15 @@ class CmdMCreate(Command):
                 self.msg("Copy prototype not found.")
                 return
             proto = dict(proto)
+        from utils import vnum_registry
+
         proto["key"] = self.new_key
+        area = self.caller.location.db.area if self.caller.location else None
+        if area:
+            try:
+                proto["vnum"] = vnum_registry.get_next_vnum_for_area(area, "npc")
+            except Exception:
+                pass
         prototypes.register_npc_prototype(self.new_key, proto)
         self.msg(f"Prototype {self.new_key} created.")
 

--- a/typeclasses/tests/test_mcreate_command.py
+++ b/typeclasses/tests/test_mcreate_command.py
@@ -31,3 +31,11 @@ class TestMCreateCommand(EvenniaTest):
         self.char1.execute_cmd("@mcreate orc")
         reg = prototypes.get_npc_prototypes()
         assert "orc" in reg
+
+    def test_mcreate_assigns_vnum_in_area(self):
+        self.char1.location.set_area("town", 1)
+        with mock.patch("utils.vnum_registry.get_next_vnum_for_area", return_value=55) as mock_vnum:
+            self.char1.execute_cmd("@mcreate gob")
+        mock_vnum.assert_called_with("town", "npc")
+        reg = prototypes.get_npc_prototypes()
+        assert reg["gob"]["vnum"] == 55

--- a/typeclasses/tests/test_quickmob_command.py
+++ b/typeclasses/tests/test_quickmob_command.py
@@ -38,9 +38,10 @@ class TestQuickMobCommand(EvenniaTest):
             prototypes._normalize_proto = prototypes._legacy._normalize_proto
 
     def test_quickmob_creates_and_spawns(self):
-        with patch("utils.mob_utils.assign_next_vnum", return_value=101) as mock_vnum:
+        self.char1.location.set_area("town", 1)
+        with patch("utils.vnum_registry.get_next_vnum_for_area", return_value=101) as mock_vnum:
             self.char1.execute_cmd("@quickmob goblin")
-        mock_vnum.assert_called_with("npc")
+        mock_vnum.assert_called_with("town", "npc")
         reg = prototypes.get_npc_prototypes()
         assert "mob_goblin" in reg
         assert reg["mob_goblin"]["vnum"] == 101

--- a/utils/tests/test_vnum_registry.py
+++ b/utils/tests/test_vnum_registry.py
@@ -1,0 +1,37 @@
+import json
+from unittest import mock
+from tempfile import TemporaryDirectory
+from pathlib import Path
+
+import django
+from django.conf import settings
+from django.test import override_settings
+from evennia.utils.test_resources import EvenniaTest
+
+from utils import vnum_registry
+
+
+@override_settings(DEFAULT_HOME=None)
+class TestVnumRegistry(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.tmp = TemporaryDirectory()
+        patcher = mock.patch.object(
+            settings,
+            "VNUM_REGISTRY_FILE",
+            Path(self.tmp.name) / "vnums.json",
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        self.addCleanup(self.tmp.cleanup)
+
+    def test_next_vnum_for_area(self):
+        with mock.patch("world.areas.get_area_vnum_range", return_value=(100, 105)):
+            val1 = vnum_registry.get_next_vnum_for_area("town", "npc")
+            self.assertEqual(val1, 100)
+            val2 = vnum_registry.get_next_vnum_for_area("town", "npc")
+            self.assertEqual(val2, 101)
+            data = json.load(open(Path(self.tmp.name) / "vnums.json"))
+            self.assertIn(100, data["npc"]["used"])
+            self.assertIn(101, data["npc"]["used"])
+


### PR DESCRIPTION
## Summary
- add `get_next_vnum_for_area` in `vnum_registry` for area range aware allocation
- assign VNUMs by area in `@quickmob` and `@mcreate`
- test new helper and command behaviour

## Testing
- `pytest -q` *(fails: django.db.utils.OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684a851a420c832c9f9d0515c1bec8fa