### PR TITLE
Implement object and room programs

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,20 @@ Conditional logic is also available using `if`, `else` and `endif` along with
         mob echo Unlucky...
     endif
 
+### Object and Room Programs
+
+Objects and rooms can have simple programs attached as well. The `opedit`
+and `rpedit` commands add an entry to an object or room prototype by VNUM.
+After entering the number you specify the event name and the command to run.
+For example::
+
+    opedit 100001
+    on_use
+    say It glows brightly.
+
+Programs are saved under `objprogs` or `roomprogs` on the prototype and are
+converted to triggers when the object or room spawns.
+
 ### NPC Prototypes
 
 A prototype is a JSON record stored in `world/prototypes/npcs.json` describing

--- a/commands/admin.py
+++ b/commands/admin.py
@@ -57,6 +57,8 @@ from .cmdmobbuilder import CmdMobProto
 from .nextvnum import CmdNextVnum
 from .builder_types import CmdBuilderTypes
 from .hedit import CmdHEdit
+from .opedit import CmdOPEdit
+from .rpedit import CmdRPEdit
 
 
 def _safe_split(text):
@@ -1465,3 +1467,5 @@ class BuilderCmdSet(CmdSet):
         self.add(CmdMobProto)
         self.add(CmdNextVnum)
         self.add(CmdHEdit)
+        self.add(CmdOPEdit)
+        self.add(CmdRPEdit)

--- a/commands/opedit.py
+++ b/commands/opedit.py
@@ -1,0 +1,75 @@
+from evennia.utils.evmenu import EvMenu
+from utils.prototype_manager import load_prototype, save_prototype
+from .command import Command
+
+
+def menunode_vnum(caller, raw_string="", **kwargs):
+    text = "|wEnter object vnum|n"
+    options = {"key": "_default", "goto": _set_vnum}
+    return text, options
+
+
+def _set_vnum(caller, raw_string, **kwargs):
+    val = raw_string.strip()
+    if not val.isdigit():
+        caller.msg("Enter a numeric vnum.")
+        return "menunode_vnum"
+    caller.ndb.op_vnum = int(val)
+    return "menunode_trigger"
+
+
+def menunode_trigger(caller, raw_string="", **kwargs):
+    text = "|wEnter trigger type|n"
+    options = {"key": "_default", "goto": _set_trigger}
+    return text, options
+
+
+def _set_trigger(caller, raw_string, **kwargs):
+    trig = raw_string.strip()
+    if not trig:
+        caller.msg("Enter a trigger type.")
+        return "menunode_trigger"
+    caller.ndb.op_trigger = trig
+    return "menunode_command"
+
+
+def menunode_command(caller, raw_string="", **kwargs):
+    text = "|wEnter command string|n"
+    options = {"key": "_default", "goto": _save_prog}
+    return text, options
+
+
+def _save_prog(caller, raw_string, **kwargs):
+    cmd = raw_string.strip()
+    if not cmd:
+        caller.msg("Enter a command string.")
+        return "menunode_command"
+    vnum = caller.ndb.op_vnum
+    trigger = caller.ndb.op_trigger
+    proto = load_prototype("object", vnum)
+    if proto is None:
+        caller.msg("Prototype not found.")
+        return None
+    progs = proto.setdefault("objprogs", [])
+    progs.append({"type": trigger, "commands": [cmd]})
+    save_prototype("object", proto, vnum=vnum)
+    caller.msg("Object program saved.")
+    caller.ndb.op_vnum = None
+    caller.ndb.op_trigger = None
+    return None
+
+
+class CmdOPEdit(Command):
+    """Attach a program to an object prototype."""
+
+    key = "opedit"
+    locks = "cmd:perm(Builder)"
+    help_category = "Building"
+
+    def func(self):
+        start = "menunode_vnum"
+        if self.args.strip().isdigit():
+            self.caller.ndb.op_vnum = int(self.args.strip())
+            start = "menunode_trigger"
+        EvMenu(self.caller, "commands.opedit", startnode=start)
+

--- a/commands/rpedit.py
+++ b/commands/rpedit.py
@@ -1,0 +1,75 @@
+from evennia.utils.evmenu import EvMenu
+from utils.prototype_manager import load_prototype, save_prototype
+from .command import Command
+
+
+def menunode_vnum(caller, raw_string="", **kwargs):
+    text = "|wEnter room vnum|n"
+    options = {"key": "_default", "goto": _set_vnum}
+    return text, options
+
+
+def _set_vnum(caller, raw_string, **kwargs):
+    val = raw_string.strip()
+    if not val.isdigit():
+        caller.msg("Enter a numeric vnum.")
+        return "menunode_vnum"
+    caller.ndb.rp_vnum = int(val)
+    return "menunode_trigger"
+
+
+def menunode_trigger(caller, raw_string="", **kwargs):
+    text = "|wEnter trigger type|n"
+    options = {"key": "_default", "goto": _set_trigger}
+    return text, options
+
+
+def _set_trigger(caller, raw_string, **kwargs):
+    trig = raw_string.strip()
+    if not trig:
+        caller.msg("Enter a trigger type.")
+        return "menunode_trigger"
+    caller.ndb.rp_trigger = trig
+    return "menunode_command"
+
+
+def menunode_command(caller, raw_string="", **kwargs):
+    text = "|wEnter command string|n"
+    options = {"key": "_default", "goto": _save_prog}
+    return text, options
+
+
+def _save_prog(caller, raw_string, **kwargs):
+    cmd = raw_string.strip()
+    if not cmd:
+        caller.msg("Enter a command string.")
+        return "menunode_command"
+    vnum = caller.ndb.rp_vnum
+    trigger = caller.ndb.rp_trigger
+    proto = load_prototype("room", vnum)
+    if proto is None:
+        caller.msg("Prototype not found.")
+        return None
+    progs = proto.setdefault("roomprogs", [])
+    progs.append({"type": trigger, "commands": [cmd]})
+    save_prototype("room", proto, vnum=vnum)
+    caller.msg("Room program saved.")
+    caller.ndb.rp_vnum = None
+    caller.ndb.rp_trigger = None
+    return None
+
+
+class CmdRPEdit(Command):
+    """Attach a program to a room prototype."""
+
+    key = "rpedit"
+    locks = "cmd:perm(Builder)"
+    help_category = "Building"
+
+    def func(self):
+        start = "menunode_vnum"
+        if self.args.strip().isdigit():
+            self.caller.ndb.rp_vnum = int(self.args.strip())
+            start = "menunode_trigger"
+        EvMenu(self.caller, "commands.rpedit", startnode=start)
+

--- a/typeclasses/objects.py
+++ b/typeclasses/objects.py
@@ -20,6 +20,7 @@ from evennia.contrib.game_systems.clothing import ContribClothing
 from evennia.contrib.game_systems.clothing.clothing import get_worn_clothes
 from evennia.utils import lazy_property
 from world.triggers import TriggerManager
+from utils.mob_utils import mobprogs_to_triggers
 
 from utils.currency import COIN_VALUES
 
@@ -199,6 +200,12 @@ class Object(ObjectParent, DefaultObject):
             self.db.display_priority = "item"
         if self.db.obj_triggers is None:
             self.db.obj_triggers = {}
+
+        if self.db.obj_programs and not self.db.obj_triggers:
+            self.db.obj_triggers = mobprogs_to_triggers(self.db.obj_programs)
+
+        if self.db.obj_triggers:
+            self.trigger_manager.start_random_triggers()
 
     @lazy_property
     def trigger_manager(self):

--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -13,6 +13,7 @@ from evennia.contrib.grid.wilderness.wilderness import WildernessRoom
 from .objects import ObjectParent
 from .scripts import RestockScript
 from world.triggers import TriggerManager
+from utils.mob_utils import mobprogs_to_triggers
 
 from commands.shops import ShopCmdSet
 from commands.skills import TrainCmdSet
@@ -31,6 +32,12 @@ class RoomParent(ObjectParent):
         self.db.exits = self.db.exits or {}
         if self.db.room_triggers is None:
             self.db.room_triggers = {}
+
+        if self.db.room_programs and not self.db.room_triggers:
+            self.db.room_triggers = mobprogs_to_triggers(self.db.room_programs)
+
+        if self.db.room_triggers:
+            self.trigger_manager.start_random_triggers()
 
     @lazy_property
     def trigger_manager(self):

--- a/world/triggers.py
+++ b/world/triggers.py
@@ -57,9 +57,22 @@ class TriggerManager:
         "hour_prog": "hour",
     }
 
-    def __init__(self, obj: Any, attr: str = "triggers"):
+    def __init__(self, obj: Any, attr: str | None = None):
+        """Create manager for ``obj``.
+
+        If ``attr`` is omitted the handler checks for ``obj.db.obj_triggers``
+        and ``obj.db.room_triggers`` before falling back to ``triggers``.
+        """
+
         self.obj = obj
-        self.attr = attr
+        if attr:
+            self.attr = attr
+        elif getattr(obj.db, "obj_triggers", None) is not None:
+            self.attr = "obj_triggers"
+        elif getattr(obj.db, "room_triggers", None) is not None:
+            self.attr = "room_triggers"
+        else:
+            self.attr = "triggers"
 
     # internal ---------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- enhance TriggerManager to auto-detect obj/room triggers
- start random triggers on objects and rooms
- add opedit/rpedit commands
- document program editing in README

## Testing
- `pytest -q` *(fails: OperationalError no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684aa08985fc832ca29217365fd26405