### PR TITLE
Add body part prototypes and update corpse spawning

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,10 @@ Several basic NPC prototypes are included out of the box. Try `cnpc dev_spawn ba
 or `@spawnnpc basic_merchant` to quickly create a merchant, or `basic_questgiver` for a quest
 giver.
 
+Body part prototypes such as `HEAD_PART` or `ARMS_PART` are also provided in
+`world/prototypes.py`. These are used when player corpses are created and can be
+spawned in your own areas or loot tables.
+
 ### Mob Program Commands
 
 Triggers can run mob program commands to control NPCs. Useful actions include:

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -885,12 +885,20 @@ class PlayerCharacter(Character):
             location=self.location,
             attributes=[("corpse_of", self.key)],
         )
+        from world import prototypes
+
         for part in BODYPARTS:
-            create.create_object(
-                "typeclasses.objects.Object",
-                key=part.value,
-                location=corpse,
-            )
+            proto_name = f"{part.name}_PART"
+            proto = getattr(prototypes, proto_name, None)
+            if proto:
+                obj = spawn(proto)[0]
+                obj.location = corpse
+            else:
+                create.create_object(
+                    "typeclasses.objects.Object",
+                    key=part.value,
+                    location=corpse,
+                )
         self.at_death(attacker)
         self.award_xp_to(attacker)
 

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -90,6 +90,7 @@ Notes:
     - Primary stats cap at 999.
     - Use @mcreate and @mset to manage NPC prototypes.
     - Shops and repairs use @makeshop/@shopset and @makerepair/@repairset.
+    - Body part prototypes like HEAD_PART and ARMS_PART can be spawned for corpses or loot.
 
 Related:
     help ansi

--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -485,6 +485,78 @@ DEER_ANTLER = {
     ],
 }
 
+### Body parts
+
+HEAD_PART = {
+    "key": "head",
+    "desc": "A severed head.",
+}
+
+ARMS_PART = {
+    "key": "arms",
+    "desc": "Two severed arms.",
+}
+
+LEGS_PART = {
+    "key": "legs",
+    "desc": "Two severed legs.",
+}
+
+HEART_PART = {
+    "key": "heart",
+    "desc": "A bloody heart.",
+}
+
+BRAIN_PART = {
+    "key": "brain",
+    "desc": "A pale brain.",
+}
+
+GUTS_PART = {
+    "key": "guts",
+    "desc": "Some slippery entrails.",
+}
+
+HANDS_PART = {
+    "key": "hands",
+    "desc": "A pair of severed hands.",
+}
+
+FEET_PART = {
+    "key": "feet",
+    "desc": "A pair of severed feet.",
+}
+
+FINGERS_PART = {
+    "key": "fingers",
+    "desc": "Several disjointed fingers.",
+}
+
+EARS_PART = {
+    "key": "ears",
+    "desc": "A pair of severed ears.",
+}
+
+EYES_PART = {
+    "key": "eyes",
+    "desc": "Two staring eyes.",
+}
+
+LONG_TONGUE_PART = {
+    "key": "long tongue",
+    "desc": "A remarkably long tongue.",
+}
+
+EYESTALKS_PART = {
+    "key": "eyestalks",
+    "desc": "A set of slimy eyestalks.",
+}
+
+TENTACLES_PART = {
+    "key": "tentacles",
+    "desc": "A mass of twitching tentacles.",
+}
+
 # Example loot table entry structure. A loot table is stored on
 # ``npc.db.loot_table`` as a list of mappings with the prototype key and the
 # percent chance to drop that prototype when the NPC dies.


### PR DESCRIPTION
## Summary
- create prototypes for each entry in `BODYPARTS`
- spawn these prototypes when a player dies
- mention body part prototypes in builder docs and README

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684b2b821f38832ca650ae231a550331