### PR TITLE
Add combat round manager

### DIFF
--- a/combat/__init__.py
+++ b/combat/__init__.py
@@ -1,6 +1,7 @@
 """Combat system package."""
 
 from .combat_engine import CombatEngine
+from .round_manager import CombatRoundManager, CombatInstance
 from .combat_actions import (
     Action,
     AttackAction,
@@ -31,4 +32,6 @@ __all__ = [
     "DamageType",
     "get_condition_msg",
     "calculate_initiative",
+    "CombatRoundManager",
+    "CombatInstance",
 ]

--- a/combat/combat_engine.py
+++ b/combat/combat_engine.py
@@ -533,6 +533,6 @@ class CombatEngine:
                         actor.msg(msg)
 
         self.round += 1
-        if not self.participants:
+        if not self.participants or self.round_time is None:
             return
-        delay(0, self.process_round)
+        delay(self.round_time, self.process_round)

--- a/combat/round_manager.py
+++ b/combat/round_manager.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+from evennia.utils import delay
+
+from .combat_engine import CombatEngine
+
+
+@dataclass
+class CombatInstance:
+    """Wrapper for a combat engine tied to a room."""
+
+    script: object
+    engine: CombatEngine
+
+    def sync_participants(self) -> None:
+        """Synchronize engine participants with script fighters."""
+        current = {p.actor for p in self.engine.participants}
+        fighters = set(self.script.fighters)
+        for actor in fighters - current:
+            self.engine.add_participant(actor)
+        for actor in current - fighters:
+            self.engine.remove_participant(actor)
+
+
+class CombatRoundManager:
+    """Manage active combat instances across rooms."""
+
+    _instance: "CombatRoundManager | None" = None
+
+    def __init__(self):
+        self.instances: List[CombatInstance] = []
+        self.running = False
+
+    @classmethod
+    def get(cls) -> "CombatRoundManager":
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance
+
+    def add_instance(self, script) -> CombatInstance:
+        """Create or fetch an instance for ``script``."""
+        for inst in self.instances:
+            if inst.script is script:
+                return inst
+        engine = CombatEngine(script.fighters, round_time=None)
+        inst = CombatInstance(script, engine)
+        self.instances.append(inst)
+        if not self.running:
+            self.running = True
+            self._schedule_tick()
+        return inst
+
+    def remove_instance(self, script) -> None:
+        self.instances = [i for i in self.instances if i.script is not script]
+        if not self.instances:
+            self.running = False
+
+    def _schedule_tick(self) -> None:
+        delay(1, self.tick)
+
+    def tick(self) -> None:
+        for inst in list(self.instances):
+            if not inst.script or not inst.script.active:
+                self.remove_instance(inst.script)
+                continue
+            inst.sync_participants()
+            inst.engine.process_round()
+        if self.instances:
+            self._schedule_tick()
+        else:
+            self.running = False

--- a/typeclasses/scripts.py
+++ b/typeclasses/scripts.py
@@ -98,6 +98,8 @@ class CombatScript(Script):
             self.db.teams[team].append(combatant)
             # reset the cache
             del self.ndb.teams
+            from combat.round_manager import CombatRoundManager
+            CombatRoundManager.get().add_instance(self)
             return True
 
         # if enemy is given, find enemy's team
@@ -109,6 +111,8 @@ class CombatScript(Script):
             self.db.teams[team].append(combatant)
             # reset the cache
             del self.ndb.teams
+            from combat.round_manager import CombatRoundManager
+            CombatRoundManager.get().add_instance(self)
             return True
 
         # if we got here, then no one provided was in combat already
@@ -118,6 +122,8 @@ class CombatScript(Script):
             self.db.teams = [[combatant], [enemy]]
             # reset the cache
             del self.ndb.teams
+            from combat.round_manager import CombatRoundManager
+            CombatRoundManager.get().add_instance(self)
             return True
 
         # at this point, there are no valid ways to add

--- a/typeclasses/tests/test_round_manager.py
+++ b/typeclasses/tests/test_round_manager.py
@@ -1,0 +1,45 @@
+from unittest.mock import patch
+from evennia.utils.test_resources import EvenniaTest
+
+from typeclasses.scripts import CombatScript
+from combat.round_manager import CombatRoundManager
+from combat.combat_engine import CombatEngine
+
+
+class TestCombatRoundManager(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.room1.scripts.add(CombatScript, key="combat")
+        self.script = self.room1.scripts.get("combat")[0]
+        self.script.add_combatant(self.char1, enemy=self.char2)
+        self.manager = CombatRoundManager.get()
+        self.manager.instances.clear()
+        self.manager.running = False
+
+    def test_tick_schedules(self):
+        with patch("combat.round_manager.delay") as mock_delay:
+            self.manager.add_instance(self.script)
+            mock_delay.assert_called_with(1, self.manager.tick)
+            mock_delay.reset_mock()
+            with patch.object(CombatEngine, "process_round") as mock_proc:
+                self.manager.tick()
+                mock_proc.assert_called()
+            mock_delay.assert_called_with(1, self.manager.tick)
+
+    def test_initiative_order(self):
+        order = []
+
+        def start_round(self):
+            original(self)
+            order.extend([p.actor for p in self.queue])
+
+        original = CombatEngine.start_round
+        with patch("combat.round_manager.delay"), \
+             patch("combat.combat_utils.calculate_initiative") as mock_calc, \
+             patch.object(CombatEngine, "start_round", new=start_round):
+            mock_calc.side_effect = lambda c: 10 if c is self.char1 else 1
+            self.manager.add_instance(self.script)
+            self.manager.tick()
+
+        self.assertEqual(order[0], self.char1)
+        self.assertEqual(order[1], self.char2)


### PR DESCRIPTION
## Summary
- add global CombatRoundManager to schedule CombatEngine rounds
- adjust CombatEngine to respect `round_time`
- integrate round manager with CombatScript
- expose manager from combat package
- test round manager tick and initiative order

## Testing
- `pytest -q` *(fails: django.db.utils.OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684ac741ac70832cb6cc6188b5b300f3