### PR TITLE
Fix peace command after combat deletion

### DIFF
--- a/commands/admin.py
+++ b/commands/admin.py
@@ -440,7 +440,7 @@ class CmdPeace(Command):
             return
 
         combat_script = location.scripts.get("combat")
-        if not combat_script:
+        if not combat_script or combat_script[0].pk is None:
             caller.msg("There is no fighting here.")
             return
 

--- a/typeclasses/tests/test_admin_commands.py
+++ b/typeclasses/tests/test_admin_commands.py
@@ -467,3 +467,23 @@ class TestAdminCommands(EvenniaTest):
 
         self.assertFalse(self.room1.scripts.get("combat"))
 
+    def test_peace_after_victory(self):
+        """Peace should handle the combat script being deleted already."""
+
+        from typeclasses.scripts import CombatScript
+
+        self.room1.scripts.add(CombatScript, key="combat")
+        script = self.room1.scripts.get("combat")[0]
+        script.add_combatant(self.char1, enemy=self.char2)
+
+        # defeat the opponent
+        self.char2.tags.add("dead", category="status")
+        script.check_victory()
+
+        # combat script should now be deleted
+        self.assertFalse(self.room1.scripts.get("combat"))
+
+        self.char1.msg.reset_mock()
+        self.char1.execute_cmd("peace")
+        self.char1.msg.assert_called_with("There is no fighting here.")
+


### PR DESCRIPTION
## Summary
- handle cases where the combat script has already been deleted
- test that `peace` handles a deleted combat script

## Testing
- `pytest -q` *(fails: OperationalError - no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684b422e9e7c832cbb1bec88fa271880