### PR TITLE
Start CNPC builder at key prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ If you wind up having any issues or questions working with Evennia, [the Discord
 ### NPC Creation Menu
 
 You can quickly set up non-player characters using `cnpc start <key>` (alias
-`createnpc`). This opens an interactive menu where you enter the description,
-type, level and other details. Follow the prompts, review the summary at the end
+`createnpc`). This opens an interactive menu where you enter the key,
+description, type, level and other details. Follow the prompts, review the summary at the end
 and confirm to create your NPC. You can later update them with `cnpc edit
 <npc>`.
 

--- a/commands/medit.py
+++ b/commands/medit.py
@@ -30,6 +30,6 @@ class CmdMEdit(Command):
         EvMenu(
             caller,
             "commands.npc_builder",
-            startnode="menunode_desc",
+            startnode="menunode_key",
             cmd_on_exit=npc_builder._on_menu_exit,
         )

--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -2192,7 +2192,7 @@ class CmdCNPC(Command):
                 OLCEditor(
                     self.caller,
                     "commands.npc_builder",
-                    startnode="menunode_desc",
+                    startnode="menunode_key",
                     state=state,
                     validator=NPCValidator(),
                 ).start()
@@ -2238,7 +2238,7 @@ class CmdCNPC(Command):
             OLCEditor(
                 self.caller,
                 "commands.npc_builder",
-                startnode="menunode_desc",
+                startnode="menunode_key",
                 state=state,
                 validator=NPCValidator(),
             ).start()
@@ -2260,7 +2260,7 @@ class CmdCNPC(Command):
             OLCEditor(
                 self.caller,
                 "commands.npc_builder",
-                startnode="menunode_desc",
+                startnode="menunode_key",
                 state=state,
                 validator=NPCValidator(),
             ).start()

--- a/typeclasses/tests/test_medit_command.py
+++ b/typeclasses/tests/test_medit_command.py
@@ -8,7 +8,8 @@ from django.conf import settings
 from evennia.utils.test_resources import EvenniaTest
 
 from commands.admin import BuilderCmdSet
-from utils import prototype_manager
+from utils import prototype_manager, vnum_registry
+from commands import npc_builder
 
 
 @override_settings(DEFAULT_HOME=None)
@@ -24,20 +25,25 @@ class TestMEditCommand(EvenniaTest):
         patcher2 = mock.patch.object(
             settings, "VNUM_REGISTRY_FILE", Path(self.tmp.name) / "vnums.json"
         )
+        patcher3 = mock.patch.object(
+            vnum_registry, "_REG_PATH", Path(self.tmp.name) / "vnums.json"
+        )
         self.addCleanup(self.tmp.cleanup)
         self.addCleanup(patcher1.stop)
         self.addCleanup(patcher2.stop)
+        self.addCleanup(patcher3.stop)
         patcher1.start()
         patcher2.start()
+        patcher3.start()
 
     def test_medit_opens_builder_with_proto(self):
         prototype_manager.save_prototype("npc", {"key": "orc"}, vnum=5)
-        with patch("commands.npc_builder.EvMenu") as mock_menu:
+        with patch("commands.medit.EvMenu") as mock_menu:
             self.char1.execute_cmd("medit 5")
             mock_menu.assert_called_with(
                 self.char1,
                 "commands.npc_builder",
-                startnode="menunode_desc",
+                startnode="menunode_key",
                 cmd_on_exit=npc_builder._on_menu_exit,
             )
         data = self.char1.ndb.buildnpc

--- a/typeclasses/tests/test_mob_builder.py
+++ b/typeclasses/tests/test_mob_builder.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, ANY
 from tempfile import TemporaryDirectory
 from pathlib import Path
 from unittest import mock
@@ -35,13 +35,13 @@ class TestMobBuilder(EvenniaTest):
         return None
 
     def test_builder_flow_and_spawn(self):
-        with patch("commands.npc_builder.EvMenu") as mock_menu:
+        with patch("olc.base.EvMenu") as mock_menu:
             self.char1.execute_cmd("mobbuilder start goblin")
         mock_menu.assert_called_with(
             self.char1,
             "commands.npc_builder",
-            startnode="menunode_desc",
-            cmd_on_exit=npc_builder._on_menu_exit,
+            startnode="menunode_key",
+            cmd_on_exit=ANY,
         )
         npc_builder._set_key(self.char1, "goblin")
         npc_builder._set_desc(self.char1, "A small goblin")

--- a/typeclasses/tests/test_vnum_mobs.py
+++ b/typeclasses/tests/test_vnum_mobs.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, ANY
 from tempfile import TemporaryDirectory
 from pathlib import Path
 from unittest import mock
@@ -32,11 +32,16 @@ class TestVnumMobs(EvenniaTest):
             "VNUM_REGISTRY_FILE",
             Path(self.tmp.name) / "vnums.json",
         )
+        patcher3 = mock.patch.object(
+            vnum_registry, "_REG_PATH", Path(self.tmp.name) / "vnums.json"
+        )
         self.addCleanup(self.tmp.cleanup)
         self.addCleanup(patcher1.stop)
         self.addCleanup(patcher2.stop)
+        self.addCleanup(patcher3.stop)
         patcher1.start()
         patcher2.start()
+        patcher3.start()
 
     def test_register_and_spawn_vnum(self):
         proto = {"key": "goblin", "typeclass": "typeclasses.npcs.BaseNPC"}
@@ -98,8 +103,8 @@ class TestVnumMobs(EvenniaTest):
         mock_menu.assert_called_with(
             self.char1,
             "commands.npc_builder",
-            startnode="menunode_desc",
-            cmd_on_exit=npc_builder._on_menu_exit,
+            startnode="menunode_key",
+            cmd_on_exit=ANY,
         )
         self.assertEqual(self.char1.ndb.mob_vnum, 1)
         self.assertEqual(self.char1.ndb.buildnpc["key"], "gob")

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -2682,7 +2682,7 @@ Notes:
       combatant and others.
     - Selecting the combatant type allows you to choose a combat class
       like Warrior or Mage.
-    - The builder prompts for description, weight category,
+    - The builder prompts for key, description, weight category,
       creature type, level, experience reward, optional HP MP SP values,
       primary stats, modifiers or buffs, combat class, behavior, skills,
       spells, resistances and AI type.


### PR DESCRIPTION
## Summary
- open the NPC builder at `menunode_key` instead of `menunode_desc`
- document that the CNPC builder prompts for the key first
- update related tests for the new start node

## Testing
- `pytest typeclasses/tests/test_medit_command.py::TestMEditCommand::test_medit_opens_builder_with_proto -q`
- `pytest typeclasses/tests/test_mob_builder.py::TestMobBuilder::test_builder_flow_and_spawn -q` *(fails: KeyError '__module__')*
- `pytest typeclasses/tests/test_vnum_mobs.py::TestVnumMobs::test_register_and_spawn_vnum -q` *(fails: AttributeError 'finalize_mob_prototype')*

------
https://chatgpt.com/codex/tasks/task_e_684ab9dbaac0832cb7dd1461c612cd86