### PR TITLE
Add equipment and shop fields to mob templates

### DIFF
--- a/commands/mob_builder.py
+++ b/commands/mob_builder.py
@@ -9,6 +9,7 @@ from evennia.utils import delay
 from world import prototypes
 from typeclasses.characters import NPC
 from . import npc_builder
+from copy import deepcopy
 
 from .command import Command
 from .mob_builder_commands import CmdMStat as _OldMStat, CmdMList as _OldMList
@@ -168,7 +169,8 @@ class CmdMobTemplate(Command):
             self.msg("Unknown template.")
             return
         self.caller.ndb.buildnpc = self.caller.ndb.buildnpc or {}
-        self.caller.ndb.buildnpc.update(data)
+        for key, val in data.items():
+            self.caller.ndb.buildnpc[key] = deepcopy(val)
         self.msg(f"Template '{arg}' loaded into builder.")
 
 

--- a/typeclasses/tests/test_mobtemplate_command.py
+++ b/typeclasses/tests/test_mobtemplate_command.py
@@ -32,9 +32,17 @@ class TestMobTemplateCommand(EvenniaTest):
         assert "Available templates" in out
         assert "warrior" in out
         assert "caster" in out
+        assert "merchant" in out
         self.char1.msg.reset_mock()
 
         self.char1.execute_cmd("@mobtemplate warrior")
         data = self.char1.ndb.buildnpc
         assert data["hp"] == 30
         assert "aggressive" in data.get("actflags", [])
+        assert "IRON_SWORD" in data.get("equipment", [])
+
+    def test_template_with_shop(self):
+        self.char1.execute_cmd("@mobtemplate merchant")
+        data = self.char1.ndb.buildnpc
+        assert data.get("shop")
+        assert data.get("equipment")

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -3087,7 +3087,7 @@ Example:
 
 Notes:
     - Templates are defined in ``world.templates.mob_templates``.
-    - Available templates include: warrior, caster.
+    - Available templates include: warrior, caster, merchant.
 """,
     },
     {

--- a/world/templates/mob_templates.py
+++ b/world/templates/mob_templates.py
@@ -12,6 +12,7 @@ MOB_TEMPLATES = {
         "primary_stats": {"STR": 4, "CON": 3, "DEX": 3, "INT": 1, "WIS": 1, "LUCK": 1},
         "actflags": ["aggressive"],
         "skills": ["slash"],
+        "equipment": ["IRON_SWORD", "IRON_HAUBERK", "LEATHER_BOOTS"],
     },
     "caster": {
         "level": 1,
@@ -22,6 +23,22 @@ MOB_TEMPLATES = {
         "primary_stats": {"STR": 1, "CON": 2, "DEX": 2, "INT": 4, "WIS": 4, "LUCK": 1},
         "spells": ["magic missile"],
         "actflags": ["sentinel"],
+        "equipment": ["IRON_DAGGER", "WOOL_TUNIC", "WOOL_LEGGINGS"],
+    },
+    "merchant": {
+        "level": 1,
+        "npc_type": "merchant",
+        "roles": ["merchant"],
+        "ai_type": "passive",
+        "actflags": ["sentinel"],
+        "equipment": ["WOOL_TUNIC", "WOOL_LEGGINGS"],
+        "shop": {
+            "buy_percent": 100,
+            "sell_percent": 100,
+            "hours": "0-24",
+            "item_types": ["weapon", "armor"],
+        },
+        "merchant_markup": 1.0,
     },
 }
 


### PR DESCRIPTION
## Summary
- add optional equipment and shop data to default mob templates
- support deep-copying template fields in `@mobtemplate`
- document new template in help entries
- test for new template data

## Testing
- `pytest typeclasses/tests/test_mobtemplate_command.py::TestMobTemplateCommand::test_list_and_apply_template -q` *(fails: django.db.utils.OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684a8caeb16c832cac27e12890983af2