### PR TITLE
Add NPC equipment spawns

### DIFF
--- a/commands/mob_builder.py
+++ b/commands/mob_builder.py
@@ -2,7 +2,7 @@
 
 from evennia.utils.evmenu import EvMenu
 from evennia.prototypes import spawner
-from utils.mob_proto import spawn_from_vnum, get_prototype
+from utils.mob_proto import spawn_from_vnum, get_prototype, apply_proto_items
 from utils import vnum_registry
 from world.scripts.mob_db import get_mobdb
 from evennia.utils import delay
@@ -92,6 +92,7 @@ class CmdMSpawn(Command):
                 if proto.get("vnum"):
                     obj.db.vnum = proto["vnum"]
                     obj.tags.add(f"M{proto['vnum']}", category="vnum")
+                apply_proto_items(obj, proto)
 
         self.msg(f"Spawned {obj.key}.")
 
@@ -141,6 +142,7 @@ class CmdMobPreview(Command):
             )
             obj = spawner.spawn(proto)[0]
             obj.move_to(self.caller.location, quiet=True)
+            apply_proto_items(obj, proto)
         delay(30, obj.delete)
         self.msg(f"Previewing {obj.key}. It will vanish soon.")
 

--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -3,7 +3,7 @@ from olc.base import OLCEditor, OLCState, OLCValidator
 from evennia import create_object
 from evennia.objects.models import ObjectDB
 from evennia.prototypes import spawner
-from utils.mob_proto import spawn_from_vnum, get_prototype
+from utils.mob_proto import spawn_from_vnum, get_prototype, apply_proto_items
 from evennia.prototypes.prototypes import PROTOTYPE_TAG_CATEGORY
 from typeclasses.characters import NPC
 from world.scripts.mob_db import get_mobdb
@@ -1077,6 +1077,7 @@ class CmdSpawnNPC(Command):
             obj = spawner.spawn(proto)[0]
             obj.move_to(self.caller.location, quiet=True)
             obj.db.prototype_key = key
+            apply_proto_items(obj, proto)
         obj.db.area_tag = self.caller.location.db.area
         obj.db.spawn_room = self.caller.location
         self.msg(f"Spawned {obj.get_display_name(self.caller)}.")

--- a/scripts/area_spawner.py
+++ b/scripts/area_spawner.py
@@ -3,7 +3,7 @@
 from random import choice, randint
 
 from evennia.prototypes import spawner
-from utils.mob_proto import spawn_from_vnum
+from utils.mob_proto import spawn_from_vnum, apply_proto_items
 from evennia.utils import logger
 from commands.npc_builder import finalize_mob_prototype
 from typeclasses.scripts import Script
@@ -71,6 +71,7 @@ class AreaSpawner(Script):
             npc = spawner.spawn(proto_data)[0]
             npc.location = room
             npc.db.prototype_key = proto_key
+            apply_proto_items(npc, proto_data)
         finalize_mob_prototype(npc, npc)
         npc.db.area_tag = area
         npc.db.spawn_room = room


### PR DESCRIPTION
## Summary
- allow mob prototypes to include loot and equipment item VNUMs
- spawn listed items when NPCs are created
- equip gear for spawnnpc, mspawn and area spawner

## Testing
- `scripts/setup_test_env.sh` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: Could not find a version that satisfies the requirement setuptools>=40.8.0)*

------
https://chatgpt.com/codex/tasks/task_e_684c84ff0054832c83a663d5c2578ce4