### PR TITLE
Fix trait access in stat manager

### DIFF
--- a/world/tests/test_stat_manager.py
+++ b/world/tests/test_stat_manager.py
@@ -1,0 +1,16 @@
+from evennia.utils.test_resources import EvenniaTest
+from world.system import stat_manager
+
+
+class Dummy:
+    def __init__(self):
+        self.db = type("DB", (), {})()
+        # intentionally no traits attribute
+
+
+class TestStatManager(EvenniaTest):
+    def test_refresh_stats_without_traits(self):
+        obj = Dummy()
+        # should not raise when traits are missing
+        stat_manager.refresh_stats(obj)
+


### PR DESCRIPTION
## Summary
- avoid AttributeError when traits handler is missing
- add simple unit test covering object without traits

## Testing
- `pytest -q` *(fails: OperationalError no such table)*
- `pytest world/tests/test_stat_manager.py -q` *(fails: OperationalError no such table)*

------
https://chatgpt.com/codex/tasks/task_e_684ab1832048832cacb3c87e0bbce801