### PR TITLE
Implement NPC death handling and alive checks

### DIFF
--- a/combat/combat_engine.py
+++ b/combat/combat_engine.py
@@ -494,7 +494,7 @@ class CombatEngine:
 
             if participant.next_action:
                 queued = participant.next_action
-            elif target:
+            elif target and getattr(target, "is_alive", lambda: True)():
                 queued = [AttackAction(actor, target)]
             else:
                 queued = []

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -116,6 +116,11 @@ class Character(ObjectParent, ClothedCharacter):
             hp_trait.max = value
 
     @property
+    def is_alive(self):
+        """Return ``True`` if this character is not flagged dead."""
+        return not bool(getattr(self.db, "dead", False))
+
+    @property
     def wielding(self):
         """Access a list of all wielded objects"""
         return [obj for obj in self.attributes.get("_wielded", {}).values() if obj]
@@ -1097,18 +1102,18 @@ class NPC(Character):
 
     def on_death(self, attacker):
         """Handle character death cleanup."""
-        if not self.location or self.attributes.get("_dead"):
+        if not self.location or self.db.dead:
             return
-        self.db._dead = True
         self.db.dead = True
 
-        # remove from combat if necessary. The combat script may have been
-        # cleaned up already, so verify it before using it.
+        # remove from combat immediately if present
         if self.in_combat and (script := self.location.scripts.get("combat")):
             if script and script[0].pk:
                 script[0].remove_combatant(self)
 
-        corpse = self.drop_loot(attacker)
+        logger.debug("NPC %s killed by %s", self.key, getattr(attacker, "key", None))
+
+        corpse = make_corpse(self)
         if corpse:
             corpse.location = self.location
 
@@ -1121,6 +1126,7 @@ class NPC(Character):
                 )
             else:
                 self.location.msg_contents(f"{self.key} dies.")
+
         self.delete()
 
     # property to mimic weapons


### PR DESCRIPTION
## Summary
- add `is_alive` property to Character
- check target is alive before AttackAction creation
- update NPC death cleanup to mark dead, remove from combat, make corpse, delete object
- test NPC death behaviours

## Testing
- `pytest typeclasses/tests/test_combat_engine.py::TestCombatNPCTurn::test_attack_skipped_when_target_dead -q` *(fails: OperationalError no such table)*

------
https://chatgpt.com/codex/tasks/task_e_684c7742237c832c899a0531ca6d9413