### PR TITLE
Fix unarmed attack name

### DIFF
--- a/combat/combat_actions.py
+++ b/combat/combat_actions.py
@@ -134,7 +134,10 @@ class AttackAction(Action):
 
         logger.debug("AttackAction weapon=%s", getattr(weapon, "key", weapon))
 
-        wname = getattr(weapon, "key", None)
+        if weapon is self.actor:
+            wname = "fists"
+        else:
+            wname = getattr(weapon, "key", None)
         if not wname and isinstance(weapon, dict):
             wname = weapon.get("name", "fists")
         attempt = f"{self.actor.key} swings {wname or 'fists'} at {target.key}."


### PR DESCRIPTION
## Summary
- set the unarmed weapon name to `fists`

## Testing
- `pip install evennia Django pytest`
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684c449fd33c832c9defb229df0e3430