### PR TITLE
Add NPC subclass validation for spawns

### DIFF
--- a/utils/mob_proto.py
+++ b/utils/mob_proto.py
@@ -68,6 +68,15 @@ def spawn_from_vnum(vnum: int, location=None):
         module, clsname = base_cls.rsplit(".", 1)
         base_cls = getattr(__import__(module, fromlist=[clsname]), clsname)
 
+    from typeclasses.characters import NPC
+    from typeclasses.npcs import BaseNPC
+
+    if not issubclass(base_cls, NPC):
+        logger.log_warn(
+            f"Prototype {vnum}: {base_cls} is not a subclass of NPC; using BaseNPC."
+        )
+        base_cls = BaseNPC
+
     metadata = proto_data.get("metadata") or {}
     role_names = metadata.get("roles") or []
     from commands.npc_builder import ROLE_MIXIN_MAP


### PR DESCRIPTION
## Summary
- check NPC subclass when spawning from vnum prototypes
- verify NPC subclass for raw prototypes in AreaSpawner
- safeguard CmdSpawnNPC against invalid typeclasses

## Testing
- `ruff check .` *(fails: error: unrecognized subcommand '.' etc)*
- `pytest -q` *(fails: django.db.utils.OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684aae7543dc832c9c249903aa02f0a9