### PR TITLE
Handle deleted CombatScript instances

### DIFF
--- a/combat/round_manager.py
+++ b/combat/round_manager.py
@@ -65,7 +65,8 @@ class CombatRoundManager:
     def tick(self) -> None:
         for inst in list(self.instances):
             script = inst.script
-            if not script or not getattr(script, "id", None):
+            # ensure the script still exists before touching any of its fields
+            if not script or not getattr(script, "pk", None):
                 self.remove_instance(script)
                 continue
             if not script.active:

--- a/typeclasses/tests/test_round_manager.py
+++ b/typeclasses/tests/test_round_manager.py
@@ -53,3 +53,11 @@ class TestCombatRoundManager(EvenniaTest):
                 self.manager.tick()
             except Exception as err:  # pragma: no cover - fail fast if exception
                 self.fail(f"tick raised {err!r}")
+
+    def test_tick_cleans_up_deleted_script(self):
+        """Tick should remove instances whose scripts were deleted."""
+        with patch("combat.round_manager.delay"):
+            inst = self.manager.add_instance(self.script)
+            self.script.delete()
+            self.manager.tick()
+            self.assertNotIn(inst, self.manager.instances)


### PR DESCRIPTION
## Summary
- ensure `CombatRoundManager.tick` verifies script.pk before using it
- test that deleted combat scripts are cleaned up on tick

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684b717b7a4c832cae2c9a85e5b4142a