### PR TITLE
Fix vnum skip in mob builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,8 @@ Example::
 
 Use `medit <vnum>` to edit an existing numeric prototype. The command
 `medit create <vnum>` reserves the number, loads a basic template and opens the
-builder from the beginning. After setting the desired values choose
+builder from the beginning. The reserved VNUM is pre-filled so the VNUM step in
+the builder is skipped. After setting the desired values choose
 **Yes & Save Prototype** to spawn the NPC and register the prototype.
 
 ## Mob Prototype Manager

--- a/commands/medit.py
+++ b/commands/medit.py
@@ -36,6 +36,7 @@ class CmdMEdit(Command):
             proto = get_template("warrior") or {}
             proto.setdefault("key", f"mob_{vnum}")
             proto.setdefault("level", 1)
+            proto["vnum"] = vnum
         else:
             if not sub.isdigit():
                 caller.msg("Usage: medit <vnum> | medit create <vnum>")
@@ -50,6 +51,7 @@ class CmdMEdit(Command):
                     return
                 register_vnum(vnum)
                 proto = {"key": f"mob_{vnum}", "level": 1}
+            proto.setdefault("vnum", vnum)
 
         caller.ndb.mob_vnum = vnum
         caller.ndb.buildnpc = dict(proto)

--- a/world/menus/mob_builder_menu.py
+++ b/world/menus/mob_builder_menu.py
@@ -10,6 +10,7 @@ from utils.menu_utils import (
     toggle_multi_select,
     format_multi_select,
 )
+from utils import vnum_registry
 from evennia.utils import dedent
 import re
 
@@ -177,7 +178,8 @@ def _set_weight(caller, raw_string, **kwargs):
             )
             return "menunode_weight"
     caller.ndb.buildnpc["weight"] = string
-    return _next_node(caller, "menunode_vnum")
+    next_step = "menunode_creature_type" if caller.ndb.buildnpc.get("vnum") is not None else "menunode_vnum"
+    return _next_node(caller, next_step)
 
 
 def menunode_desc(caller, raw_string="", **kwargs):


### PR DESCRIPTION
## Summary
- skip redundant vnum prompt in mob builder
- fix missing vnum_registry import
- pre-fill reserved vnum when launching medit
- document the new behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684b015c2330832c8ae378b17d276af7