### PR TITLE
Ensure NPC finalization

### DIFF
--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -1982,8 +1982,12 @@ def _create_npc(caller, raw_string, register=False, **kwargs):
                         caller.msg(
                             f"VNUM {data['vnum']} outside {area} range {rng[0]}-{rng[1]}"
                         )
+                        npc.db.vnum = None
+                        finalize_mob_prototype(caller, npc)
                         return None
                 caller.msg("Invalid VNUM for prototype.")
+                npc.db.vnum = None
+                finalize_mob_prototype(caller, npc)
                 return None
         if area:
             from world import area_npcs
@@ -2097,6 +2101,9 @@ def finalize_mob_prototype(caller, npc):
     ):
         caller.msg("|rCannot finalize mob. Missing level or class.|n")
         return
+
+    from world import stats as world_stats
+    world_stats.apply_stats(npc)
 
     meta = npc.db.metadata or {}
 


### PR DESCRIPTION
## Summary
- finalize NPCs in `npc_builder` even on bad VNUMs
- apply default stats when finalizing mobs

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684aafcf3dfc832cb09529026994de8f