### PR TITLE
Add medit creation subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,12 @@ Example::
 
     @quickmob goblin warrior
 
+### MEdit
+
+Use `medit <vnum>` to edit an existing numeric prototype. The command
+`medit create <vnum>` reserves the number, loads a basic template and
+opens the same builder menu for customization.
+
 ## Mob Prototype Manager
 
 `@mobproto` works with numeric VNUMs to store and spawn NPCs. Newly

--- a/commands/admin.py
+++ b/commands/admin.py
@@ -52,7 +52,7 @@ from .mob_builder import (
     CmdQuickMob,
 )
 from .medit import CmdMEdit as CmdMEditMenu
-from .mob_builder_commands import CmdMEdit
+from .mob_builder_commands import CmdProtoEdit
 from .cmdmobbuilder import CmdMobProto
 from .nextvnum import CmdNextVnum
 from .builder_types import CmdBuilderTypes
@@ -1451,7 +1451,7 @@ class BuilderCmdSet(CmdSet):
         self.add(CmdMSpawn)
         self.add(CmdMobPreview)
         self.add(CmdMEditMenu)
-        self.add(CmdMEdit)
+        self.add(CmdProtoEdit)
         self.add(CmdMCreate)
         self.add(CmdMSet)
         self.add(CmdMList)

--- a/commands/medit.py
+++ b/commands/medit.py
@@ -3,6 +3,7 @@ from utils.prototype_manager import load_prototype
 from utils.vnum_registry import validate_vnum, register_vnum
 from .command import Command
 from . import npc_builder
+from world.templates.mob_templates import get_template
 
 
 class CmdMEdit(Command):
@@ -14,17 +15,39 @@ class CmdMEdit(Command):
 
     def func(self):
         caller = self.caller
-        if not self.args or not self.args.strip().isdigit():
-            caller.msg("Usage: medit <vnum>")
+        args = self.args.strip()
+        if not args:
+            caller.msg("Usage: medit <vnum> | medit create <vnum>")
             return
-        vnum = int(self.args.strip())
-        proto = load_prototype("npc", vnum)
-        if proto is None:
+
+        parts = args.split(None, 1)
+        sub = parts[0].lower()
+
+        if sub == "create":
+            if len(parts) != 2 or not parts[1].isdigit():
+                caller.msg("Usage: medit create <vnum>")
+                return
+            vnum = int(parts[1])
             if not validate_vnum(vnum, "npc"):
                 caller.msg("Invalid or already used VNUM.")
                 return
             register_vnum(vnum)
-            proto = {"key": f"mob_{vnum}", "level": 1}
+            proto = get_template("warrior") or {}
+            proto.setdefault("key", f"mob_{vnum}")
+            proto.setdefault("level", 1)
+        else:
+            if not sub.isdigit():
+                caller.msg("Usage: medit <vnum> | medit create <vnum>")
+                return
+            vnum = int(sub)
+            proto = load_prototype("npc", vnum)
+            if proto is None:
+                if not validate_vnum(vnum, "npc"):
+                    caller.msg("Invalid or already used VNUM.")
+                    return
+                register_vnum(vnum)
+                proto = {"key": f"mob_{vnum}", "level": 1}
+
         caller.ndb.mob_vnum = vnum
         caller.ndb.buildnpc = dict(proto)
         EvMenu(

--- a/commands/mob_builder_commands.py
+++ b/commands/mob_builder_commands.py
@@ -839,10 +839,15 @@ class CmdMobImport(Command):
 
 
 
-class CmdMEdit(Command):
-    """Edit fields on a numbered mob prototype or display its summary."""
+class CmdProtoEdit(Command):
+    """Edit fields on a numbered mob prototype or display its summary.
 
-    key = "@medit"
+    The ``@medit`` alias is kept for backward compatibility but is
+    deprecated in favor of ``@protoedit``.
+    """
+
+    key = "@protoedit"
+    aliases = ["@medit"]
     locks = "cmd:perm(Builder) or perm(Admin) or perm(Developer)"
     help_category = "Building"
 
@@ -884,7 +889,7 @@ class CmdMEdit(Command):
         from utils.mob_proto import get_prototype, register_prototype
 
         if self.vnum is None:
-            self.msg("Usage: @medit <vnum> [<field> <value>]")
+            self.msg("Usage: @protoedit <vnum> [<field> <value>]")
             return
 
         proto = get_prototype(self.vnum)
@@ -894,7 +899,7 @@ class CmdMEdit(Command):
 
         if not self.field:
             self.msg(npc_builder.format_mob_summary(proto))
-            self.msg(f"Edit with: @medit {self.vnum} <field> <value>")
+            self.msg(f"Edit with: @protoedit {self.vnum} <field> <value>")
             return
 
         cast = self._FIELD_CASTS.get(self.field, str)

--- a/typeclasses/tests/test_medit_command.py
+++ b/typeclasses/tests/test_medit_command.py
@@ -49,3 +49,18 @@ class TestMEditCommand(EvenniaTest):
         data = self.char1.ndb.buildnpc
         assert data["key"] == "orc"
         assert self.char1.ndb.mob_vnum == 5
+
+    def test_medit_create(self):
+        with patch("commands.medit.EvMenu") as mock_menu, patch(
+            "commands.medit.get_template", return_value={"level": 2}
+        ):
+            self.char1.execute_cmd("medit create 10")
+            mock_menu.assert_called_with(
+                self.char1,
+                "commands.npc_builder",
+                startnode="menunode_key",
+                cmd_on_exit=npc_builder._on_menu_exit,
+            )
+        data = self.char1.ndb.buildnpc
+        assert data["level"] == 2
+        assert self.char1.ndb.mob_vnum == 10

--- a/typeclasses/tests/test_protoedit_command.py
+++ b/typeclasses/tests/test_protoedit_command.py
@@ -12,7 +12,7 @@ from utils.mob_proto import register_prototype, get_prototype
 
 
 @override_settings(DEFAULT_HOME=None)
-class TestMEditProto(EvenniaTest):
+class TestProtoEdit(EvenniaTest):
     def setUp(self):
         super().setUp()
         self.char1.msg = MagicMock()
@@ -34,15 +34,15 @@ class TestMEditProto(EvenniaTest):
         patcher1.start()
         patcher2.start()
 
-    def test_medit_sets_field(self):
+    def test_protoedit_sets_field(self):
         register_prototype({"key": "orc"}, vnum=5)
-        self.char1.execute_cmd("@medit 5 level 3")
+        self.char1.execute_cmd("@protoedit 5 level 3")
         self.assertEqual(get_prototype(5)["level"], 3)
 
-    def test_medit_shows_summary(self):
+    def test_protoedit_shows_summary(self):
         register_prototype({"key": "orc", "level": 2}, vnum=7)
         self.char1.msg.reset_mock()
-        self.char1.execute_cmd("@medit 7")
+        self.char1.execute_cmd("@protoedit 7")
         out = self.char1.msg.call_args[0][0]
         self.assertIn("orc", out)
         self.assertIn("2", out)

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -3091,6 +3091,26 @@ Notes:
 """,
     },
     {
+        "key": "medit",
+        "category": "Building",
+        "text": """Help for medit
+
+Open the NPC builder for a numeric prototype. ``create`` reserves the
+number and loads a default template for editing.
+
+Usage:
+    medit <vnum>
+    medit create <vnum>
+
+Example:
+    medit create 10
+
+Notes:
+    - VNUMs are validated against the registry.
+    - Choose |wYes & Save Prototype|n in the builder to store the result.
+""",
+    },
+    {
         "key": "@mobpreview",
         "category": "Building",
         "text": """Help for @mobpreview


### PR DESCRIPTION
## Summary
- add `medit create <vnum>` to bootstrap a new NPC prototype
- rename field-based `@medit` to `@protoedit`
- update admin command set
- document medit usage in help entries and README
- adjust tests for new commands

## Testing
- `pytest -q` *(fails: OperationalError no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684acaf1fdd8832cbe67d89d8cf589b3