### PR TITLE
Update mlist status text

### DIFF
--- a/commands/mob_builder_commands.py
+++ b/commands/mob_builder_commands.py
@@ -499,7 +499,7 @@ class CmdMList(Command):
                 finalized = True
             elif key in finalized_lookup or proto.get("key") in finalized_lookup:
                 finalized = True
-            status = "✅" if finalized else "🚫"
+            status = "yes" if finalized else "no"
             primary = roles[0] if roles else "-"
             table.add_row(
                 str(vnum) if vnum is not None else "-",

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -3012,7 +3012,7 @@ You may filter results with ``class=<name>``, ``race=<name>``,
 ``role=<name>``, ``tag=<tag>`` or ``zone=<area>``. Use ``/room`` to count
 NPCs present in your current room or ``/area`` for the entire area. The
 table shows columns for VNUM, Key, Status, Level, Class, Primary Role,
-Roles and Count. Finalized prototypes display a ``✅`` in the Status
+Roles and Count. Finalized prototypes display ``yes`` in the Status
 column.
 
 Usage:


### PR DESCRIPTION
## Summary
- show "yes" or "no" text for finalized status in `@mlist`
- update help entry to match new status text

## Testing
- `pytest -q` *(fails: `django.db.utils.OperationalError: no such table: accounts_accountdb`)*

------
https://chatgpt.com/codex/tasks/task_e_684ab4a4fb84832c9694a117dda6786f