### PR TITLE
Implement corpse utility and enhance NPC death

### DIFF
--- a/typeclasses/tests/test_combat_engine.py
+++ b/typeclasses/tests/test_combat_engine.py
@@ -197,6 +197,12 @@ class TestCombatDeath(EvenniaTest):
         npc.db.exp_reward = 5
         npc.db.coin_drop = {"silver": 3}
         self.char1.db.coins = from_copper(0)
+        item = create.create_object("typeclasses.objects.Object", key="loot", location=npc)
+        weapon = create.create_object("typeclasses.objects.Object", key="sword")
+        weapon.tags.add("equipment", category="flag")
+        weapon.tags.add("identified", category="flag")
+        npc.db.equipment = {"mainhand": weapon}
+        weapon.location = None
 
         engine = CombatEngine([player, npc], round_time=0)
         engine.queue_action(player, KillAction(player, npc))
@@ -214,6 +220,8 @@ class TestCombatDeath(EvenniaTest):
         )
         self.assertEqual(corpse.db.corpse_of, npc.key)
         self.assertEqual(corpse.db.desc, f"The corpse of {npc.key} lies here.")
+        self.assertIn(item, corpse.contents)
+        self.assertIn(weapon, corpse.contents)
 
     def test_npc_death_creates_only_one_corpse(self):
         from evennia.utils import create

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -10,6 +10,7 @@ try:  # optional during early initialization
         add_to_mlist,
         auto_calc,
         auto_calc_secondary,
+        make_corpse,
     )
 except Exception:  # pragma: no cover - may fail before Django setup
     pass

--- a/world/mob_constants.py
+++ b/world/mob_constants.py
@@ -68,6 +68,7 @@ class ACTFLAGS(_StrEnum):
     WIMPY = "wimpy"
     ASSIST = "assist"
     CALL_FOR_HELP = "call_for_help"
+    NOLOOT = "noloot"
 
 
 class AFFECTED_BY(_StrEnum):


### PR DESCRIPTION
## Summary
- introduce `make_corpse` helper to create corpses, transfer gear and drop coins
- add `NOLOOT` act flag
- update NPC death handling to stop combat, create corpses and give rewards
- adjust loot dropping to use new corpse helper
- test that equipment and inventory end up in corpses on death

## Testing
- `pytest -k "TestCombatDeath" -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684b29569728832ca086c331d88d3fb3