### PR TITLE
Add default NPC fields

### DIFF
--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -534,6 +534,11 @@ def _normalize_proto(proto: dict) -> None:
         if old in proto and new not in proto:
             proto[new] = proto[old]
 
+    proto.setdefault("npc_type", "base")
+    proto.setdefault("race", "human")
+    proto.setdefault("level", 1)
+    proto.setdefault("damage", 1)
+
 
 def _save_npc_registry(registry: Dict[str, dict]):
     path = _npc_proto_file()

--- a/world/tests/test_prototypes_defaults.py
+++ b/world/tests/test_prototypes_defaults.py
@@ -1,0 +1,42 @@
+import json
+from tempfile import TemporaryDirectory
+from pathlib import Path
+from unittest import mock
+
+from django.conf import settings
+from evennia.utils.test_resources import EvenniaTest
+
+from world import prototypes
+
+
+class TestPrototypeDefaults(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.tmp = TemporaryDirectory()
+        patcher = mock.patch.object(
+            settings, "PROTOTYPE_NPC_FILE", Path(self.tmp.name) / "npcs.json"
+        )
+        self.addCleanup(self.tmp.cleanup)
+        self.addCleanup(patcher.stop)
+        patcher.start()
+
+    def test_register_inserts_defaults(self):
+        prototypes.register_npc_prototype("orc", {"key": "orc"})
+        reg = prototypes.get_npc_prototypes()
+        proto = reg["orc"]
+        self.assertEqual(proto["npc_type"], "base")
+        self.assertEqual(proto["race"], "human")
+        self.assertEqual(proto["level"], 1)
+        self.assertEqual(proto["damage"], 1)
+
+    def test_load_inserts_defaults(self):
+        path = Path(settings.PROTOTYPE_NPC_FILE)
+        data = {"goblin": {"key": "goblin"}}
+        with path.open("w") as f:
+            json.dump(data, f)
+        reg = prototypes.get_npc_prototypes()
+        proto = reg["goblin"]
+        self.assertEqual(proto["npc_type"], "base")
+        self.assertEqual(proto["race"], "human")
+        self.assertEqual(proto["level"], 1)
+        self.assertEqual(proto["damage"], 1)


### PR DESCRIPTION
## Summary
- normalize NPC prototypes with defaults for `npc_type`, `race`, `level` and `damage`
- test prototype defaults when registering and loading

## Testing
- `pytest world/tests/test_prototypes_defaults.py -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684ab324f59c832c9a5f32704a7cb3be