### PR TITLE
Fix combat script initialization

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -1237,13 +1237,9 @@ class NPC(Character):
         self.at_emote("$conj(charges) at {target}!", mapping={"target": target})
         location = self.location
 
-        if not (combat_script := location.scripts.get("combat")):
-            # there's no combat instance; start one
-            from typeclasses.scripts import CombatScript
+        from typeclasses.scripts import get_or_create_combat_script
 
-            location.scripts.add(CombatScript, key="combat")
-            combat_script = location.scripts.get("combat")
-        combat_script = combat_script[0]
+        combat_script = get_or_create_combat_script(location)
 
         self.db.combat_target = target
         # adding a combatant to combat just returns True if they're already there, so this is safe


### PR DESCRIPTION
## Summary
- use `get_or_create_combat_script` in `enter_combat`
- ensure tests save combat scripts before using them
- add regression test for NPC combat then peace

## Testing
- `pytest -k peace -q` *(fails: ValueError about unsaved CombatScript)*

------
https://chatgpt.com/codex/tasks/task_e_684b50e26c70832c823622e30c233ba0