### PR TITLE
Guard combat target removal in combat script

### DIFF
--- a/typeclasses/scripts.py
+++ b/typeclasses/scripts.py
@@ -172,7 +172,8 @@ class CombatScript(Script):
                 state_manager.check_level_up(obj)
         self.check_victory()
         # remove their combat target if they have one
-        del combatant.db.combat_target
+        if hasattr(combatant.db, "combat_target"):
+            del combatant.db.combat_target
         return True
 
     def check_victory(self):
@@ -212,7 +213,8 @@ class CombatScript(Script):
         # only one team is active at this point; message the winners
         for obj in active_fighters:
             # remove their combat target if they have one
-            del obj.db.combat_target
+            if hasattr(obj.db, "combat_target"):
+                del obj.db.combat_target
             obj.msg("The fight is over.")
 
         # say farewell to the combat script!

--- a/typeclasses/tests/test_combat_script.py
+++ b/typeclasses/tests/test_combat_script.py
@@ -37,3 +37,36 @@ class TestCombatVictory(EvenniaTest):
 
         self.assertEqual(script.db.teams, [[], []])
         script.check_victory()
+
+    def test_remove_combatant_handles_missing_target(self):
+        """Removing a fighter without combat_target should not error."""
+        from typeclasses.scripts import CombatScript
+
+        self.room1.scripts.add(CombatScript, key="combat")
+        script = self.room1.scripts.get("combat")[0]
+        script.add_combatant(self.char1, enemy=self.char2)
+
+        if hasattr(self.char1.db, "combat_target"):
+            del self.char1.db.combat_target
+
+        # should not raise
+        script.remove_combatant(self.char1)
+        self.assertNotIn(self.char1, script.fighters)
+
+    def test_victory_handles_missing_combat_target(self):
+        """Victory check should succeed if fighters lack combat_target."""
+        from typeclasses.scripts import CombatScript
+
+        self.room1.scripts.add(CombatScript, key="combat")
+        script = self.room1.scripts.get("combat")[0]
+        script.add_combatant(self.char1, enemy=self.char2)
+
+        self.char2.tags.add("dead", category="status")
+        script.delete = MagicMock()
+
+        if hasattr(self.char1.db, "combat_target"):
+            del self.char1.db.combat_target
+
+        # should not raise and should delete the script
+        script.check_victory()
+        script.delete.assert_called()


### PR DESCRIPTION
## Summary
- guard combat target deletion in `remove_combatant`
- guard combat target removal when checking victory
- add tests covering missing `combat_target` attributes

## Testing
- `pytest typeclasses/tests/test_combat_script.py::TestCombatVictory::test_remove_combatant_handles_missing_target -q`
- `pytest typeclasses/tests/test_combat_script.py::TestCombatVictory::test_victory_handles_missing_combat_target -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b5664aed8832ca16832b70f10f4fa