### PR TITLE
Fix CombatScript.stop uses super stop

### DIFF
--- a/typeclasses/scripts.py
+++ b/typeclasses/scripts.py
@@ -77,7 +77,7 @@ class CombatScript(Script):
             return
         from combat.round_manager import CombatRoundManager
         CombatRoundManager.get().remove_instance(self)
-        self.stop_script()
+        super().stop()
         self.delete()
 
     def delete(self, *args, **kwargs):


### PR DESCRIPTION
## Summary
- ensure CombatScript.stop uses Evennia's built-in stopping logic
- run tests (fails due to DB setup)

## Testing
- `pytest -q typeclasses/tests/test_combat_engine.py::TestCombatDeath::test_on_death_handles_deleted_combat_script` *(fails: no such table accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684b712e8848832c9dd2f1f18f04410f