### PR TITLE
Enable vnum-based loot table entries

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -973,6 +973,7 @@ class NPC(Character):
     def drop_loot(self, killer=None):
         """Create a corpse and deposit any drops and coins."""
         from utils.currency import COIN_VALUES
+        from utils.prototype_manager import load_prototype
 
         drops = list(self.db.drops)
         coin_loot: dict[str, int] = {}
@@ -989,11 +990,16 @@ class NPC(Character):
                 if roll <= chance or (
                     guaranteed is not None and count >= int(guaranteed)
                 ):
-                    if proto.lower() in COIN_VALUES:
+                    if isinstance(proto, str) and proto.lower() in COIN_VALUES:
                         amt = int(entry.get("amount", 1))
                         coin_loot[proto.lower()] = coin_loot.get(proto.lower(), 0) + amt
                     else:
-                        drops.append(proto)
+                        if isinstance(proto, int) or (isinstance(proto, str) and proto.isdigit()):
+                            proto_data = load_prototype("object", int(proto))
+                            if proto_data:
+                                drops.append(proto_data)
+                        else:
+                            drops.append(proto)
                     entry["_count"] = 0
                 else:
                     entry["_count"] = count + 1

--- a/typeclasses/tests/test_loot_table.py
+++ b/typeclasses/tests/test_loot_table.py
@@ -9,14 +9,17 @@ class TestNPCLootTable(EvenniaTest):
 
         npc = create.create_object(NPC, key="mob", location=self.room1)
         npc.db.drops = []
-        npc.db.loot_table = [{"proto": "RAW_MEAT", "chance": 100}]
+        npc.db.loot_table = [{"proto": 100001, "chance": 100}]
         npc.db.coin_drop = {"gold": 1}
         self.char1.db.coins = from_copper(0)
         npc.traits.health.current = 1
-        with patch("evennia.prototypes.spawner.spawn", return_value=[MagicMock()]) as mock_spawn:
+        proto_data = {"key": "ruby dagger"}
+        with patch("utils.prototype_manager.load_prototype", return_value=proto_data) as load_mock, \
+             patch("evennia.prototypes.spawner.spawn", return_value=[MagicMock()]) as mock_spawn:
             room = npc.location
             npc.at_damage(self.char1, 2)
-            mock_spawn.assert_called_with("RAW_MEAT")
+            load_mock.assert_called_with("object", 100001)
+            mock_spawn.assert_called_with(proto_data)
 
             corpse = next(
                 obj

--- a/typeclasses/tests/test_mob_builder.py
+++ b/typeclasses/tests/test_mob_builder.py
@@ -240,6 +240,14 @@ class TestMobBuilder(EvenniaTest):
             {"proto": "gold", "chance": 100, "amount": 5}
         ]
 
+    def test_edit_loot_table_vnum(self):
+        self.char1.ndb.buildnpc = {}
+        with patch("world.menus.mob_builder_menu.load_prototype", return_value={"key": "obj"}):
+            npc_builder._edit_loot_table(self.char1, "add 100001 50")
+        assert self.char1.ndb.buildnpc["loot_table"] == [
+            {"proto": 100001, "chance": 50}
+        ]
+
     def test_exp_reward_back_returns_to_level(self):
         """Entering back at exp reward should return to level menu."""
         self.char1.ndb.buildnpc = {"level": 1}

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -3523,7 +3523,7 @@ Usage:
         "text": """Help for loot tables
 
 Loot tables control random item drops from NPCs. Each entry is a mapping with
-the prototype key and drop chance::
+the prototype key or object VNUM and drop chance::
 
     [{"proto": "RAW_MEAT", "chance": 50}]
 
@@ -3533,7 +3533,7 @@ Usage:
     @mset <proto> loot_table <json>
 
 Examples:
-    @mset wolf loot_table "[{\"proto\": \"RAW_MEAT\", \"chance\": 75}]"
+    @mset wolf loot_table "[{\"proto\": 5000, \"chance\": 75}]"
     @mset bandit loot_table "[{\"proto\": \"IRON_SWORD\", \"chance\": 25}]"
     @mset goblin loot_table "[{\"proto\": \"gold\", \"chance\": 100, \"amount\": 5}]"
 

--- a/world/menus/mob_builder_menu.py
+++ b/world/menus/mob_builder_menu.py
@@ -645,6 +645,8 @@ def menunode_coin_drop(caller, raw_string="", **kwargs):
 
 def _set_coin_drop(caller, raw_string, **kwargs):
     from utils.currency import COIN_VALUES
+    from utils.prototype_manager import load_prototype
+    from utils import vnum_registry
 
     string = raw_string.strip()
     if string.lower() == "back":
@@ -683,7 +685,7 @@ def menunode_loot_table(caller, raw_string="", **kwargs):
         text += "None\n"
     text += (
         "Commands:\n  add <proto> [chance] [amount] [guaranteed]\n  remove <proto>\n  done - finish\n  back - previous step\n"
-        "Example: |wadd RAW_MEAT 50 3|n, |wadd gold 100 5|n"
+        "Example: |wadd 5000 50|n, |wadd gold 100 5|n"
     )
     options = add_back_skip(
         {"key": "_default", "goto": _edit_loot_table}, _edit_loot_table
@@ -706,6 +708,15 @@ def _edit_loot_table(caller, raw_string, **kwargs):
             caller.msg("Usage: add <proto> [chance] [amount] [guaranteed]")
             return "menunode_loot_table"
         proto = parts[0]
+        if proto.isdigit():
+            vnum = int(proto)
+            if not vnum_registry.VNUM_RANGES["object"][0] <= vnum <= vnum_registry.VNUM_RANGES["object"][1]:
+                caller.msg("Invalid object VNUM.")
+                return "menunode_loot_table"
+            if not load_prototype("object", vnum):
+                caller.msg("Unknown object VNUM.")
+                return "menunode_loot_table"
+            proto = vnum
         chance = 100
         amount = 1
         guaranteed = None
@@ -714,7 +725,7 @@ def _edit_loot_table(caller, raw_string, **kwargs):
                 caller.msg("Chance must be a number.")
                 return "menunode_loot_table"
             chance = int(parts[1])
-        if proto.lower() in COIN_VALUES and len(parts) > 2:
+        if isinstance(proto, str) and proto.lower() in COIN_VALUES and len(parts) > 2:
             if not parts[2].isdigit():
                 caller.msg("Amount must be a number.")
                 return "menunode_loot_table"
@@ -733,7 +744,7 @@ def _edit_loot_table(caller, raw_string, **kwargs):
         for entry in table:
             if entry.get("proto") == proto:
                 entry["chance"] = chance
-                if proto.lower() in COIN_VALUES:
+                if isinstance(proto, str) and proto.lower() in COIN_VALUES:
                     entry["amount"] = amount
                 if guaranteed is not None:
                     entry["guaranteed_after"] = guaranteed
@@ -743,7 +754,7 @@ def _edit_loot_table(caller, raw_string, **kwargs):
                 break
         else:
             entry = {"proto": proto, "chance": chance}
-            if proto.lower() in COIN_VALUES:
+            if isinstance(proto, str) and proto.lower() in COIN_VALUES:
                 entry["amount"] = amount
             if guaranteed is not None:
                 entry["guaranteed_after"] = guaranteed


### PR DESCRIPTION
## Summary
- allow loot table editor to accept object VNUMs
- verify VNUMs are valid and object prototypes exist
- spawn loot from item VNUMs when NPCs die
- document VNUM usage in loot table help
- update tests for new behaviour

## Testing
- `python -m py_compile commands/rom_mob_editor.py world/menus/mob_builder_menu.py typeclasses/characters.py typeclasses/tests/test_loot_table.py typeclasses/tests/test_mob_builder.py world/help_entries.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684b2bfd5c14832ca6678bd4cb928add