### PR TITLE
Attach AI script on prototype finalization

### DIFF
--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -684,6 +684,9 @@ def finalize_mob_prototype(caller, npc):
         npc.db.gender = meta["gender"]
     if meta.get("ai_type"):
         npc.db.ai_type = meta["ai_type"]
+        from scripts.npc_ai_script import NPCAIScript
+        if npc.db.ai_type and not npc.scripts.get("npc_ai"):
+            npc.scripts.add(NPCAIScript, key="npc_ai")
     if meta.get("combat_class"):
         npc.db.combat_class = meta["combat_class"]
 

--- a/typeclasses/tests/test_npc_ai.py
+++ b/typeclasses/tests/test_npc_ai.py
@@ -159,3 +159,23 @@ class TestAIBehaviors(EvenniaTest):
             ai.process_ai(caller)
             mock.assert_called_with(self.char1)
         self.assertTrue(self.room1.msg_contents.called)
+
+    def test_finalize_adds_ai_script_and_auto_attacks(self):
+        from commands import npc_builder
+        from typeclasses.npcs import BaseNPC
+
+        npc = create.create_object(BaseNPC, key="attacker", location=self.room1)
+        npc.db.level = 1
+        npc.db.combat_class = "Warrior"
+        npc.db.ai_type = "aggressive"
+
+        npc_builder.finalize_mob_prototype(self.char1, npc)
+
+        script = npc.scripts.get("npc_ai")[0]
+        self.assertTrue(script)
+
+        self.char1.location = self.room1
+
+        with patch.object(npc, "enter_combat") as mock:
+            script.at_repeat()
+            mock.assert_called_with(self.char1)


### PR DESCRIPTION
## Summary
- ensure NPC AI script is added in `finalize_mob_prototype`
- test that finalized mobs auto-attack via the script

## Testing
- `scripts/setup_test_env.sh` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684c92c87ab8832c84bee2b02c006adf