### PR TITLE
Fix _current_hp default and cleanup logic

### DIFF
--- a/combat/combat_engine.py
+++ b/combat/combat_engine.py
@@ -18,16 +18,19 @@ from world.combat import get_health_description
 
 
 def _current_hp(obj):
-    """Return current health of ``obj`` if available."""
+    """Return current health of ``obj`` as an integer."""
     if hasattr(obj, "hp"):
         try:
-            return obj.hp
+            return int(obj.hp)
         except Exception:
             pass
     hp_trait = getattr(getattr(obj, "traits", None), "health", None)
     if hp_trait is not None:
-        return hp_trait.value
-    return None
+        try:
+            return int(hp_trait.value)
+        except Exception:
+            return 0
+    return 0
 
 
 @dataclass
@@ -462,7 +465,7 @@ class CombatEngine:
             target = getattr(getattr(actor, "db", None), "combat_target", None)
             if (
                 getattr(actor, "location", None) is None
-                or (hp is not None and hp <= 0)
+                or hp <= 0
                 or target is None
             ):
                 self.remove_participant(actor)
@@ -482,7 +485,7 @@ class CombatEngine:
         for participant in list(self.queue):
             actor = participant.actor
             hp = _current_hp(actor)
-            if hp is not None and hp <= 0:
+            if hp <= 0:
                 continue
             target = getattr(getattr(actor, "db", None), "combat_target", None)
             hook = getattr(actor, "at_combat_turn", None)
@@ -540,7 +543,7 @@ class CombatEngine:
             if actor.location and result.message:
                 actor.location.msg_contents(result.message)
             target_hp = _current_hp(result.target)
-            if target_hp is not None and target_hp <= 0:
+            if target_hp <= 0:
                 self.handle_defeat(result.target, actor)
                 self.award_experience(actor, result.target)
             self.track_aggro(result.target, actor)


### PR DESCRIPTION
## Summary
- always return integer from `_current_hp`
- adjust combat engine checks for integer hp values
- remove combatants without hp from fights
- test removal of hp-less participants

## Testing
- `pytest -q` *(fails: django.db module not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b6244b1bc832c86352bffb7fd3a8d