### PR TITLE
Fix vnum back navigation

### DIFF
--- a/world/menus/mob_builder_menu.py
+++ b/world/menus/mob_builder_menu.py
@@ -295,7 +295,7 @@ def menunode_vnum(caller, raw_string="", **kwargs):
 def _set_vnum(caller, raw_string, **kwargs):
     string = str(raw_string).strip()
     if string.lower() == "back":
-        return "menunode_desc"
+        return "menunode_weight"
 
     data = caller.ndb.buildnpc or {}
     old = data.get("vnum")


### PR DESCRIPTION
## Summary
- ensure the vnum menu "back" command goes to the weight menu

## Testing
- `pytest -k mob_builder -q` *(fails: django.db.utils.OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684aecd2bc5c832cbb30bebf746dd28e