### PR TITLE
Fix logger debug calls

### DIFF
--- a/combat/combat_actions.py
+++ b/combat/combat_actions.py
@@ -130,7 +130,7 @@ class AttackAction(Action):
             else:
                 weapon = self.actor
 
-        logger.debug("AttackAction weapon=%s", getattr(weapon, "key", weapon))
+        logger.log_info("AttackAction weapon=%s", getattr(weapon, "key", weapon))
 
         if weapon is self.actor:
             wname = "fists"

--- a/combat/combat_utils.py
+++ b/combat/combat_utils.py
@@ -57,7 +57,7 @@ def roll_evade(attacker, target, base: int = 50) -> bool:
     chance = max(5, min(95, base + evade - acc))
     roll = random.randint(1, 100)
     result = roll <= chance
-    logger.debug(
+    logger.log_info(
         "evade roll=%s chance=%s result=%s",
         roll,
         chance,
@@ -74,7 +74,7 @@ def roll_block(attacker, target, base: int = 0) -> bool:
     chance = max(0, min(95, base + block - acc))
     roll = random.randint(1, 100)
     result = roll <= chance
-    logger.debug("block roll=%s chance=%s result=%s", roll, chance, result)
+    logger.log_info("block roll=%s chance=%s result=%s", roll, chance, result)
     return result
 
 
@@ -86,7 +86,7 @@ def roll_parry(attacker, target, base: int = 0) -> bool:
     chance = max(0, min(95, base + parry - acc))
     roll = random.randint(1, 100)
     result = roll <= chance
-    logger.debug("parry roll=%s chance=%s result=%s", roll, chance, result)
+    logger.log_info("parry roll=%s chance=%s result=%s", roll, chance, result)
     return result
 
 
@@ -95,7 +95,7 @@ def apply_attack_power(attacker, damage: int) -> int:
 
     ap = state_manager.get_effective_stat(attacker, "attack_power")
     result = int(round(damage * (1 + ap / 100)))
-    logger.debug("atk power=%s dmg=%s result=%s", ap, damage, result)
+    logger.log_info("atk power=%s dmg=%s result=%s", ap, damage, result)
     return result
 
 
@@ -104,7 +104,7 @@ def apply_spell_power(caster, damage: int) -> int:
 
     sp = state_manager.get_effective_stat(caster, "spell_power")
     result = int(round(damage * (1 + sp / 100)))
-    logger.debug("spell power=%s dmg=%s result=%s", sp, damage, result)
+    logger.log_info("spell power=%s dmg=%s result=%s", sp, damage, result)
     return result
 
 
@@ -144,7 +144,7 @@ def check_distance(a, b, max_range: int) -> bool:
 
     dist = get_distance(a, b)
     result = dist <= max_range
-    logger.debug("distance %s max=%s result=%s", dist, max_range, result)
+    logger.log_info("distance %s max=%s result=%s", dist, max_range, result)
     return result
 
 

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -1109,7 +1109,9 @@ class NPC(Character):
             if script and script[0].pk:
                 script[0].remove_combatant(self)
 
-        logger.debug("NPC %s killed by %s", self.key, getattr(attacker, "key", None))
+        logger.log_info(
+            "NPC %s killed by %s", self.key, getattr(attacker, "key", None)
+        )
 
         corpse = make_corpse(self)
         if corpse:


### PR DESCRIPTION
## Summary
- replace Python logger.debug calls with supported log_info function
- ensure NPC.on_death logs via log_info when killed

## Testing
- `pytest -k on_death -q` *(fails: django.db.utils.OperationalError: no such table: accounts_accountdb)*
- `pytest utils/tests/test_combat_utils.py::TestCombatUtils::test_get_condition_msg -q` *(fails: django.db.utils.OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684c7fa0777c832c83dd696e4f1e18ee