### PR TITLE
Fix loot list when no drops defined

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -983,7 +983,7 @@ class NPC(Character):
         from utils.currency import COIN_VALUES
         from utils.prototype_manager import load_prototype
 
-        drops = list(self.db.drops)
+        drops = list(self.db.drops or [])
         coin_loot: dict[str, int] = {}
         if loot_table := self.db.loot_table:
             for entry in loot_table:


### PR DESCRIPTION
## Summary
- handle `None` drops when NPCs drop loot

## Testing
- `pytest -q` *(fails: OperationalError - no such table)*

------
https://chatgpt.com/codex/tasks/task_e_684b307b16fc832ca8dafe0638846461