### PR TITLE
Improve prototype validation when spawning NPCs

### DIFF
--- a/commands/cmdmobbuilder.py
+++ b/commands/cmdmobbuilder.py
@@ -124,7 +124,11 @@ class CmdMobProto(Command):
             else:
                 caller.msg("Invalid room.")
                 return
-        npc = spawn_from_vnum(vnum, location=location)
+        try:
+            npc = spawn_from_vnum(vnum, location=location)
+        except ValueError as err:
+            caller.msg(str(err))
+            return
         if not npc:
             caller.msg("Prototype not found.")
         else:

--- a/commands/mob_builder.py
+++ b/commands/mob_builder.py
@@ -56,7 +56,11 @@ class CmdMSpawn(Command):
                 else:
                     self.msg("Invalid VNUM.")
                 return
-            obj = spawn_from_vnum(vnum, location=self.caller.location)
+            try:
+                obj = spawn_from_vnum(vnum, location=self.caller.location)
+            except ValueError as err:
+                self.msg(str(err))
+                return
             if not obj:
                 self.msg("Prototype not found.")
                 return
@@ -65,7 +69,11 @@ class CmdMSpawn(Command):
             mob_db = get_mobdb()
             vmatch = next((num for num, p in mob_db.db.vnums.items() if p.get("key") == arg), None)
             if vmatch is not None:
-                obj = spawn_from_vnum(vmatch, location=self.caller.location)
+                try:
+                    obj = spawn_from_vnum(vmatch, location=self.caller.location)
+                except ValueError as err:
+                    self.msg(str(err))
+                    return
                 if not obj:
                     self.msg("Prototype not found.")
                     return
@@ -116,7 +124,11 @@ class CmdMobPreview(Command):
             self.msg("Usage: @mobpreview <prototype>")
             return
         if key.isdigit():
-            obj = spawn_from_vnum(int(key), location=self.caller.location)
+            try:
+                obj = spawn_from_vnum(int(key), location=self.caller.location)
+            except ValueError as err:
+                self.msg(str(err))
+                return
             if not obj:
                 self.msg("Prototype not found.")
                 return

--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -2366,7 +2366,11 @@ class CmdSpawnNPC(Command):
                 not in COMBATANT_TYPES
             ):
                 self.msg("|rCombat class defined for non-combat NPC type.|n")
-            obj = spawn_from_vnum(vnum, location=self.caller.location)
+            try:
+                obj = spawn_from_vnum(vnum, location=self.caller.location)
+            except ValueError as err:
+                self.msg(str(err))
+                return
             if not obj:
                 self.msg("Unknown NPC prototype.")
                 return

--- a/typeclasses/tests/test_mob_proto_commands.py
+++ b/typeclasses/tests/test_mob_proto_commands.py
@@ -112,3 +112,10 @@ class TestMobPrototypeCommands(EvenniaTest):
         self.assertIn("deleted", out)
         self.assertIsNone(get_prototype(vnum))
 
+    def test_spawn_reports_missing_fields(self):
+        vnum = register_prototype({"desc": "bad"}, vnum=50)
+        self.char1.msg.reset_mock()
+        self.char1.execute_cmd(f"@mobproto spawn {vnum}")
+        out = self.char1.msg.call_args[0][0]
+        assert "missing required field" in out.lower()
+

--- a/typeclasses/tests/test_vnum_mobs.py
+++ b/typeclasses/tests/test_vnum_mobs.py
@@ -218,3 +218,18 @@ class TestVnumMobs(EvenniaTest):
         out = self.char1.msg.call_args[0][0]
         self.assertIn("not finalized", out)
         self.assertIn("editnpc 42", out)
+
+    def test_spawn_from_vnum_missing_key_error(self):
+        proto = {"desc": "bad"}
+        vnum = register_prototype(proto, vnum=60)
+        with patch("evennia.utils.logger.log_err") as mock_log:
+            with self.assertRaises(ValueError):
+                spawn_from_vnum(vnum, location=self.char1.location)
+            mock_log.assert_called()
+
+    def test_mspawn_reports_missing_fields(self):
+        vnum = register_prototype({"desc": "bad"}, vnum=61)
+        self.char1.msg.reset_mock()
+        self.char1.execute_cmd(f"@mspawn M{vnum}")
+        out = self.char1.msg.call_args[0][0]
+        self.assertIn("missing required field", out.lower())


### PR DESCRIPTION
## Summary
- validate mob prototypes when spawning from VNUM
- surface missing-field errors in mob commands
- add tests for invalid prototypes

## Testing
- `pytest -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684a951a4f90832c99419461e1a26b1b