### PR TITLE
Fix invalid loot table VNUM

### DIFF
--- a/commands/rom_mob_editor.py
+++ b/commands/rom_mob_editor.py
@@ -329,7 +329,7 @@ def menunode_loot(caller, raw_string="", **kwargs):
         text += "None\n"
     text += (
         "Commands:\n  add <proto> [chance] [amount] [guaranteed]\n  remove <proto>\n  "
-        "done - return\n  back - return\nExample: |wadd 5000 50|n, |wadd gold 100 5|n"
+        "done - return\n  back - return\nExample: |wadd 100001 50|n, |wadd gold 100 5|n"
     )
     options = {"key": "_default", "goto": _edit_loot}
     return _with_summary(caller, text), options

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -3534,7 +3534,7 @@ Usage:
     @mset <proto> loot_table <json>
 
 Examples:
-    @mset wolf loot_table "[{\"proto\": 5000, \"chance\": 75}]"
+    @mset wolf loot_table "[{\"proto\": 100001, \"chance\": 75}]"
     @mset bandit loot_table "[{\"proto\": \"IRON_SWORD\", \"chance\": 25}]"
     @mset goblin loot_table "[{\"proto\": \"gold\", \"chance\": 100, \"amount\": 5}]"
 

--- a/world/menus/mob_builder_menu.py
+++ b/world/menus/mob_builder_menu.py
@@ -685,7 +685,7 @@ def menunode_loot_table(caller, raw_string="", **kwargs):
         text += "None\n"
     text += (
         "Commands:\n  add <proto> [chance] [amount] [guaranteed]\n  remove <proto>\n  done - finish\n  back - previous step\n"
-        "Example: |wadd 5000 50|n, |wadd gold 100 5|n"
+        "Example: |wadd 100001 50|n, |wadd gold 100 5|n"
     )
     options = add_back_skip(
         {"key": "_default", "goto": _edit_loot_table}, _edit_loot_table


### PR DESCRIPTION
## Summary
- replace obsolete vnum `5000` with valid `100001` in loot table documentation and menu prompts

## Testing
- `pytest -q` *(fails: django.db errors)*

------
https://chatgpt.com/codex/tasks/task_e_684b32381d8c832ca658423c21a93790