### PR TITLE
Add @medit command for VNUM mob editing

### DIFF
--- a/commands/admin.py
+++ b/commands/admin.py
@@ -51,7 +51,8 @@ from .mob_builder import (
     CmdMobTemplate,
     CmdQuickMob,
 )
-from .medit import CmdMEdit
+from .medit import CmdMEdit as CmdMEditMenu
+from .mob_builder_commands import CmdMEdit
 from .cmdmobbuilder import CmdMobProto
 from .nextvnum import CmdNextVnum
 from .builder_types import CmdBuilderTypes
@@ -1446,6 +1447,7 @@ class BuilderCmdSet(CmdSet):
         self.add(CmdQuickMob)
         self.add(CmdMSpawn)
         self.add(CmdMobPreview)
+        self.add(CmdMEditMenu)
         self.add(CmdMEdit)
         self.add(CmdMCreate)
         self.add(CmdMSet)

--- a/typeclasses/tests/test_medit_proto_command.py
+++ b/typeclasses/tests/test_medit_proto_command.py
@@ -1,0 +1,48 @@
+from unittest.mock import MagicMock
+from tempfile import TemporaryDirectory
+from pathlib import Path
+from unittest import mock
+
+from django.test import override_settings
+from django.conf import settings
+from evennia.utils.test_resources import EvenniaTest
+
+from commands.admin import BuilderCmdSet
+from utils.mob_proto import register_prototype, get_prototype
+
+
+@override_settings(DEFAULT_HOME=None)
+class TestMEditProto(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.char1.msg = MagicMock()
+        self.char1.cmdset.add_default(BuilderCmdSet)
+        self.tmp = TemporaryDirectory()
+        patcher1 = mock.patch.object(
+            settings,
+            "PROTOTYPE_NPC_FILE",
+            Path(self.tmp.name) / "npcs.json",
+        )
+        patcher2 = mock.patch.object(
+            settings,
+            "VNUM_REGISTRY_FILE",
+            Path(self.tmp.name) / "vnums.json",
+        )
+        self.addCleanup(self.tmp.cleanup)
+        self.addCleanup(patcher1.stop)
+        self.addCleanup(patcher2.stop)
+        patcher1.start()
+        patcher2.start()
+
+    def test_medit_sets_field(self):
+        register_prototype({"key": "orc"}, vnum=5)
+        self.char1.execute_cmd("@medit 5 level 3")
+        self.assertEqual(get_prototype(5)["level"], 3)
+
+    def test_medit_shows_summary(self):
+        register_prototype({"key": "orc", "level": 2}, vnum=7)
+        self.char1.msg.reset_mock()
+        self.char1.execute_cmd("@medit 7")
+        out = self.char1.msg.call_args[0][0]
+        self.assertIn("orc", out)
+        self.assertIn("2", out)


### PR DESCRIPTION
## Summary
- add `CmdMEdit` for editing VNUM mob prototypes
- expose the command in the builder cmdset
- test editing VNUM prototypes with `@medit`

## Testing
- `pytest -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684a88a250ec832c874db962b1a3f672