### PR TITLE
Update corpse key naming

### DIFF
--- a/utils/mob_utils.py
+++ b/utils/mob_utils.py
@@ -108,7 +108,7 @@ def make_corpse(npc):
         attrs.append(("decay_time", decay))
     corpse = create_object(
         "typeclasses.objects.Corpse",
-        key=f"{npc.key} corpse",
+        key=f"corpse of {npc.key}",
         location=npc.location,
         attributes=attrs,
     )


### PR DESCRIPTION
## Summary
- create corpses with key `corpse of <name>` instead of `<name> corpse`

## Testing
- `pytest -q` *(fails: OperationalError no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684c5fd3adf8832caf9c9b84c8da152c