### PR TITLE
Add get_health_description helper

### DIFF
--- a/combat/combat_engine.py
+++ b/combat/combat_engine.py
@@ -12,9 +12,9 @@ from .combat_actions import Action, AttackAction, CombatResult
 from .damage_types import DamageType
 from .combat_utils import (
     format_combat_message,
-    get_condition_msg,
     calculate_initiative,
 )
+from world.combat import get_health_description
 
 
 @dataclass
@@ -509,10 +509,7 @@ class CombatEngine:
                 damage_totals[actor] = damage_totals.get(actor, 0) + damage_done
 
             if result.target:
-                hp = getattr(getattr(result.target, "traits", None), "health", None)
-                cur = getattr(hp, "value", getattr(result.target, "hp", 0))
-                max_hp = getattr(hp, "max", getattr(result.target, "max_hp", cur))
-                cond = get_condition_msg(cur, max_hp)
+                cond = get_health_description(result.target)
                 self.round_output.append(f"The {result.target.key} {cond}")
 
             if actor.location and result.message:

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -17,7 +17,7 @@ import math
 from world.triggers import TriggerManager
 from world.spells import Spell
 from combat.combat_actions import CombatResult
-from combat import get_condition_msg
+from world.combat import get_health_description
 from combat import combat_utils
 
 from .objects import ObjectParent
@@ -1056,10 +1056,7 @@ class NPC(Character):
             and looker.has_account
             and self.is_typeclass("typeclasses.npcs.NPC", exact=False)
         ):
-            hp = getattr(getattr(self, "traits", None), "health", None)
-            cur = getattr(hp, "value", getattr(self, "hp", 0))
-            max_hp = getattr(hp, "max", getattr(self, "max_hp", cur))
-            cond = get_condition_msg(cur, max_hp)
+            cond = get_health_description(self)
             text = text.rstrip() + f"\n{self.get_display_name(looker)} {cond}"
         return text
 

--- a/typeclasses/gear.py
+++ b/typeclasses/gear.py
@@ -6,6 +6,7 @@ from evennia.contrib.game_systems.containers import ContribContainer
 from .objects import Object, ClothingObject
 from world.system import stat_manager, state_manager
 from combat import combat_utils
+from world.combat import get_health_description
 
 
 class BareHand:
@@ -80,10 +81,7 @@ class BareHand:
             )
             dealt = target.at_damage(wielder, damage, "bludgeon", critical=crit)
             combat_utils.apply_lifesteal(wielder, dealt)
-            hp = getattr(getattr(target, "traits", None), "health", None)
-            cur = getattr(hp, "value", getattr(target, "hp", 0))
-            max_hp = getattr(hp, "max", getattr(target, "max_hp", cur))
-            condition = combat_utils.get_condition_msg(cur, max_hp)
+            condition = get_health_description(target)
             if wielder.location:
                 wielder.location.msg_contents(f"The {target.key} {condition}")
             if status := getattr(self, "status_effect", None):
@@ -198,10 +196,7 @@ class MeleeWeapon(Object):
             )
             dealt = target.at_damage(wielder, damage, damage_type, critical=crit)
             combat_utils.apply_lifesteal(wielder, dealt)
-            hp = getattr(getattr(target, "traits", None), "health", None)
-            cur = getattr(hp, "value", getattr(target, "hp", 0))
-            max_hp = getattr(hp, "max", getattr(target, "max_hp", cur))
-            condition = combat_utils.get_condition_msg(cur, max_hp)
+            condition = get_health_description(target)
             if wielder.location:
                 wielder.location.msg_contents(f"The {target.key} {condition}")
             if status := getattr(self.db, "status_effect", None):

--- a/world/combat.py
+++ b/world/combat.py
@@ -1,0 +1,19 @@
+"""Combat-related helper functions for the world package."""
+
+from combat import combat_utils
+
+__all__ = ["get_health_description"]
+
+
+def get_health_description(char):
+    """Return a health status string for `char`.
+
+    This looks for ``traits.health`` on ``char`` if available, with
+    ``char.hp`` and ``char.max_hp`` as fallbacks. The values are then
+    passed to :func:`combat.combat_utils.get_condition_msg` to create a
+    readable description.
+    """
+    hp_trait = getattr(getattr(char, "traits", None), "health", None)
+    cur = getattr(hp_trait, "value", getattr(char, "hp", 0))
+    max_hp = getattr(hp_trait, "max", getattr(char, "max_hp", cur))
+    return combat_utils.get_condition_msg(cur, max_hp)


### PR DESCRIPTION
## Summary
- add `world.combat.get_health_description`
- use it in the combat engine, gear, and characters modules

## Testing
- `pytest -q utils/tests/test_combat_utils.py::TestCombatUtils::test_get_condition_msg -q` *(fails: django.db.utils.OperationalError: no such table)*

------
https://chatgpt.com/codex/tasks/task_e_684b1573e100832c80f8a7eff7f39e99