### PR TITLE
Add errors for missing prototypes

### DIFF
--- a/commands/cmdmobbuilder.py
+++ b/commands/cmdmobbuilder.py
@@ -129,10 +129,7 @@ class CmdMobProto(Command):
         except ValueError as err:
             caller.msg(str(err))
             return
-        if not npc:
-            caller.msg("Prototype not found.")
-        else:
-            caller.msg(f"Spawned {npc.key} (vnum {vnum}).")
+        caller.msg(f"Spawned {npc.key} (vnum {vnum}).")
 
     def _sub_delete(self, rest: str):
         caller = self.caller

--- a/commands/mob_builder.py
+++ b/commands/mob_builder.py
@@ -61,9 +61,6 @@ class CmdMSpawn(Command):
             except ValueError as err:
                 self.msg(str(err))
                 return
-            if not obj:
-                self.msg("Prototype not found.")
-                return
         else:
             # look for a vnum prototype matching this key
             mob_db = get_mobdb()
@@ -73,9 +70,6 @@ class CmdMSpawn(Command):
                     obj = spawn_from_vnum(vmatch, location=self.caller.location)
                 except ValueError as err:
                     self.msg(str(err))
-                    return
-                if not obj:
-                    self.msg("Prototype not found.")
                     return
             else:
                 registry = prototypes.get_npc_prototypes()
@@ -128,9 +122,6 @@ class CmdMobPreview(Command):
                 obj = spawn_from_vnum(int(key), location=self.caller.location)
             except ValueError as err:
                 self.msg(str(err))
-                return
-            if not obj:
-                self.msg("Prototype not found.")
                 return
         else:
             registry = prototypes.get_npc_prototypes()

--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -2371,9 +2371,6 @@ class CmdSpawnNPC(Command):
             except ValueError as err:
                 self.msg(str(err))
                 return
-            if not obj:
-                self.msg("Unknown NPC prototype.")
-                return
             key = None
         else:
             if "/" in arg:

--- a/scripts/area_spawner.py
+++ b/scripts/area_spawner.py
@@ -4,6 +4,7 @@ from random import choice, randint
 
 from evennia.prototypes import spawner
 from utils.mob_proto import spawn_from_vnum
+from evennia.utils import logger
 from commands.npc_builder import finalize_mob_prototype
 from typeclasses.scripts import Script
 from typeclasses.npcs import BaseNPC
@@ -41,8 +42,10 @@ class AreaSpawner(Script):
 
         proto_key = choice(proto_keys)
         if proto_key.isdigit():
-            npc = spawn_from_vnum(int(proto_key), location=room)
-            if not npc:
+            try:
+                npc = spawn_from_vnum(int(proto_key), location=room)
+            except ValueError as err:
+                logger.log_err(str(err))
                 return
         else:
             proto = prototypes.get_npc_prototypes().get(proto_key)

--- a/typeclasses/tests/test_vnum_mobs.py
+++ b/typeclasses/tests/test_vnum_mobs.py
@@ -233,3 +233,15 @@ class TestVnumMobs(EvenniaTest):
         self.char1.execute_cmd(f"@mspawn M{vnum}")
         out = self.char1.msg.call_args[0][0]
         self.assertIn("missing required field", out.lower())
+
+    def test_spawn_from_vnum_invalid_vnum_error(self):
+        """spawn_from_vnum should raise if the prototype is missing."""
+        with self.assertRaises(ValueError):
+            spawn_from_vnum(999, location=self.char1.location)
+
+    def test_mspawn_invalid_vnum_message(self):
+        with patch("utils.mob_proto.spawn_from_vnum") as mock_spawn:
+            self.char1.execute_cmd("@mspawn 999")
+            mock_spawn.assert_not_called()
+        out = self.char1.msg.call_args[0][0]
+        self.assertIn("Invalid VNUM", out)

--- a/utils/mob_proto.py
+++ b/utils/mob_proto.py
@@ -46,7 +46,7 @@ def spawn_from_vnum(vnum: int, location=None):
     mob_db = get_mobdb()
     proto = mob_db.get_proto(vnum)
     if not proto:
-        return None
+        raise ValueError(f"Prototype not found for VNUM {vnum}")
     from commands.npc_builder import validate_prototype  # lazy import
 
     warnings = validate_prototype(proto)

--- a/world/mpcommands.py
+++ b/world/mpcommands.py
@@ -47,7 +47,10 @@ def execute_mpcommand(mob, command: str) -> None:
             vnum = int(arg.strip())
         except (TypeError, ValueError):
             return
-        spawn_from_vnum(vnum, location=mob.location)
+        try:
+            spawn_from_vnum(vnum, location=mob.location)
+        except ValueError:
+            return
         return
 
     if subcmd == "oload":


### PR DESCRIPTION
## Summary
- raise ValueError when prototype VNUM doesn't exist
- handle errors in commands and scripts
- log spawn errors in area spawner
- add tests for invalid VNUM cases

## Testing
- `pytest -q` *(fails: django.db.utils.OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684a978822e0832cb5ef308b82b6a46a