### PR TITLE
Fix service registration in server plugin

### DIFF
--- a/server/conf/server_services_plugins.py
+++ b/server/conf/server_services_plugins.py
@@ -41,5 +41,5 @@ def start_plugin_services(server):
     """Hook for attaching additional Twisted services to the Server."""
 
     heartbeat = HeartbeatService()
-    server.services.addService(heartbeat)
+    server.services.append(heartbeat)
 


### PR DESCRIPTION
## Summary
- fix `server_services_plugins` to correctly append service objects

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684c2eb5cfac832c87bb89b46596a482