### PR TITLE
Use weakrefs for combat state tracking

### DIFF
--- a/combat/combat_states.py
+++ b/combat/combat_states.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 from typing import Callable, Dict, Optional
+from weakref import WeakKeyDictionary
 
 
 @dataclass
@@ -23,7 +24,7 @@ class CombatStateManager:
     """Track active combat states on characters."""
 
     def __init__(self):
-        self.states: Dict[object, Dict[str, CombatState]] = {}
+        self.states: WeakKeyDictionary[object, Dict[str, CombatState]] = WeakKeyDictionary()
 
     def add_state(self, obj: object, state: CombatState) -> None:
         """Add ``state`` to ``obj``.

--- a/typeclasses/tests/test_combat_states.py
+++ b/typeclasses/tests/test_combat_states.py
@@ -53,3 +53,14 @@ class TestCombatStates(unittest.TestCase):
 
         self.assertEqual(events, ["apply", "tick", "expire"])
 
+    def test_states_removed_when_object_deleted(self):
+        mgr = CombatStateManager()
+        obj = Dummy()
+        mgr.add_state(obj, CombatState(key="bleeding", duration=1))
+        self.assertIn(obj, mgr.states)
+        del obj
+        import gc
+
+        gc.collect()
+        self.assertEqual(len(mgr.states), 0)
+


### PR DESCRIPTION
## Summary
- replace state dict with `WeakKeyDictionary`
- ensure states disappear when an object is garbage collected
- regression test for garbage-collection cleanup

## Testing
- `pytest typeclasses/tests/test_combat_states.py::TestCombatStates::test_states_removed_when_object_deleted -q`
- `pytest typeclasses/tests/test_builder_autosave.py::TestBuilderAutosave::test_restore_mobproto_session -q` *(fails: OperationalError: no such table)*

------
https://chatgpt.com/codex/tasks/task_e_684b5fb4e528832c9a70e028f1a3322e