### PR TITLE
Fix loot removal comparison for numeric prototypes

### DIFF
--- a/commands/rom_mob_editor.py
+++ b/commands/rom_mob_editor.py
@@ -404,6 +404,8 @@ def _edit_loot(caller, raw_string, **kwargs):
         return "menunode_loot"
     if string.lower().startswith("remove "):
         proto = string[7:].strip()
+        if proto.isdigit():
+            proto = int(proto)
         for entry in list(table):
             if entry.get("proto") == proto:
                 table.remove(entry)

--- a/world/menus/mob_builder_menu.py
+++ b/world/menus/mob_builder_menu.py
@@ -762,6 +762,8 @@ def _edit_loot_table(caller, raw_string, **kwargs):
         return _next_node(caller, "menunode_loot_table")
     if string.lower().startswith("remove "):
         proto = string[7:].strip()
+        if proto.isdigit():
+            proto = int(proto)
         for entry in list(table):
             if entry.get("proto") == proto:
                 table.remove(entry)


### PR DESCRIPTION
## Summary
- update the remove command in rom_mob_editor
- update the remove command in mob_builder_menu

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684b34cd821c832c8588a936c7b56dce