### PR TITLE
Fix combat script persistence

### DIFF
--- a/typeclasses/scripts.py
+++ b/typeclasses/scripts.py
@@ -66,6 +66,7 @@ class CombatScript(Script):
         ]
 
     def at_script_creation(self):
+        self.persistent = True
         self.db.teams = [[], []]
 
     def get_team(self, combatant):


### PR DESCRIPTION
## Summary
- set `CombatScript` to be persistent so combatants can be tracked using `db` attributes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b5448c7e8832c82727f2121f7cd64