### PR TITLE
Remove deprecated PvP and movement stats

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -331,11 +331,7 @@ class Character(ObjectParent, ClothedCharacter):
 
         carry_capacity = self.db.carry_capacity or 0
         carry_weight = self.db.carry_weight or 0
-        from world.system import state_manager
-
         cost = _MOVE_SP_BASE
-        ms = state_manager.get_effective_stat(self, "movement_speed") or 1
-        cost = max(1, int(round(cost / ms)))
         if carry_weight > carry_capacity and carry_capacity > 0:
             excess = carry_weight - carry_capacity
             cost += excess // 10
@@ -394,11 +390,6 @@ class Character(ObjectParent, ClothedCharacter):
             if mres > 0:
                 damage = max(0, damage - mres)
 
-        # PvP modifiers
-        if utils.inherits_from(attacker, PlayerCharacter) and utils.inherits_from(self, PlayerCharacter):
-            pvp_pow = state_manager.get_effective_stat(attacker, "pvp_power")
-            pvp_res = state_manager.get_effective_stat(self, "pvp_resilience")
-            damage = int(round(damage * (1 + pvp_pow / 100 - pvp_res / 100)))
 
         self.traits.health.current -= damage
         crit_prefix = "|rCritical!|n " if critical else ""

--- a/typeclasses/tests/test_extended_stats.py
+++ b/typeclasses/tests/test_extended_stats.py
@@ -71,20 +71,6 @@ class TestExtendedStats(EvenniaTest):
         state_manager.add_cooldown(self.char1, "test", 10)
         self.assertLess(self.char1.cooldowns.time_left("test", use_int=True), 10)
 
-    def test_movement_speed_reduces_cost(self):
-        self.char1.traits.movement_speed.base = 2
-        self.char1.db.carry_capacity = 10
-        self.char1.db.carry_weight = 20
-        self.char1.traits.stamina.current = 10
-        self.char1.at_post_move(self.room1)
-        self.assertEqual(self.char1.traits.stamina.current, 9)
-
-    def test_pvp_power_and_resilience(self):
-        self.char1.traits.pvp_power.base = 100
-        self.char2.traits.pvp_resilience.base = 0
-        self.char2.traits.armor.base = 0
-        dmg = self.char2.at_damage(self.char1, 10)
-        self.assertEqual(dmg, 20)
 
     def test_threat_increases_aggro(self):
         from combat.combat_engine import CombatEngine
@@ -103,12 +89,6 @@ class TestExtendedStats(EvenniaTest):
             recipe.craft()
             mock_rand.assert_called_with(0, 15)
 
-    def test_guild_honor_mod_promotes(self):
-        guild = Guild("Test", ranks=ADVENTURERS_GUILD_RANKS, rank_thresholds={t: v for v, t in ADVENTURERS_GUILD_RANKS})
-        self.char1.db.guild_points = {"Test": 9}
-        self.char1.traits.guild_honor_mod.base = 20
-        auto_promote(self.char1, guild)
-        self.assertEqual(self.char1.db.guild_rank, "Corporal")
 
 
 if __name__ == "__main__":

--- a/utils/stats_utils.py
+++ b/utils/stats_utils.py
@@ -26,7 +26,6 @@ ALIAS_MAP = {
     "armor_pen": "piercing",
     "spell_pen": "spell_penetration",
     "crafting_bonus": "craft_bonus",
-    "guild_honor_rank_modifiers": "guild_honor_mod",
 }
 
 
@@ -49,7 +48,6 @@ from world.stats import (
     REGEN_STATS,
     TEMPO_STATS,
     UTILITY_STATS,
-    PVP_STATS,
     sum_bonus,
     apply_stats,
 )
@@ -69,7 +67,6 @@ SECONDARY_STATS = (
     + REGEN_STATS
     + TEMPO_STATS
     + [stat for stat in UTILITY_STATS if stat.key != PRIMARY_EXTRA]
-    + PVP_STATS
 )
 
 SECONDARY_KEYS = [stat.key for stat in SECONDARY_STATS]

--- a/world/guilds.py
+++ b/world/guilds.py
@@ -133,12 +133,8 @@ def auto_promote(player, guild: Guild):
     """Update player's guild rank based on their points in the guild."""
     if not guild.rank_thresholds:
         return
-    from world.system import state_manager
-
     gp_map = player.db.guild_points or {}
     points = gp_map.get(guild.name, 0)
-    mod = state_manager.get_effective_stat(player, "guild_honor_mod")
-    points = int(points * (1 + mod / 100))
     new_rank = ""
     for title, threshold in sorted(guild.rank_thresholds.items(), key=lambda it: it[1]):
         if points >= threshold:

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -2674,8 +2674,7 @@ Evasion, Armor, Magic Resist, Dodge, Block Rate, Parry Rate, Status Resist,
 Critical Resist, Attack Power, Spell Power, Critical Chance, Critical Damage
 Bonus, Accuracy, Armor Penetration, Spell Penetration, Health Regen, Mana Regen,
 Stamina Regen, Lifesteal, Leech, Cooldown Reduction, Initiative, Stealth,
-Detection, Threat, Movement Speed, Crafting Bonus, PvP Power, PvP Resilience,
-Guild Honor Rank Modifiers.
+Detection, Threat, Crafting Bonus.
 """,
     },
     {

--- a/world/stats.py
+++ b/world/stats.py
@@ -77,15 +77,12 @@ UTILITY_STATS: List[Stat] = [
     Stat("detection", "Detection", stat="WIS"),
     Stat("perception", "Perception", base=5, stat="WIS"),
     Stat("threat", "Threat", stat="STR"),
-    Stat("movement_speed", "Movement Speed", base=1, stat="DEX"),
     Stat("craft_bonus", "Crafting Bonus", stat="INT"),
 ]
 
 # PvP / guild-related stats
 PVP_STATS: List[Stat] = [
-    Stat("pvp_power", "PvP Power", stat="STR"),
-    Stat("pvp_resilience", "PvP Resilience", stat="CON"),
-    Stat("guild_honor_mod", "Guild Honor Rank Modifiers", stat="WIS"),
+    # deprecated PvP related stats removed
 ]
 
 
@@ -98,7 +95,6 @@ ALL_STATS: List[Stat] = (
     + REGEN_STATS
     + TEMPO_STATS
     + UTILITY_STATS
-    + PVP_STATS
 )
 
 # Convenience: list of only core stat keys

--- a/world/system/stat_manager.py
+++ b/world/system/stat_manager.py
@@ -61,11 +61,7 @@ STAT_SCALING: Dict[str, Dict[str, float]] = {
     "detection": {"perception": 0.4, "WIS": 0.2},
     "perception": {},
     "threat": {"STR": 0.2, "CON": 0.1},
-    "movement_speed": {"DEX": 0.1, "perception": 0.1},
     "craft_bonus": {"INT": 0.2, "WIS": 0.2, "LUCK": 0.1},
-    # PvP stats
-    "pvp_power": {"STR": 0.2, "INT": 0.2, "DEX": 0.1},
-    "pvp_resilience": {"CON": 0.2, "WIS": 0.2},
     # Base evasion skill
     "evasion": {"DEX": 0.5, "perception": 0.2},
 }


### PR DESCRIPTION
## Summary
- drop movement speed, pvp and guild honor stats
- clean up stat manager scaling
- update alias and secondary stat lists
- remove old references in characters, guilds and help
- adjust extended stats tests

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684c78a11198832c826cb41267826338