### PR TITLE
Skip key prompt for known NPCs

### DIFF
--- a/commands/cmdmobbuilder.py
+++ b/commands/cmdmobbuilder.py
@@ -163,10 +163,13 @@ class CmdMobProto(Command):
                 caller.ndb.mob_vnum = caller.ndb.buildnpc.get("vnum")
                 caller.db.builder_autosave = None
                 caller.scripts.add(BuilderAutosave, key="builder_autosave")
+                startnode = (
+                    "menunode_desc" if caller.ndb.buildnpc.get("key") else "menunode_key"
+                )
                 EvMenu(
                     caller,
                     "commands.npc_builder",
-                    startnode="menunode_desc",
+                    startnode=startnode,
                     cmd_on_exit=npc_builder._on_menu_exit,
                 )
             else:
@@ -187,10 +190,11 @@ class CmdMobProto(Command):
         caller.ndb.buildnpc = dict(proto)
         caller.ndb.mob_vnum = vnum
         caller.scripts.add(BuilderAutosave, key="builder_autosave")
+        startnode = "menunode_desc" if caller.ndb.buildnpc.get("key") else "menunode_key"
         EvMenu(
             caller,
             "commands.npc_builder",
-            startnode="menunode_desc",
+            startnode=startnode,
             cmd_on_exit=npc_builder._on_menu_exit,
         )
 

--- a/commands/medit.py
+++ b/commands/medit.py
@@ -50,9 +50,10 @@ class CmdMEdit(Command):
 
         caller.ndb.mob_vnum = vnum
         caller.ndb.buildnpc = dict(proto)
+        startnode = "menunode_desc" if caller.ndb.buildnpc.get("key") else "menunode_key"
         EvMenu(
             caller,
             "commands.npc_builder",
-            startnode="menunode_key",
+            startnode=startnode,
             cmd_on_exit=npc_builder._on_menu_exit,
         )

--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -2202,10 +2202,13 @@ class CmdCNPC(Command):
                 self.caller.db.builder_autosave = None
                 self.caller.scripts.add(BuilderAutosave, key="builder_autosave")
                 state = OLCState(data=self.caller.ndb.buildnpc)
+                startnode = (
+                    "menunode_desc" if self.caller.ndb.buildnpc.get("key") else "menunode_key"
+                )
                 OLCEditor(
                     self.caller,
                     "commands.npc_builder",
-                    startnode="menunode_key",
+                    startnode=startnode,
                     state=state,
                     validator=NPCValidator(),
                 ).start()
@@ -2248,10 +2251,13 @@ class CmdCNPC(Command):
                 self.caller.ndb.buildnpc["use_mob"] = True
             self.caller.scripts.add(BuilderAutosave, key="builder_autosave")
             state = OLCState(data=self.caller.ndb.buildnpc)
+            startnode = (
+                "menunode_desc" if self.caller.ndb.buildnpc.get("key") else "menunode_key"
+            )
             OLCEditor(
                 self.caller,
                 "commands.npc_builder",
-                startnode="menunode_key",
+                startnode=startnode,
                 state=state,
                 validator=NPCValidator(),
             ).start()
@@ -2270,10 +2276,13 @@ class CmdCNPC(Command):
                 self.caller.ndb.buildnpc["use_mob"] = True
             self.caller.scripts.add(BuilderAutosave, key="builder_autosave")
             state = OLCState(data=self.caller.ndb.buildnpc)
+            startnode = (
+                "menunode_desc" if self.caller.ndb.buildnpc.get("key") else "menunode_key"
+            )
             OLCEditor(
                 self.caller,
                 "commands.npc_builder",
-                startnode="menunode_key",
+                startnode=startnode,
                 state=state,
                 validator=NPCValidator(),
             ).start()

--- a/typeclasses/tests/test_medit_command.py
+++ b/typeclasses/tests/test_medit_command.py
@@ -43,7 +43,7 @@ class TestMEditCommand(EvenniaTest):
             mock_menu.assert_called_with(
                 self.char1,
                 "commands.npc_builder",
-                startnode="menunode_key",
+                startnode="menunode_desc",
                 cmd_on_exit=npc_builder._on_menu_exit,
             )
         data = self.char1.ndb.buildnpc
@@ -58,7 +58,7 @@ class TestMEditCommand(EvenniaTest):
             mock_menu.assert_called_with(
                 self.char1,
                 "commands.npc_builder",
-                startnode="menunode_key",
+                startnode="menunode_desc",
                 cmd_on_exit=npc_builder._on_menu_exit,
             )
         data = self.char1.ndb.buildnpc

--- a/typeclasses/tests/test_mob_builder.py
+++ b/typeclasses/tests/test_mob_builder.py
@@ -40,7 +40,7 @@ class TestMobBuilder(EvenniaTest):
         mock_menu.assert_called_with(
             self.char1,
             "commands.npc_builder",
-            startnode="menunode_key",
+            startnode="menunode_desc",
             cmd_on_exit=ANY,
         )
         npc_builder._set_key(self.char1, "goblin")

--- a/typeclasses/tests/test_vnum_mobs.py
+++ b/typeclasses/tests/test_vnum_mobs.py
@@ -103,7 +103,7 @@ class TestVnumMobs(EvenniaTest):
         mock_menu.assert_called_with(
             self.char1,
             "commands.npc_builder",
-            startnode="menunode_key",
+            startnode="menunode_desc",
             cmd_on_exit=ANY,
         )
         self.assertEqual(self.char1.ndb.mob_vnum, 1)


### PR DESCRIPTION
## Summary
- detect existing keys before entering NPC builder
- skip key prompt when editing with `cnpc`, `medit`, or `@mobproto/edit`
- update tests for new start nodes

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684ad4f20204832cbd4f2abe564d428f