### PR TITLE
Remove unused imports from mob builder menu

### DIFF
--- a/world/menus/mob_builder_menu.py
+++ b/world/menus/mob_builder_menu.py
@@ -11,6 +11,7 @@ from utils.menu_utils import (
     format_multi_select,
 )
 from utils import vnum_registry
+from utils.prototype_manager import load_prototype
 from evennia.utils import dedent
 import re
 
@@ -645,8 +646,6 @@ def menunode_coin_drop(caller, raw_string="", **kwargs):
 
 def _set_coin_drop(caller, raw_string, **kwargs):
     from utils.currency import COIN_VALUES
-    from utils.prototype_manager import load_prototype
-    from utils import vnum_registry
 
     string = raw_string.strip()
     if string.lower() == "back":


### PR DESCRIPTION
## Summary
- clean up `_set_coin_drop` imports
- add global `load_prototype` import used by loot table editing

## Testing
- `ruff check world/menus/mob_builder_menu.py`

------
https://chatgpt.com/codex/tasks/task_e_684b3378e4b4832c81ad37c49952e982