### PR TITLE
Add loot command

### DIFF
--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -36,6 +36,7 @@ from commands.bank import CmdBank
 from commands.info import InfoCmdSet
 from commands.guilds import GuildCmdSet
 from commands.rest import RestCmdSet
+from commands.loot import LootCmdSet
 from commands.who import CmdWho
 from commands.building import CmdDig, CmdTeleport, CmdDelRoom
 from commands.areas import AreaCmdSet
@@ -77,6 +78,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(SpellCmdSet)
         self.add(InteractCmdSet)
         self.add(InfoCmdSet)
+        self.add(LootCmdSet)
         self.add(RestCmdSet)
         self.add(GuildCmdSet)
         self.add(EquipmentCmdSet)

--- a/commands/loot.py
+++ b/commands/loot.py
@@ -1,0 +1,40 @@
+from evennia import CmdSet
+from .command import Command
+
+
+class CmdLoot(Command):
+    """Loot items from a corpse."""
+
+    key = "loot"
+    help_category = "General"
+
+    def func(self):
+        caller = self.caller
+        if not self.args:
+            caller.msg("Loot what?")
+            return
+        target = caller.search(self.args.strip())
+        if not target:
+            return
+        if not target.is_typeclass("typeclasses.objects.Corpse", exact=False):
+            caller.msg("You can only loot corpses.")
+            return
+        items = list(target.contents)
+        if not items:
+            caller.msg("There's nothing left to loot.")
+            return
+        for obj in items:
+            if obj.move_to(caller, quiet=True, move_type="get"):
+                obj.at_get(caller)
+                caller.msg(
+                    f"You loot {obj.get_display_name(caller)} from {target.get_display_name(caller)}."
+                )
+        caller.update_carry_weight()
+
+
+class LootCmdSet(CmdSet):
+    key = "Loot CmdSet"
+
+    def at_cmdset_creation(self):
+        super().at_cmdset_creation()
+        self.add(CmdLoot)

--- a/typeclasses/tests/test_loot_command.py
+++ b/typeclasses/tests/test_loot_command.py
@@ -1,0 +1,31 @@
+"""Tests for the loot command."""
+
+from unittest.mock import MagicMock
+from django.test import override_settings
+from evennia.utils import create
+from evennia.utils.test_resources import EvenniaTest
+
+
+@override_settings(DEFAULT_HOME=None)
+class TestCmdLoot(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.char1.msg = MagicMock()
+
+    def test_loot_moves_items(self):
+        from typeclasses.characters import NPC
+
+        npc = create.create_object(NPC, key="mob", location=self.room1)
+        item = create.create_object("typeclasses.objects.Object", key="loot", location=npc)
+        npc.db.drops = []
+        npc.traits.health.current = 1
+        npc.at_damage(self.char1, 2)
+
+        corpse = next(
+            obj for obj in self.room1.contents
+            if obj.is_typeclass("typeclasses.objects.Corpse", exact=False)
+        )
+
+        self.char1.execute_cmd(f"loot {corpse.key}")
+
+        assert item.location == self.char1


### PR DESCRIPTION
## Summary
- introduce `CmdLoot` to take items from corpses
- wire loot command into the default command set
- cover behaviour with a new test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684b47901794832cb9f3d71cb42411be