### PR TITLE
Implement player appearance with equipment

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -878,6 +878,29 @@ class PlayerCharacter(Character):
         self.move_to(self.home)
         self.msg(prompt=self.get_display_status(self))
 
+    def return_appearance(self, looker):
+        """Return a description of this player with equipped items."""
+
+        if not looker:
+            return ""
+
+        eq_lines = []
+        for slot, item in self.equipment.items():
+            if not item:
+                continue
+            if not item.access(looker, "view") or not item.access(looker, "search", default=True):
+                continue
+            if hasattr(looker, "can_see") and not looker.can_see(item):
+                continue
+            eq_lines.append(f"|w{slot.capitalize()}|n: {item.get_display_name(looker)}")
+
+        if not eq_lines:
+            eq_lines.append("They are not wearing any equipment.")
+
+        eq_text = "\n".join(eq_lines)
+        desc = self.db.desc or "You see nothing special."
+        return f"{eq_text}\n{desc}"
+
 
 class NPC(Character):
     """Base typeclass for AI-driven non-player characters.

--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -525,6 +525,27 @@ class TestReturnAppearance(EvenniaTest):
         out = npc.return_appearance(self.char1)
         self.assertIn("Mob is in excellent condition.", out)
 
+    def test_player_equipment_displayed(self):
+        from evennia.utils import create
+
+        item = create.create_object(
+            "typeclasses.objects.ClothingObject",
+            key="cap",
+            location=self.char1,
+        )
+        item.tags.add("equipment", category="flag")
+        item.tags.add("identified", category="flag")
+        item.tags.add("head", category="slot")
+        item.wear(self.char1, True)
+
+        out = self.char1.return_appearance(self.char2)
+        self.assertIn("|wHead|n: ", out)
+        self.assertIn(item.key, out)
+
+    def test_player_no_equipment(self):
+        out = self.char1.return_appearance(self.char2)
+        self.assertIn("They are not wearing any equipment.", out)
+
 
 class TestRestCommands(EvenniaTest):
     def setUp(self):


### PR DESCRIPTION
## Summary
- add `PlayerCharacter.return_appearance` to list equipped items
- show placeholder when no equipment is worn
- append player description after the equipment list
- add unit tests for player appearance

## Testing
- `pytest typeclasses/tests/test_commands.py::TestReturnAppearance::test_player_equipment_displayed -q`


------
https://chatgpt.com/codex/tasks/task_e_684b189082bc832c80522df49f4cc68b