### PR TITLE
Update test setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,10 +414,10 @@ with VNUM-based NPCs.
 
 ## Running the Tests
 
-The test suite requires Evennia and Django in addition to `pytest`. Make sure
-these packages are installed before invoking the test runner. The easiest way is
-to use the provided requirements file which installs compatible versions of all
-three:
+The test suite relies on Evennia (with its optional **extras**) and Django in
+addition to `pytest`. Make sure these packages are installed before invoking the
+test runner. The easiest way is to use the provided requirements file, which
+installs compatible versions of all three dependencies:
 
 ```bash
 python -m pip install --upgrade pip
@@ -425,6 +425,9 @@ pip install -r requirements-test.txt
 # Install the project itself so tests can import it
 pip install -e .
 ```
+
+Ensure these requirements are installed before running `pytest` so that Django
+and the full Evennia extras are available to the test suite.
 
 You can also run `scripts/setup_test_env.sh` to automate the above steps.
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,7 @@
-# Packages required to run the test suite
-# Evennia brings in Django but we list it explicitly to avoid missing deps
+# Packages required to run the test suite.
+# Install these first with `pip install -r requirements-test.txt` before
+# running `pytest`. Evennia brings in Django but we list it explicitly to avoid
+# missing dependencies.
 "evennia[extra] >= 4.2, <5.0"
 Django>=4.2,<5.0
 pytest


### PR DESCRIPTION
## Summary
- clarify instructions to install Django and Evennia extras
- advise running `pip install -r requirements-test.txt` before pytest

## Testing
- `pytest -q` *(fails: OperationalError no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684c1dac19d4832cae85f43af0520a29