### PR TITLE
Adjust combat tick timing

### DIFF
--- a/combat/round_manager.py
+++ b/combat/round_manager.py
@@ -59,7 +59,8 @@ class CombatRoundManager:
             self.running = False
 
     def _schedule_tick(self) -> None:
-        delay(1, self.tick)
+        """Schedule the next combat tick."""
+        delay(0.3, self.tick)
 
     def tick(self) -> None:
         for inst in list(self.instances):

--- a/typeclasses/tests/test_round_manager.py
+++ b/typeclasses/tests/test_round_manager.py
@@ -19,12 +19,12 @@ class TestCombatRoundManager(EvenniaTest):
     def test_tick_schedules(self):
         with patch("combat.round_manager.delay") as mock_delay:
             self.manager.add_instance(self.script)
-            mock_delay.assert_called_with(1, self.manager.tick)
+            mock_delay.assert_called_with(0.3, self.manager.tick)
             mock_delay.reset_mock()
             with patch.object(CombatEngine, "process_round") as mock_proc:
                 self.manager.tick()
                 mock_proc.assert_called()
-            mock_delay.assert_called_with(1, self.manager.tick)
+            mock_delay.assert_called_with(0.3, self.manager.tick)
 
     def test_initiative_order(self):
         order = []


### PR DESCRIPTION
## Summary
- reduce round manager tick interval to ~0.3s
- expect new interval in round manager tests

## Testing
- `evennia test --verbosity=2 typeclasses.tests.test_round_manager.TestCombatRoundManager.test_tick_schedules`

------
https://chatgpt.com/codex/tasks/task_e_684af29d5ffc832c81fe377960cd5c77