### PR TITLE
Fix cooldown removal

### DIFF
--- a/world/system/state_manager.py
+++ b/world/system/state_manager.py
@@ -107,8 +107,17 @@ def add_cooldown(chara, key: str, duration: int):
 
 
 def remove_cooldown(chara, key: str):
-    """Remove a cooldown."""
-    chara.cooldowns.remove(key)
+    """Remove a cooldown if it exists."""
+    handler = getattr(chara, "cooldowns", None)
+    if not handler:
+        return
+    if hasattr(handler, "remove"):
+        handler.remove(key)
+    else:
+        try:
+            del handler[key]
+        except Exception:
+            pass
 
 
 def add_effect(chara, key: str, duration: int):


### PR DESCRIPTION
## Summary
- make `state_manager.remove_cooldown` tolerant of Evennia versions that don't expose `CooldownHandler.remove`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684b5841d920832cb4997135f239b9e7