### PR TITLE
Attach plugin service to Twisted application

### DIFF
--- a/server/conf/portal_services_plugins.py
+++ b/server/conf/portal_services_plugins.py
@@ -29,5 +29,11 @@ def start_plugin_services(portal):
 
     factory = protocol.ServerFactory()
     factory.protocol = Echo
-    portal.services.addService(internet.TCPServer(9000, factory))
+
+    # Attach the Echo service to the Twisted application container. The
+    # `application` attribute was introduced in newer Evennia versions but
+    # older installs may not define it yet, so fall back to the Portal's
+    # parent service when needed.
+    application = getattr(portal, "application", None) or portal.parent
+    application.addService(internet.TCPServer(9000, factory))
 


### PR DESCRIPTION
## Summary
- update `start_plugin_services` to attach the TCP service to the portal's Twisted application
- handle older Evennia versions where the `application` attribute may be missing

## Testing
- `evennia start > /tmp/evennia_start.log && tail -n 20 /tmp/evennia_start.log`

------
https://chatgpt.com/codex/tasks/task_e_684c1ad0afb8832cb5483ff1d23fd213