### PR TITLE
Add corpse loot command

### DIFF
--- a/commands/loot.py
+++ b/commands/loot.py
@@ -32,9 +32,47 @@ class CmdLoot(Command):
         caller.update_carry_weight()
 
 
+class CmdLootCorpse(Command):
+    """Loot everything from a corpse that you can pick up."""
+
+    key = "lootcorpse"
+    help_category = "General"
+
+    def func(self):
+        caller = self.caller
+        if not self.args:
+            caller.msg("Loot what?")
+            return
+        target = caller.search(self.args.strip())
+        if not target:
+            return
+        if not target.is_typeclass("typeclasses.objects.Corpse", exact=False):
+            caller.msg("You can only loot corpses.")
+            return
+        items = list(target.contents)
+        if not items:
+            caller.msg("There's nothing left to loot.")
+            return
+        moved_any = False
+        for obj in items:
+            if not obj.access(caller, "get"):
+                continue
+            if obj.move_to(caller, quiet=True, move_type="get"):
+                obj.at_get(caller)
+                moved_any = True
+                caller.msg(
+                    f"You loot {obj.get_display_name(caller)} from {target.get_display_name(caller)}."
+                )
+        caller.update_carry_weight()
+        if not moved_any:
+            caller.msg("You cannot loot anything from it.")
+
+
 class LootCmdSet(CmdSet):
     key = "Loot CmdSet"
 
     def at_cmdset_creation(self):
         super().at_cmdset_creation()
         self.add(CmdLoot)
+        self.add(CmdLootCorpse)
+

--- a/typeclasses/tests/test_loot_command.py
+++ b/typeclasses/tests/test_loot_command.py
@@ -29,3 +29,22 @@ class TestCmdLoot(EvenniaTest):
         self.char1.execute_cmd(f"loot {corpse.key}")
 
         assert item.location == self.char1
+
+    def test_lootcorpse_respects_get_lock(self):
+        from typeclasses.characters import NPC
+
+        npc = create.create_object(NPC, key="mob", location=self.room1)
+        item = create.create_object("typeclasses.objects.Object", key="loot", location=npc)
+        item.locks.add("get:false()")
+        npc.db.drops = []
+        npc.traits.health.current = 1
+        npc.at_damage(self.char1, 2)
+
+        corpse = next(
+            obj for obj in self.room1.contents
+            if obj.is_typeclass("typeclasses.objects.Corpse", exact=False)
+        )
+
+        self.char1.execute_cmd(f"lootcorpse {corpse.key}")
+
+        assert item.location == corpse


### PR DESCRIPTION
## Summary
- loot corpses with a new command that only moves accessible contents
- ensure LootCmdSet exposes the new corpse command
- test that locked items stay in the corpse when looting

## Testing
- `evennia migrate`
- `pytest typeclasses/tests/test_loot_command.py::TestCmdLoot::test_lootcorpse_respects_get_lock -q` *(fails: ImportError: cannot import name 'create' from 'evennia')*

------
https://chatgpt.com/codex/tasks/task_e_684c3704c900832c9c34315c9c83efbc