### PR TITLE
Fix missing traits in stat helpers

### DIFF
--- a/typeclasses/tests/test_stat_manager.py
+++ b/typeclasses/tests/test_stat_manager.py
@@ -264,3 +264,8 @@ class TestBonusPersistence(EvenniaTest):
 
         self.assertFalse(self.char1.db.equip_bonuses)
         self.assertFalse(any(itm == item for itm in self.char1.db.equipment.values()))
+
+    def test_effective_stat_handles_objects_without_traits(self):
+        obj = create.create_object("typeclasses.objects.Object", key="rock")
+        self.assertEqual(stat_manager.get_effective_stat(obj, "STR"), 0)
+        self.assertEqual(state_manager.get_effective_stat(obj, "STR"), 0)

--- a/world/stats.py
+++ b/world/stats.py
@@ -126,8 +126,12 @@ def apply_stats(chara):
 def sum_bonus(obj, stat_key: str) -> int:
     """Return the total value of a stat, including bonuses."""
     total = 0
-    if (trait := obj.traits.get(stat_key)):
-        total += trait.value
+    traits = getattr(obj, "traits", None)
+    trait_get = getattr(traits, "get", None)
+    if callable(trait_get):
+        trait = trait_get(stat_key)
+        if trait:
+            total += trait.value
     # allow bonuses stored directly on the character
     if hasattr(obj, "attributes"):
         total += obj.attributes.get(f"{stat_key}_bonus", default=0)

--- a/world/system/stat_manager.py
+++ b/world/system/stat_manager.py
@@ -387,10 +387,18 @@ def refresh_stats(obj) -> None:
 
 
 def get_effective_stat(obj, key: str) -> int:
-    """Return ``key`` value including temporary bonuses."""
+    """Return ``key`` value including temporary bonuses.
+
+    Gracefully handles objects without the trait system by
+    falling back to ``0`` for missing values.
+    """
     base = 0
-    if trait := obj.traits.get(key):
-        base = trait.value
+    traits = getattr(obj, "traits", None)
+    trait_get = getattr(traits, "get", None)
+    if callable(trait_get):
+        trait = trait_get(key)
+        if trait:
+            base = trait.value
     bonus_get = getattr(getattr(obj, "db", None), "get", None)
     if callable(bonus_get):
         try:

--- a/world/system/state_manager.py
+++ b/world/system/state_manager.py
@@ -156,6 +156,9 @@ def get_temp_bonus(chara, stat: str) -> int:
 
 def get_effective_stat(chara, stat: str) -> int:
     """Return ``stat`` value including temporary bonuses."""
+    if not hasattr(chara, "traits"):
+        return 0
+
     base = stats.sum_bonus(chara, stat)
     base += get_temp_bonus(chara, stat)
     base += get_effect_mods(chara).get(stat, 0)


### PR DESCRIPTION
## Summary
- avoid AttributeError when calling stat helpers on objects without `traits`
- test that stat helpers return `0` for plain objects

## Testing
- `black -q world/system/stat_manager.py world/stats.py world/system/state_manager.py typeclasses/tests/test_stat_manager.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684a900c4a34832cb153549134f43b6b