### PR TITLE
Modify NPC appearance formatting

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -1047,18 +1047,24 @@ class NPC(Character):
         super().at_object_receive(obj, source_location, **kwargs)
         self.check_triggers("object_receive", item=obj, giver=source_location)
 
-    def return_appearance(self, looker, **kwargs):
-        text = super().return_appearance(looker, **kwargs)
+    def return_appearance(self, looker, *, room=False, **kwargs):
+        """Return a description of this NPC.
+
+        Args:
+            looker (Object): The object looking at us.
+            room (bool, optional): If ``True``, return the short room
+                description. Defaults to ``False``.
+        """
+
+        if room:
+            return f"{self.db.shortdesc or self.key} is here."
+
         if looker != self:
             self.check_triggers("on_look", looker=looker)
-        if (
-            looker
-            and looker.has_account
-            and self.is_typeclass("typeclasses.npcs.NPC", exact=False)
-        ):
-            cond = get_health_description(self)
-            text = text.rstrip() + f"\n{self.get_display_name(looker)} {cond}"
-        return text
+
+        longdesc = self.db.long_desc or self.db.desc or "You see nothing special."
+        status = get_health_description(self)
+        return f"{longdesc}\n\n{self.key.capitalize()} {status}"
 
     def at_damage(self, attacker, damage, damage_type=None, critical=False):
         """

--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -153,15 +153,14 @@ class RoomParent(ObjectParent):
 
         env_objects, npcs, items, players = [], [], [], []
         for obj in visible:
-            name = obj.get_display_name(looker)
             if obj.db.display_priority == "environment":
-                env_objects.append(name)
+                env_objects.append(obj.get_display_name(looker))
             elif obj.is_typeclass("typeclasses.npcs.NPC", exact=False):
-                npcs.append(name)
+                npcs.append(obj.return_appearance(looker, room=True))
             elif obj.is_typeclass("typeclasses.characters.Character", exact=False):
-                players.append(name)
+                players.append(obj.get_display_name(looker))
             else:
-                items.append(name)
+                items.append(obj.get_display_name(looker))
 
         for category in (env_objects, npcs, items, players):
             if category:

--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -523,7 +523,7 @@ class TestReturnAppearance(EvenniaTest):
 
         npc = create.create_object(BaseNPC, key="mob", location=self.room1)
         out = npc.return_appearance(self.char1)
-        self.assertIn("excellent condition", out)
+        self.assertIn("Mob is in excellent condition.", out)
 
 
 class TestRestCommands(EvenniaTest):


### PR DESCRIPTION
## Summary
- NPCs get a new `return_appearance` implementation
- Rooms display NPCs using their short room description
- Adjust test to match new NPC format

## Testing
- `pytest -q` *(fails: OperationalError - no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684b17182d58832ca1a71a67f8770f68