### PR TITLE
Add coin drop rewards

### DIFF
--- a/typeclasses/tests/test_combat_engine.py
+++ b/typeclasses/tests/test_combat_engine.py
@@ -4,6 +4,7 @@ from evennia.utils.test_resources import EvenniaTest
 
 from combat.combat_engine import CombatEngine
 from combat.combat_actions import Action, CombatResult
+from utils.currency import from_copper, to_copper
 from combat.combat_utils import get_condition_msg
 
 
@@ -194,6 +195,8 @@ class TestCombatDeath(EvenniaTest):
         npc = create.create_object(NPC, key="mob", location=self.room1)
         npc.db.drops = []
         npc.db.exp_reward = 5
+        npc.db.coin_drop = {"silver": 3}
+        self.char1.db.coins = from_copper(0)
 
         engine = CombatEngine([player, npc], round_time=0)
         engine.queue_action(player, KillAction(player, npc))
@@ -204,6 +207,7 @@ class TestCombatDeath(EvenniaTest):
             engine.process_round()
 
         self.assertEqual(player.db.exp, 5)
+        self.assertEqual(to_copper(player.db.coins), to_copper({"silver": 3}))
         corpse = next(
             obj for obj in self.room1.contents
             if obj.is_typeclass('typeclasses.objects.Corpse', exact=False)

--- a/typeclasses/tests/test_loot_table.py
+++ b/typeclasses/tests/test_loot_table.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch, MagicMock
 from evennia.utils import create
 from evennia.utils.test_resources import EvenniaTest
+from utils.currency import from_copper, to_copper
 
 class TestNPCLootTable(EvenniaTest):
     def test_loot_table_spawn(self):
@@ -9,6 +10,8 @@ class TestNPCLootTable(EvenniaTest):
         npc = create.create_object(NPC, key="mob", location=self.room1)
         npc.db.drops = []
         npc.db.loot_table = [{"proto": "RAW_MEAT", "chance": 100}]
+        npc.db.coin_drop = {"gold": 1}
+        self.char1.db.coins = from_copper(0)
         npc.traits.health.current = 1
         with patch("evennia.prototypes.spawner.spawn", return_value=[MagicMock()]) as mock_spawn:
             room = npc.location
@@ -22,6 +25,7 @@ class TestNPCLootTable(EvenniaTest):
             )
             item = mock_spawn.return_value[0]
             self.assertIs(item.location, corpse)
+            self.assertEqual(to_copper(self.char1.db.coins), to_copper({"gold": 1}))
 
     def test_loot_table_guaranteed_after(self):
         from typeclasses.characters import NPC


### PR DESCRIPTION
## Summary
- drop coins on NPC death
- award coin drops directly to killer
- test that loot table coin drop moves money to killer
- test coin rewards for killing NPCs

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684af44da684832c84d40cd8878eb0f9