### PR TITLE
Implement area reset script and builder permissions

### DIFF
--- a/commands/aedit.py
+++ b/commands/aedit.py
@@ -29,7 +29,7 @@ class CmdAList(Command):
         if not areas:
             self.msg("No areas defined.")
             return
-        table = EvTable("Name", "Range", "Builders", "Flags", "Age", border="cells")
+        table = EvTable("Name", "Range", "Builders", "Flags", "Age", "Interval", border="cells")
         for area in areas:
             table.add_row(
                 area.key,
@@ -37,6 +37,7 @@ class CmdAList(Command):
                 ", ".join(area.builders),
                 ", ".join(area.flags),
                 str(area.age),
+                str(area.reset_interval),
             )
         self.msg(str(table))
 
@@ -68,7 +69,8 @@ class CmdAEdit(Command):
             self.msg(
                 "Usage: aedit create <name> <start> <end> | "
                 "aedit range <name> <start> <end> | "
-                "aedit builders <name> <list> | aedit flags <name> <list>"
+                "aedit builders <name> <list> | aedit flags <name> <list> | "
+                "aedit interval <name> <ticks>"
             )
             return
         parts = self.args.split(None, 1)
@@ -121,6 +123,20 @@ class CmdAEdit(Command):
             area.builders = [b.strip() for b in builders.split(',') if b.strip()]
             update_area(idx, area)
             self.msg("Builders updated.")
+            return
+        if sub == "interval":
+            args = rest.split()
+            if len(args) != 2 or not args[1].isdigit():
+                self.msg("Usage: aedit interval <name> <ticks>")
+                return
+            name, val = args[0], int(args[1])
+            idx, area = find_area(name)
+            if area is None:
+                self.msg("Unknown area.")
+                return
+            area.reset_interval = val
+            update_area(idx, area)
+            self.msg("Reset interval updated.")
             return
         if sub == "flags":
             args = rest.split(None, 1)

--- a/commands/mob_builder.py
+++ b/commands/mob_builder.py
@@ -205,7 +205,11 @@ class CmdQuickMob(Command):
         area = self.caller.location.db.area if self.caller.location else None
         if area:
             try:
-                vnum = vnum_registry.get_next_vnum_for_area(area, "npc")
+                vnum = vnum_registry.get_next_vnum_for_area(
+                    area,
+                    "npc",
+                    builder=self.caller.key,
+                )
             except Exception:
                 vnum = vnum_registry.get_next_vnum("npc")
         else:

--- a/commands/mob_builder_commands.py
+++ b/commands/mob_builder_commands.py
@@ -243,7 +243,11 @@ class CmdMCreate(Command):
         area = self.caller.location.db.area if self.caller.location else None
         if area:
             try:
-                proto["vnum"] = vnum_registry.get_next_vnum_for_area(area, "npc")
+                proto["vnum"] = vnum_registry.get_next_vnum_for_area(
+                    area,
+                    "npc",
+                    builder=self.caller.key,
+                )
             except Exception:
                 pass
         prototypes.register_npc_prototype(self.new_key, proto)

--- a/server/conf/at_server_startstop.py
+++ b/server/conf/at_server_startstop.py
@@ -46,6 +46,12 @@ def at_server_start():
             script.delete()
         create.create_script("typeclasses.scripts.GlobalTick", key="global_tick")
 
+    script = ScriptDB.objects.filter(db_key="area_reset").first()
+    if not script or script.typeclass_path != "world.area_reset.AreaReset":
+        if script:
+            script.delete()
+        create.create_script("world.area_reset.AreaReset", key="area_reset")
+
     # Ensure mob database script exists
     get_mobdb()
 

--- a/typeclasses/tests/test_mcreate_command.py
+++ b/typeclasses/tests/test_mcreate_command.py
@@ -36,6 +36,6 @@ class TestMCreateCommand(EvenniaTest):
         self.char1.location.set_area("town", 1)
         with mock.patch("utils.vnum_registry.get_next_vnum_for_area", return_value=55) as mock_vnum:
             self.char1.execute_cmd("@mcreate gob")
-        mock_vnum.assert_called_with("town", "npc")
+        mock_vnum.assert_called_with("town", "npc", builder=self.char1.key)
         reg = prototypes.get_npc_prototypes()
         assert reg["gob"]["vnum"] == 55

--- a/typeclasses/tests/test_quickmob_command.py
+++ b/typeclasses/tests/test_quickmob_command.py
@@ -41,7 +41,7 @@ class TestQuickMobCommand(EvenniaTest):
         self.char1.location.set_area("town", 1)
         with patch("utils.vnum_registry.get_next_vnum_for_area", return_value=101) as mock_vnum:
             self.char1.execute_cmd("@quickmob goblin")
-        mock_vnum.assert_called_with("town", "npc")
+        mock_vnum.assert_called_with("town", "npc", builder=self.char1.key)
         reg = prototypes.get_npc_prototypes()
         assert "mob_goblin" in reg
         assert reg["mob_goblin"]["vnum"] == 101

--- a/utils/tests/test_vnum_registry.py
+++ b/utils/tests/test_vnum_registry.py
@@ -9,6 +9,7 @@ from django.test import override_settings
 from evennia.utils.test_resources import EvenniaTest
 
 from utils import vnum_registry
+from world.areas import Area
 
 
 @override_settings(DEFAULT_HOME=None)
@@ -26,12 +27,24 @@ class TestVnumRegistry(EvenniaTest):
         self.addCleanup(self.tmp.cleanup)
 
     def test_next_vnum_for_area(self):
-        with mock.patch("world.areas.get_area_vnum_range", return_value=(100, 105)):
-            val1 = vnum_registry.get_next_vnum_for_area("town", "npc")
+        area = Area(key="town", start=100, end=105, reset_interval=0)
+        with mock.patch("world.areas.get_area_vnum_range", return_value=(100, 105)), \
+             mock.patch("world.areas.find_area", return_value=(0, area)):
+            val1 = vnum_registry.get_next_vnum_for_area("town", "npc", builder=None)
             self.assertEqual(val1, 100)
-            val2 = vnum_registry.get_next_vnum_for_area("town", "npc")
+            val2 = vnum_registry.get_next_vnum_for_area("town", "npc", builder=None)
             self.assertEqual(val2, 101)
             data = json.load(open(Path(self.tmp.name) / "vnums.json"))
             self.assertIn(100, data["npc"]["used"])
             self.assertIn(101, data["npc"]["used"])
+
+    def test_builder_permissions(self):
+        area = Area(key="town", start=100, end=105, builders=["Alice"], reset_interval=0)
+        with mock.patch("world.areas.get_area_vnum_range", return_value=(100, 105)), \
+             mock.patch("world.areas.find_area", return_value=(0, area)):
+            with self.assertRaises(PermissionError):
+                vnum_registry.get_next_vnum_for_area("town", "npc", builder="Bob")
+        with mock.patch("world.areas.get_area_vnum_range", return_value=(100, 105)), \
+             mock.patch("world.areas.find_area", return_value=(0, area)):
+            vnum_registry.get_next_vnum_for_area("town", "npc", builder="Alice")
 

--- a/utils/vnum_registry.py
+++ b/utils/vnum_registry.py
@@ -89,13 +89,14 @@ def get_next_vnum(category: str) -> int:
     return vnum
 
 
-def get_next_vnum_for_area(area_name: str, category: str) -> int:
+def get_next_vnum_for_area(area_name: str, category: str, *, builder: str | None = None) -> int:
     """Return and reserve the next available VNUM for ``category`` in ``area_name``.
 
-    The area's valid VNUM range is read from :mod:`world.areas`. The returned
-    VNUM will be persisted as used in the registry.
+    The area's valid VNUM range is read from :mod:`world.areas`. If ``builder``
+    is given, they must be listed as an authorized builder for the area. The
+    returned VNUM will be persisted as used in the registry.
     """
-    from world.areas import get_area_vnum_range
+    from world.areas import get_area_vnum_range, find_area
 
     if category not in VNUM_RANGES:
         raise KeyError(f"Unknown category: {category}")
@@ -103,6 +104,10 @@ def get_next_vnum_for_area(area_name: str, category: str) -> int:
     area_range = get_area_vnum_range(area_name)
     if not area_range:
         raise ValueError(f"Unknown area: {area_name}")
+    if builder is not None:
+        _, area = find_area(area_name)
+        if area and area.builders and builder not in area.builders:
+            raise PermissionError("Builder not authorized for this area")
 
     cat_start, cat_end = VNUM_RANGES[category]
     start = max(area_range[0], cat_start)

--- a/world/area_reset.py
+++ b/world/area_reset.py
@@ -1,0 +1,19 @@
+from evennia.scripts.scripts import DefaultScript
+from world.areas import get_areas, update_area
+
+class AreaReset(DefaultScript):
+    """Global script that increments area ages and performs resets."""
+
+    def at_script_creation(self):
+        self.key = "area_reset"
+        self.desc = "Handles area reset timers"
+        self.interval = 60
+        self.persistent = True
+
+    def at_repeat(self):
+        areas = get_areas()
+        for idx, area in enumerate(areas):
+            area.age += 1
+            if area.reset_interval and area.age >= area.reset_interval:
+                area.age = 0
+            update_area(idx, area)

--- a/world/areas.py
+++ b/world/areas.py
@@ -15,6 +15,7 @@ class Area:
     end: int
     desc: str = ""
     builders: List[str] = field(default_factory=list)
+    reset_interval: int = 0
     flags: List[str] = field(default_factory=list)
     age: int = 0
 
@@ -26,6 +27,7 @@ class Area:
             end=int(data.get("end", 0)),
             desc=data.get("desc", ""),
             builders=data.get("builders", []),
+            reset_interval=int(data.get("reset_interval", 0)),
             flags=data.get("flags", []),
             age=int(data.get("age", 0)),
         )

--- a/world/tests/test_area_reset.py
+++ b/world/tests/test_area_reset.py
@@ -1,0 +1,19 @@
+from unittest import mock
+from evennia.utils.test_resources import EvenniaTest
+from world.area_reset import AreaReset
+from world.areas import Area
+
+class TestAreaReset(EvenniaTest):
+    def test_age_increment_and_reset(self):
+        area = Area(key="town", start=1, end=10, reset_interval=2)
+        areas = [area]
+        with mock.patch("world.area_reset.get_areas", return_value=areas), \
+             mock.patch("world.area_reset.update_area") as mock_update:
+            script = AreaReset()
+            script.at_script_creation()
+            script.at_repeat()
+            self.assertEqual(area.age, 1)
+            script.at_repeat()
+            self.assertEqual(area.age, 0)
+            self.assertTrue(mock_update.called)
+


### PR DESCRIPTION
## Summary
- add a Script to update area ages and handle resets
- support reset_interval in Area dataclass
- extend aedit to configure reset intervals
- restrict get_next_vnum_for_area to authorized builders
- create area_reset script on server start
- tests for reset timing and permission checks

## Testing
- `pytest world/tests/test_area_reset.py utils/tests/test_vnum_registry.py typeclasses/tests/test_mcreate_command.py typeclasses/tests/test_quickmob_command.py -q` *(fails: OperationalError no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684aa2aba8cc832c99a2e3eaa8948804