### PR TITLE
Implement initiative calculation feature

### DIFF
--- a/combat/__init__.py
+++ b/combat/__init__.py
@@ -12,7 +12,7 @@ from .combat_actions import (
 from .combat_states import CombatState, CombatStateManager
 from .combat_skills import Skill, ShieldBash, Cleave, SKILL_CLASSES
 from .damage_types import DamageType
-from .combat_utils import get_condition_msg
+from .combat_utils import get_condition_msg, calculate_initiative
 
 __all__ = [
     "CombatEngine",
@@ -30,4 +30,5 @@ __all__ = [
     "SKILL_CLASSES",
     "DamageType",
     "get_condition_msg",
+    "calculate_initiative",
 ]

--- a/combat/combat_engine.py
+++ b/combat/combat_engine.py
@@ -10,7 +10,11 @@ from world.system import state_manager
 
 from .combat_actions import Action, AttackAction, CombatResult
 from .damage_types import DamageType
-from .combat_utils import format_combat_message, get_condition_msg
+from .combat_utils import (
+    format_combat_message,
+    get_condition_msg,
+    calculate_initiative,
+)
 
 
 @dataclass
@@ -316,10 +320,7 @@ class CombatEngine:
             actor = participant.actor
             if hasattr(actor, "traits"):
                 state_manager.apply_regen(actor)
-                base = getattr(actor.traits.get("initiative"), "value", 0)
-            else:
-                base = getattr(actor, "initiative", 0)
-            participant.initiative = base + random.randint(1, 20)
+            participant.initiative = calculate_initiative(actor)
             self.queue.append(participant)
         if self.use_initiative:
             self.queue.sort(key=lambda p: p.initiative, reverse=True)

--- a/typeclasses/tests/test_initiative_calc.py
+++ b/typeclasses/tests/test_initiative_calc.py
@@ -1,0 +1,19 @@
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+from combat.combat_utils import calculate_initiative
+
+class Dummy:
+    def __init__(self, init=0, level=1, bonus=0):
+        self.traits = MagicMock()
+        self.traits.get.return_value = MagicMock(value=init)
+        self.db = type("DB", (), {"level": level})()
+        self.equipment = {"slot": MagicMock()}
+        self.equipment["slot"].attributes = MagicMock()
+        self.equipment["slot"].attributes.get.return_value = bonus
+
+class TestInitiativeCalculation(TestCase):
+    def test_calculate_initiative(self):
+        d = Dummy(init=5, level=8, bonus=2)
+        with patch("random.randint", return_value=4):
+            result = calculate_initiative(d)
+        self.assertEqual(result, 5 + 2 + (8 // 4) + 4)


### PR DESCRIPTION
## Summary
- add `calculate_initiative` helper in `combat_utils`
- expose it via combat package
- use new function when generating initiative in `CombatEngine`
- add tests for initiative calculation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684aa509d994832cb9b709b49c115bea