### PR TITLE
Refresh stats when finalizing mobs

### DIFF
--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -729,6 +729,10 @@ def finalize_mob_prototype(caller, npc):
     if npc.db.vnum is not None:
         msg += f" with VNUM {npc.db.vnum}"
     msg += " and added to mob list.|n"
+
+    from world.system import stat_manager
+    stat_manager.refresh_stats(npc)
+
     caller.msg(msg)
 
 


### PR DESCRIPTION
## Summary
- refresh NPC stats before sending finalized message

## Testing
- `pytest -q` *(fails: OperationalError - no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684c9472ece8832c97d154c6b4ffbde5