### PR TITLE
Add target validation for attacks

### DIFF
--- a/commands/admin.py
+++ b/commands/admin.py
@@ -308,7 +308,8 @@ class CmdSlay(Command):
             self.msg("Target has no health stat.")
             return
         target.traits.health.current = 0
-        target.at_damage(self.caller, 0)
+        if callable(getattr(target, "at_damage", None)):
+            target.at_damage(self.caller, 0)
         self.msg(f"You slay {target.key}.")
 
 

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -793,6 +793,11 @@ class Character(ObjectParent, ClothedCharacter):
                 self.msg("You don't see your target.")
             return
 
+        if not getattr(target, "traits", None) or not callable(getattr(target, "at_damage", None)):
+            if self.sessions.count():
+                self.msg("You can't attack that.")
+            return
+
         if not (hasattr(weapon, "at_pre_attack") and hasattr(weapon, "at_attack")):
             if self.sessions.count():
                 self.msg(f"You cannot attack with {weapon.get_numbered_name(1, self)}.")
@@ -1113,6 +1118,10 @@ class NPC(Character):
         """
         attack with your natural weapon
         """
+        if not getattr(target, "traits", None) or not callable(getattr(target, "at_damage", None)):
+            if hasattr(wielder, "msg"):
+                wielder.msg("You can't attack that.")
+            return
         from world.system import stat_manager
 
         weapon = self.db.natural_weapon

--- a/typeclasses/gear.py
+++ b/typeclasses/gear.py
@@ -38,6 +38,10 @@ class BareHand:
         """
         Hit something with your fists!
         """
+        if not getattr(target, "traits", None) or not callable(getattr(target, "at_damage", None)):
+            if hasattr(wielder, "msg"):
+                wielder.msg("You can't attack that.")
+            return
         damage = self.damage
         # subtract the stamina required to use this
         wielder.traits.stamina.current -= self.stamina_cost
@@ -129,6 +133,10 @@ class MeleeWeapon(Object):
         """
         Use this weapon in an attack against a target.
         """
+        if not getattr(target, "traits", None) or not callable(getattr(target, "at_damage", None)):
+            if hasattr(wielder, "msg"):
+                wielder.msg("You can't attack that.")
+            return
         # get the weapon's damage bonus
         damage = 0
         if dice := getattr(self.db, "damage_dice", None):

--- a/world/mpcommands.py
+++ b/world/mpcommands.py
@@ -110,7 +110,7 @@ def _run_single(mob, command: str) -> None:
             amount = int(amount_str)
         except (TypeError, ValueError):
             return
-        if target:
+        if target and getattr(target, "traits", None) and callable(getattr(target, "at_damage", None)):
             target.at_damage(mob, amount, damage_type=dtype or None)
         return
 


### PR DESCRIPTION
## Summary
- ensure `attack` verifies the target has traits and an `at_damage` hook
- guard weapon attack helpers against invalid targets
- validate MP damage targets and admin slay target

## Testing
- `scripts/setup_test_env.sh` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pytest -q` *(fails: 423 failed, 14 passed, 2 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_684aaca30234832c925fd298ad105f13