### PR TITLE
Add loot editing menu for ROM mob editor

### DIFF
--- a/typeclasses/tests/test_medit_command.py
+++ b/typeclasses/tests/test_medit_command.py
@@ -80,3 +80,13 @@ class TestMEditCommand(EvenniaTest):
         data = self.char1.ndb.buildnpc
         assert data["key"] == "troll"
         assert self.char1.ndb.mob_vnum == 7
+
+    def test_rom_menu_has_loot_option(self):
+        from commands import rom_mob_editor
+
+        self.char1.ndb.mob_proto = {}
+        self.char1.ndb.mob_vnum = 1
+        _, options = rom_mob_editor.menunode_main(self.char1)
+        gotos = [opt.get("goto") for opt in options]
+        assert "menunode_loot" in gotos
+        assert gotos[-2:] == ["menunode_loot", "menunode_cancel"]


### PR DESCRIPTION
## Summary
- add a loot editing menu node to the ROM mob editor
- insert Edit loot option in the main menu
- test that the loot option appears in the ROM editor menu

## Testing
- `python -m py_compile commands/rom_mob_editor.py typeclasses/tests/test_medit_command.py`
- `pytest typeclasses/tests/test_medit_command.py::TestMEditCommand::test_rom_menu_has_loot_option -vv` *(fails: OperationalError no such table)*

------
https://chatgpt.com/codex/tasks/task_e_684b1bda0890832ca463a93889569c80