### PR TITLE
Allow multiple NPC corpses per key

### DIFF
--- a/typeclasses/tests/test_combat_engine.py
+++ b/typeclasses/tests/test_combat_engine.py
@@ -269,6 +269,24 @@ class TestCombatDeath(EvenniaTest):
         ]
         self.assertEqual(len(corpses), 1)
 
+    def test_same_key_npcs_create_multiple_corpses(self):
+        """Killing NPCs with the same key should spawn separate corpses."""
+        from evennia.utils import create
+        from typeclasses.characters import NPC
+
+        npc1 = create.create_object(NPC, key="mob", location=self.room1)
+        npc2 = create.create_object(NPC, key="mob", location=self.room1)
+        for npc in (npc1, npc2):
+            npc.db.drops = []
+            npc.on_death(self.char1)
+
+        corpses = [
+            obj
+            for obj in self.room1.contents
+            if obj.is_typeclass("typeclasses.objects.Corpse", exact=False)
+        ]
+        self.assertEqual(len(corpses), 2)
+
     def test_corpse_decay_script(self):
         from evennia.utils import create
         from typeclasses.characters import NPC

--- a/utils/mob_utils.py
+++ b/utils/mob_utils.py
@@ -93,17 +93,17 @@ def make_corpse(npc):
     if not npc or not npc.location:
         return None
 
-    # avoid multiple corpses if on_death is called repeatedly
+    # avoid multiple corpses if on_death is called repeatedly for the same npc
     existing = [
         obj
         for obj in npc.location.contents
         if obj.is_typeclass("typeclasses.objects.Corpse", exact=False)
-        and obj.db.corpse_of == npc.key
+        and obj.db.corpse_of_id == npc.dbref
     ]
     if existing:
         return existing[0]
 
-    attrs = [("corpse_of", npc.key)]
+    attrs = [("corpse_of", npc.key), ("corpse_of_id", npc.dbref)]
     if decay := getattr(npc.db, "corpse_decay_time", None):
         attrs.append(("decay_time", decay))
     corpse = create_object(


### PR DESCRIPTION
## Summary
- allow corpse creation for NPCs with duplicate keys by tracking dbref
- test creating corpses for two NPCs with the same key

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684c5e5de3f0832cab62bca80437572c