### PR TITLE
Improve medit command vnum loading

### DIFF
--- a/commands/medit.py
+++ b/commands/medit.py
@@ -1,6 +1,7 @@
 from evennia.utils.evmenu import EvMenu
 from utils.prototype_manager import load_prototype
 from utils.vnum_registry import validate_vnum, register_vnum
+from utils.mob_proto import get_prototype
 from .command import Command
 from . import npc_builder
 from world.templates.mob_templates import get_template
@@ -40,7 +41,9 @@ class CmdMEdit(Command):
                 caller.msg("Usage: medit <vnum> | medit create <vnum>")
                 return
             vnum = int(sub)
-            proto = load_prototype("npc", vnum)
+            proto = get_prototype(vnum)
+            if proto is None:
+                proto = load_prototype("npc", vnum)
             if proto is None:
                 if not validate_vnum(vnum, "npc"):
                     caller.msg("Invalid or already used VNUM.")

--- a/typeclasses/tests/test_medit_command.py
+++ b/typeclasses/tests/test_medit_command.py
@@ -64,3 +64,19 @@ class TestMEditCommand(EvenniaTest):
         data = self.char1.ndb.buildnpc
         assert data["level"] == 2
         assert self.char1.ndb.mob_vnum == 10
+
+    def test_medit_registered_proto(self):
+        from utils.mob_proto import register_prototype
+
+        register_prototype({"key": "troll"}, vnum=7)
+        with patch("commands.medit.EvMenu") as mock_menu:
+            self.char1.execute_cmd("medit 7")
+            mock_menu.assert_called_with(
+                self.char1,
+                "commands.npc_builder",
+                startnode="menunode_desc",
+                cmd_on_exit=npc_builder._on_menu_exit,
+            )
+        data = self.char1.ndb.buildnpc
+        assert data["key"] == "troll"
+        assert self.char1.ndb.mob_vnum == 7


### PR DESCRIPTION
## Summary
- use mob prototypes when available in `medit`
- test registered prototype loading

## Testing
- `evennia migrate`
- `pytest typeclasses/tests/test_medit_command.py::TestMEditCommand::test_medit_registered_proto -q`
- `pytest -q` *(fails: evennia.objects.models.ObjectDB.DoesNotExist...)*

------
https://chatgpt.com/codex/tasks/task_e_684ad9fd5478832c8a988e78b61ff30b