### PR TITLE
Add scheduling for hour and time triggers

### DIFF
--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -3286,7 +3286,9 @@ Events:
     on_attack  - combat starts or damage occurs
     on_timer   - once every game tick
     hour       - fires at a specific game hour
+    hour_prog  - alias of hour
     time       - fires at an exact HH:MM time
+    time_prog  - alias of time
 
 Reactions:
     say <text>         - speak
@@ -3384,6 +3386,7 @@ Examples:
     leave_prog         - someone leaves
     sleep_prog         - someone sleeps here
     time_prog <hour>   - at a specific game hour
+    hour_prog <hour>   - alias of time_prog
     rand_prog <pct>    - random chance
     speech_prog <txt>  - hears someone speak <txt>
 


### PR DESCRIPTION
## Summary
- add aliases for `hour_prog` and update `time_prog`
- provide helpers to fire hour/time triggers by game clock
- document new trigger events

## Testing
- `pytest -q` *(fails: OperationalError - could not install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684a8a804788832c976f7fca11d11273