### PR TITLE
Document corpse looting

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,10 @@ If a character's `sated` value reaches zero they gain the `hungry_thirsty`
 status effect. Each tick removes 5% of their maximum health, mana and stamina
 while this status is active, rather than a single point from each resource.
 
+### Looting Corpses
+
+Defeated enemies leave a corpse containing any gear they carried. Use `loot` or `get all corpse` to quickly grab everything before the body decays.
+
 ### AI Settings
 
 NPC behavior is configured by an AI type during `cnpc` or `mobbuilder`.

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -2068,6 +2068,36 @@ Related:
 """,
     },
     {
+        "key": "corpse",
+        "aliases": ["corpses"],
+        "category": "General",
+        "text": """Help for corpse
+
+Dead characters leave corpses that hold any items they carried.
+
+Usage:
+    get all corpse
+    loot
+
+Switches:
+    None
+
+Arguments:
+    None
+
+Examples:
+    loot
+    get all corpse
+
+Notes:
+    - |wloot|n is a shortcut for |wget all corpse|n.
+    - Corpses decay after a time.
+
+Related:
+    help inventory
+""",
+    },
+    {
         "key": "buffs",
         "category": "General",
         "text": """


### PR DESCRIPTION
## Summary
- describe how to loot corpses in README
- add help entry on corpse loot commands

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684c38e85da0832c88af9f240fe2cf73