### PR TITLE
Fix CombatRoundManager handling of deleted scripts

### DIFF
--- a/combat/round_manager.py
+++ b/combat/round_manager.py
@@ -64,8 +64,12 @@ class CombatRoundManager:
 
     def tick(self) -> None:
         for inst in list(self.instances):
-            if not inst.script or not inst.script.active:
-                self.remove_instance(inst.script)
+            script = inst.script
+            if not script or not getattr(script, "id", None):
+                self.remove_instance(script)
+                continue
+            if not script.active:
+                self.remove_instance(script)
                 continue
             inst.sync_participants()
             inst.engine.process_round()

--- a/typeclasses/scripts.py
+++ b/typeclasses/scripts.py
@@ -80,6 +80,12 @@ class CombatScript(Script):
         self.stop_script()
         self.delete()
 
+    def delete(self, *args, **kwargs):
+        """Remove this script from the round manager before deletion."""
+        from combat.round_manager import CombatRoundManager
+        CombatRoundManager.get().remove_instance(self)
+        super().delete(*args, **kwargs)
+
     def get_team(self, combatant):
         """
         Gets the index of the team containing combatant, or None if combatant is not in this combat

--- a/typeclasses/tests/test_round_manager.py
+++ b/typeclasses/tests/test_round_manager.py
@@ -43,3 +43,13 @@ class TestCombatRoundManager(EvenniaTest):
 
         self.assertEqual(order[0], self.char1)
         self.assertEqual(order[1], self.char2)
+
+    def test_tick_handles_deleted_script(self):
+        with patch("combat.round_manager.delay"):
+            self.manager.add_instance(self.script)
+            # deleting the script should not cause tick to fail
+            self.script.delete()
+            try:
+                self.manager.tick()
+            except Exception as err:  # pragma: no cover - fail fast if exception
+                self.fail(f"tick raised {err!r}")


### PR DESCRIPTION
## Summary
- ensure CombatScript.remove_instance is called when scripts are deleted
- guard round manager tick against deleted scripts
- test tick when script is deleted during combat

## Testing
- `pytest -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684b6ed83c10832c9dd2de51dd7acc5c