### PR TITLE
Fix peace command when combat script deleted

### DIFF
--- a/commands/admin.py
+++ b/commands/admin.py
@@ -440,7 +440,7 @@ class CmdPeace(Command):
             return
 
         combat_script = location.scripts.get("combat")
-        if not combat_script or combat_script[0].pk is None:
+        if not combat_script or not combat_script[0].pk:
             caller.msg("There is no fighting here.")
             return
 


### PR DESCRIPTION
## Summary
- handle a deleted combat script in `peace`
- test peace after victory from active combat

## Testing
- `pytest typeclasses/tests/test_admin_commands.py::TestAdminCommands::test_peace_after_victory_from_active_combat -q` *(fails: django.db.utils.OperationalError)*

------
https://chatgpt.com/codex/tasks/task_e_684b5b9a44c4832c84c60364765694ff