### PR TITLE
Fix duplicate corpse creation on defeat

### DIFF
--- a/combat/combat_engine.py
+++ b/combat/combat_engine.py
@@ -362,17 +362,28 @@ class CombatEngine:
         Calls ``target.at_defeat`` if defined, removes the participant
         from combat and notifies allies in the same room.
         """
+        if getattr(target, "pk", None) is None:
+            # already cleaned up elsewhere
+            self.remove_participant(target)
+            return
+
         if hasattr(target, "on_exit_combat"):
             target.on_exit_combat()
+
         if hasattr(target, "at_defeat"):
             target.at_defeat(attacker)
-        if hasattr(target, "on_death"):
+
+        if getattr(target, "pk", None) is not None and hasattr(target, "on_death"):
             target.on_death(attacker)
-        self.update_pos(target)
+
+        if getattr(target, "pk", None) is not None:
+            self.update_pos(target)
+
         if attacker and attacker.location:
             attacker.location.msg_contents(
                 f"{target.key} is defeated by {attacker.key}!"
             )
+
         self.remove_participant(target)
         for participant in list(self.participants):
             ally = participant.actor


### PR DESCRIPTION
## Summary
- prevent `handle_defeat` from running death cleanup twice
- test that only one corpse is created when killing an NPC

## Testing
- `pytest -q` *(fails: 363 failed, 9 passed, 2 warnings, 1 error in 64.65s)*

------
https://chatgpt.com/codex/tasks/task_e_684af703e758832c98ef5b4027d5d459