### PR TITLE
Clarify prototypes and archetypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,10 @@ A prototype is a JSON record stored in `world/prototypes/npcs.json` describing
 all of an NPC's settings such as stats, roles, triggers and AI. When you finish
 the builder, selecting **Yes** spawns the NPC in your current location.
 Choosing **Yes & Save Prototype** spawns the NPC and writes the prototype to
-that file so you can recreate it later.
+that file so you can recreate it later. In this context **prototype** means the
+saved blueprint of the NPC. The **archetype**, set by the `NPCType` field in the
+builder, defines the NPC's overall role or behavior such as *merchant* or
+*combatant*.
 
 You can spawn a saved prototype at any time with `@spawnnpc <key>`. Prototypes
 made with `mobbuilder` are automatically given the `mob_` prefix. Use

--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -392,6 +392,7 @@ def menunode_key(caller, raw_string="", **kwargs):
     """Prompt for the NPC key."""
     default = caller.ndb.buildnpc.get("key", "")
     text = "|wEnter NPC key|n"
+    text += "\n(Prototype = saved blueprint; archetype/NPC type defines role)"
     if default:
         text += f" [default: {default}]"
     text += "\nExample: |wmerchant_01|n"


### PR DESCRIPTION
## Summary
- clarify that prototypes are saved blueprints and archetypes define the role
- note this in the NPC builder's first prompt

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684ac06a2468832cb7b555ea820c39e5