### PR TITLE
Fix XP reward None crash

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -1084,7 +1084,10 @@ class NPC(Character):
     def award_xp_to(self, attacker):
         """Grant experience reward to ``attacker``."""
         from world.system import state_manager
-        exp = int(getattr(self.db, "exp_reward", 0))
+        exp_reward = getattr(self.db, "exp_reward", 0)
+        if exp_reward is None:
+            exp_reward = 0
+        exp = int(exp_reward)
         if not attacker or not exp:
             return
         attacker.db.exp = (attacker.db.exp or 0) + exp


### PR DESCRIPTION
## Summary
- prevent crash in `award_xp_to` when `exp_reward` is `None`

## Testing
- `pytest -q` *(fails: 74 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_684c6f100e04832c83848b610f847804