### PR TITLE
Add corpse commands and remove attack cooldown

### DIFF
--- a/combat/combat_actions.py
+++ b/combat/combat_actions.py
@@ -112,8 +112,6 @@ class AttackAction(Action):
 
     def validate(self) -> tuple[bool, str]:
         """Check if the actor can attack this round."""
-        if hasattr(self.actor, "cooldowns") and not self.actor.cooldowns.ready("attack"):
-            return False, "Still recovering."
         return super().validate()
 
     def resolve(self) -> CombatResult:

--- a/commands/info.py
+++ b/commands/info.py
@@ -412,6 +412,31 @@ class CmdGetAll(Command):
         caller.msg("You pick up everything you can.")
 
 
+class CmdGetAllCorpse(Command):
+    """Pick up all corpses in the room."""
+
+    key = "get all corpse"
+    help_category = "General"
+
+    def func(self):
+        caller = self.caller
+        location = caller.location
+        if not location:
+            caller.msg("You cannot pick anything up.")
+            return
+        corpses = [
+            obj for obj in location.contents if getattr(obj.db, "is_corpse", False)
+        ]
+        if not corpses:
+            caller.msg("There are no corpses here.")
+            return
+        for obj in corpses:
+            if obj.move_to(caller, quiet=True, move_type="get"):
+                obj.at_get(caller)
+        caller.update_carry_weight()
+        caller.msg("You gather the corpses.")
+
+
 class CmdEquipment(Command):
     """
     Show what you are wearing and wielding. Usage: equipment
@@ -821,6 +846,7 @@ class InfoCmdSet(CmdSet):
         self.add(CmdDrop)
         self.add(CmdGive)
         self.add(CmdGetAll)
+        self.add(CmdGetAllCorpse)
         self.add(CmdDropAll)
         self.add(CmdInspect)
         self.add(CmdEquipment)

--- a/commands/loot.py
+++ b/commands/loot.py
@@ -6,14 +6,27 @@ class CmdLoot(Command):
     """Loot items from a corpse."""
 
     key = "loot"
+    aliases = ("loot corpse",)
     help_category = "General"
 
     def func(self):
         caller = self.caller
         if not self.args:
-            caller.msg("Loot what?")
-            return
-        target = caller.search(self.args.strip())
+            if self.cmdstring.strip().lower() == "loot corpse":
+                corpses = [
+                    obj
+                    for obj in caller.location.contents
+                    if obj.is_typeclass("typeclasses.objects.Corpse", exact=False)
+                ]
+                if not corpses:
+                    caller.msg("There is nothing to loot.")
+                    return
+                target = corpses[0]
+            else:
+                caller.msg("Loot what?")
+                return
+        else:
+            target = caller.search(self.args.strip())
         if not target:
             return
         if not target.is_typeclass("typeclasses.objects.Corpse", exact=False):

--- a/commands/rest.py
+++ b/commands/rest.py
@@ -99,6 +99,13 @@ class CmdLook(DefaultCmdLook):
         look
     """
 
+    aliases = ("l", "look in", "l in")
+
+    def parse(self):
+        super().parse()
+        if self.args and self.args.lower().startswith("in "):
+            self.args = self.args[3:].strip()
+
     def func(self):
         if self.caller.tags.has("sleeping", category="status"):
             self.caller.msg("You can't see anything with your eyes closed.")

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -918,7 +918,7 @@ class PlayerCharacter(Character):
             "typeclasses.objects.Corpse",
             key=f"{self.key} corpse",
             location=self.location,
-            attributes=[("corpse_of", self.key)],
+            attributes=[("corpse_of", self.key), ("is_corpse", True)],
         )
         from world import prototypes
 
@@ -1267,10 +1267,6 @@ class NPC(Character):
         # make sure wielder has enough strength left
         if self.traits.stamina.value < weapon.get("stamina_cost", 5):
             return False
-        # can't attack if on cooldown
-        if not wielder.cooldowns.ready("attack"):
-            return False
-
         return True
 
     def at_attack(self, wielder, target, **kwargs):
@@ -1301,7 +1297,6 @@ class NPC(Character):
                     f"$conj(swings) $pron(your) {weapon.get('name')} at $you(target), but they evade.",
                     mapping={"target": target},
                 )
-                wielder.cooldowns.add("attack", speed)
                 return
             verb = weapon.get("damage_type", "hits")
             crit = stat_manager.roll_crit(wielder, target)
@@ -1312,7 +1307,7 @@ class NPC(Character):
                 mapping={"target": target},
             )
             target.at_damage(wielder, damage, weapon.get("damage_type"), critical=crit)
-        wielder.cooldowns.add("attack", speed)
+        return
 
     def at_tick(self):
         super().at_tick()

--- a/typeclasses/gear.py
+++ b/typeclasses/gear.py
@@ -29,11 +29,6 @@ class BareHand:
         if wielder.traits.stamina.value < self.stamina_cost:
             wielder.msg("You are too tired to hit anything.")
             return False
-        # can't attack if on cooldown
-        if not wielder.cooldowns.ready("attack"):
-            wielder.msg("You can't attack again yet.")
-            return False
-
         return True
 
     def at_attack(self, wielder, target, **kwargs):
@@ -89,7 +84,7 @@ class BareHand:
                 effect, chance = status
                 if stat_manager.roll_status(wielder, target, int(chance)):
                     state_manager.add_status_effect(target, effect, 1)
-        wielder.cooldowns.add("attack", self.speed)
+        pass
 
 
 class MeleeWeapon(Object):
@@ -114,10 +109,6 @@ class MeleeWeapon(Object):
         # make sure wielder has enough strength left
         if wielder.traits.stamina.value < self.attributes.get("stamina_cost", 0):
             wielder.msg("You are too tired to use this.")
-            return False
-        # can't attack if on cooldown
-        if not wielder.cooldowns.ready("attack"):
-            wielder.msg("You can't attack again yet.")
             return False
         # this can only be used if it's being wielded
         if self not in wielder.wielding:
@@ -212,7 +203,7 @@ class MeleeWeapon(Object):
                 effect, chance = status
                 if stat_manager.roll_status(wielder, target, int(chance)):
                     state_manager.add_status_effect(target, effect, 1)
-        wielder.cooldowns.add("attack", self.speed)
+        pass
 
 
 class WearableContainer(ContribContainer, ClothingObject):

--- a/typeclasses/tests/test_action_cooldowns.py
+++ b/typeclasses/tests/test_action_cooldowns.py
@@ -3,7 +3,6 @@ from evennia.utils.test_resources import EvenniaTest
 
 from combat.combat_actions import AttackAction
 from typeclasses.npcs import BaseNPC
-from world.system import state_manager
 
 
 class TestAttackCooldowns(EvenniaTest):
@@ -16,8 +15,8 @@ class TestAttackCooldowns(EvenniaTest):
 
         action = AttackAction(attacker, defender)
         valid, err = action.validate()
-        assert not valid
-        assert "recovering" in err.lower()
+        assert valid
+        assert err == ""
 
     def test_npc_attack_respects_cooldown(self):
         npc = create.create_object(BaseNPC, key="mob", location=self.room1)
@@ -26,6 +25,6 @@ class TestAttackCooldowns(EvenniaTest):
 
         action = AttackAction(npc, target)
         valid, err = action.validate()
-        assert not valid
-        assert "recovering" in err.lower()
+        assert valid
+        assert err == ""
 

--- a/utils/mob_utils.py
+++ b/utils/mob_utils.py
@@ -103,7 +103,7 @@ def make_corpse(npc):
     if existing:
         return existing[0]
 
-    attrs = [("corpse_of", npc.key), ("corpse_of_id", npc.dbref)]
+    attrs = [("corpse_of", npc.key), ("corpse_of_id", npc.dbref), ("is_corpse", True)]
     if decay := getattr(npc.db, "corpse_decay_time", None):
         attrs.append(("decay_time", decay))
     corpse = create_object(


### PR DESCRIPTION
## Summary
- allow instant attacks by removing cooldown checks
- add `get all corpse` command to grab corpse objects
- support `look in` syntax for corpses
- make `loot` command accept `loot corpse` alias
- mark corpses with `is_corpse`
- update tests for removed cooldown

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684c70ab9590832cb33d3caa7b1d3a4d