### PR TITLE
Add hp helper properties and trait fallbacks

### DIFF
--- a/combat/combat_actions.py
+++ b/combat/combat_actions.py
@@ -156,7 +156,8 @@ class AttackAction(Action):
         dmg = 0
         dtype = DamageType.BLUDGEONING
 
-        if hasattr(target, "hp"):
+        hp_trait = getattr(getattr(target, "traits", None), "health", None)
+        if hasattr(target, "hp") or hp_trait:
             if isinstance(weapon, dict):
                 dmg = weapon.get("damage", 0)
                 dtype = weapon.get("damage_type", DamageType.BLUDGEONING)

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -87,6 +87,34 @@ class Character(ObjectParent, ClothedCharacter):
         return CooldownHandler(self, db_attribute="cooldowns")
 
     @property
+    def hp(self):
+        """Current health points."""
+        hp_trait = getattr(self.traits, "health", None)
+        if hp_trait:
+            return hp_trait.current
+        return 0
+
+    @hp.setter
+    def hp(self, value: int) -> None:
+        hp_trait = getattr(self.traits, "health", None)
+        if hp_trait:
+            hp_trait.current = value
+
+    @property
+    def max_hp(self):
+        """Maximum health points."""
+        hp_trait = getattr(self.traits, "health", None)
+        if hp_trait:
+            return hp_trait.max
+        return 0
+
+    @max_hp.setter
+    def max_hp(self, value: int) -> None:
+        hp_trait = getattr(self.traits, "health", None)
+        if hp_trait:
+            hp_trait.max = value
+
+    @property
     def wielding(self):
         """Access a list of all wielded objects"""
         return [obj for obj in self.attributes.get("_wielded", {}).values() if obj]


### PR DESCRIPTION
## Summary
- support `hp`/`max_hp` as properties backed by `traits.health`
- resolve attacks when targets only expose `traits.health`
- rely on trait health in combat engine when `hp` attr is absent

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684b381dcd5c832c9e1043412d1ae457