### PR TITLE
Validate NPC prototypes

### DIFF
--- a/typeclasses/tests/test_mob_proto_commands.py
+++ b/typeclasses/tests/test_mob_proto_commands.py
@@ -119,3 +119,8 @@ class TestMobPrototypeCommands(EvenniaTest):
         out = self.char1.msg.call_args[0][0]
         assert "missing required field" in out.lower()
 
+    def test_invalid_typeclass(self):
+        with self.assertRaises(ValueError):
+            register_prototype({"key": "bad", "typeclass": "typeclasses.objects.ObjectParent"}, vnum=51)
+
+

--- a/typeclasses/tests/test_vnum_mobs.py
+++ b/typeclasses/tests/test_vnum_mobs.py
@@ -278,3 +278,12 @@ class TestVnumMobs(EvenniaTest):
         npc = [o for o in self.char1.location.contents if o.key == "orc"][0]
         self.assertTrue(npc.tags.has("M2", category="vnum"))
         self.assertFalse(npc.tags.has("M1", category="vnum"))
+
+    def test_typeclass_object_converted_to_path(self):
+        vnum = register_prototype({"key": "ogre", "typeclass": BaseNPC}, vnum=64)
+        self.assertEqual(get_prototype(vnum)["typeclass"], "typeclasses.npcs.BaseNPC")
+
+    def test_invalid_typeclass_raises(self):
+        with self.assertRaises(ValueError):
+            register_prototype({"key": "bad", "typeclass": "typeclasses.objects.ObjectParent"}, vnum=65)
+

--- a/utils/mob_proto.py
+++ b/utils/mob_proto.py
@@ -18,6 +18,23 @@ def register_prototype(data: dict, vnum: int | None = None, *, area: str | None 
     If ``area`` is given, ``vnum`` must fall within that area's range.
     """
     mob_db = get_mobdb()
+    if "typeclass" in data:
+        from typeclasses.characters import NPC
+        tc = data["typeclass"]
+        if isinstance(tc, type):
+            if not issubclass(tc, NPC):
+                raise ValueError(f"Typeclass {tc} does not inherit from NPC")
+            data["typeclass"] = f"{tc.__module__}.{tc.__name__}"
+        elif isinstance(tc, str):
+            module, clsname = tc.rsplit(".", 1)
+            try:
+                cls = getattr(__import__(module, fromlist=[clsname]), clsname)
+            except Exception as err:
+                raise ValueError(f"Could not import typeclass '{tc}'") from err
+            if not issubclass(cls, NPC):
+                raise ValueError(f"Typeclass {tc} does not inherit from NPC")
+        else:
+            raise ValueError("typeclass must be a dotted path string or class object")
     if vnum is None:
         vnum = get_next_vnum("npc")
         if area:


### PR DESCRIPTION
## Summary
- validate typeclass when registering mob prototypes
- test typeclass conversions and invalid typeclass

## Testing
- `pytest typeclasses/tests/test_vnum_mobs.py::TestVnumMobs::test_typeclass_object_converted_to_path -q` *(fails: OperationalError: no such table)*

------
https://chatgpt.com/codex/tasks/task_e_684afa90c0ac832c8f3a9daf79a72545