### PR TITLE
Add dice formula support for weapon damage

### DIFF
--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -19,3 +19,5 @@ try:
 except Exception:  # pragma: no cover - may fail before Django setup
     def eval_safe(*args, **kwargs):
         raise RuntimeError("eval_safe unavailable before Django setup")
+
+from .dice import roll_dice_string

--- a/utils/dice.py
+++ b/utils/dice.py
@@ -1,0 +1,36 @@
+"""Dice rolling utilities."""
+
+import random
+import re
+
+_DICE_TERM = re.compile(r"(?P<count>\d*)d(?P<sides>\d+)", re.I)
+
+
+def roll_dice_string(formula: str) -> int:
+    """Roll dice defined by ``formula``.
+
+    The formula may contain dice expressions like ``'2d6'`` mixed with
+    integer values separated by ``+`` or ``-``. Missing counts default
+    to one die.
+    """
+    if not formula:
+        return 0
+
+    expr = str(formula).replace(" ", "")
+    total = 0
+    for term in re.finditer(r"([+-]?[^+-]+)", expr):
+        piece = term.group(0)
+        sign = 1
+        if piece[0] in "+-":
+            if piece[0] == "-":
+                sign = -1
+            piece = piece[1:]
+        match = _DICE_TERM.fullmatch(piece)
+        if match:
+            count = int(match.group("count") or 1)
+            sides = int(match.group("sides"))
+            value = sum(random.randint(1, sides) for _ in range(count))
+        else:
+            value = int(piece)
+        total += sign * value
+    return total


### PR DESCRIPTION
## Summary
- add `utils.dice.roll_dice_string` helper for rolling dice formulas
- export `roll_dice_string`
- support `db.damage` mapping in `MeleeWeapon.at_attack`
- test damage mapping logic

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684b4edf94fc832c8e7c5e97af1b5bb7