### PR TITLE
Fix CombatScript deletion

### DIFF
--- a/commands/admin.py
+++ b/commands/admin.py
@@ -447,7 +447,7 @@ class CmdPeace(Command):
         combat_script = combat_script[0]
         for fighter in list(combat_script.fighters):
             combat_script.remove_combatant(fighter)
-        combat_script.delete()
+        combat_script.stop()
         location.msg_contents("Peace falls over the area.")
 
 

--- a/typeclasses/tests/test_combat_engine.py
+++ b/typeclasses/tests/test_combat_engine.py
@@ -305,10 +305,10 @@ class TestCombatDeath(EvenniaTest):
         npc = create.create_object(NPC, key="mob", location=self.room1)
         npc.db.drops = []
 
-        # create combat script then immediately delete it to mimic victory cleanup
+        # create combat script then immediately stop it to mimic victory cleanup
         self.room1.scripts.add(CombatScript, key="combat")
         combat_script = self.room1.scripts.get("combat")[0]
-        combat_script.delete()
+        combat_script.stop()
 
         # should not raise when combat script has been removed
         npc.on_death(player)


### PR DESCRIPTION
## Summary
- add safe `stop` method to `CombatScript`
- use `stop` instead of direct `delete`
- guard `remove_combatant` when script is gone
- adjust admin command and tests for new method

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684b6d7bbb34832ca657ba2b76956f48