### PR TITLE
Fix BareHand plural messaging

### DIFF
--- a/typeclasses/gear.py
+++ b/typeclasses/gear.py
@@ -18,7 +18,7 @@ class BareHand:
     damage = 1
     stamina_cost = 3
     skill = "unarmed"
-    name = "fist"
+    name = "fists"
     speed = 2
 
     def at_pre_attack(self, wielder, **kwargs):


### PR DESCRIPTION
## Summary
- fix BareHand name to `fists`
- use the plural name for unarmed attack messages

## Testing
- `pytest -q` *(fails: many errors)*

------
https://chatgpt.com/codex/tasks/task_e_684c52a63540832c9a1a2ffe09b1e8fc