### PR TITLE
Fix combat script initialization

### DIFF
--- a/typeclasses/scripts.py
+++ b/typeclasses/scripts.py
@@ -232,9 +232,12 @@ def get_or_create_combat_script(location):
     if not (combat_script := location.scripts.get("combat")):
         # there's no combat instance; start one
         location.scripts.add(CombatScript, key="combat")
-        combat_script = location.scripts.get("combat")
+        combat_script = location.scripts.get("combat")[0]
+        # ensure the script is saved before any modifications occur
+        combat_script.save()
+    else:
+        combat_script = combat_script[0]
 
-    combat_script = combat_script[0]
     return combat_script
 
 

--- a/typeclasses/tests/test_admin_commands.py
+++ b/typeclasses/tests/test_admin_commands.py
@@ -444,3 +444,26 @@ class TestAdminCommands(EvenniaTest):
         self.assertIsNotNone(weapon)
         self.assertEqual(weapon.key, "|BBigger Ass Sword|n")
 
+    def test_peace_on_fresh_combat(self):
+        """Peace should immediately end a newly started fight."""
+
+        from commands.combat import CombatCmdSet
+        from commands.admin import CmdPeace
+
+        self.char1.cmdset.add_default(CombatCmdSet)
+        self.char2.cmdset.add_default(CombatCmdSet)
+
+        # avoid running the full combat logic
+        self.char1.attack = MagicMock()
+
+        # start combat via attack command
+        self.char1.execute_cmd(f"attack {self.char2.key}")
+
+        self.assertTrue(self.char1.in_combat)
+
+        cmd = CmdPeace()
+        cmd.caller = self.char1
+        cmd.func()
+
+        self.assertFalse(self.room1.scripts.get("combat"))
+


### PR DESCRIPTION
## Summary
- ensure new CombatScript is saved before team edits
- verify peace command works on newly started combat

## Testing
- `pytest typeclasses/tests/test_admin_commands.py::TestAdminCommands::test_peace_on_fresh_combat -q` *(fails: CombatScript needs id before many-to-many relationship can be used)*

------
https://chatgpt.com/codex/tasks/task_e_684afbd4ec58832cb073feccdb593ec1