### PR TITLE
Add whitespace give syntax

### DIFF
--- a/commands/info.py
+++ b/commands/info.py
@@ -332,14 +332,23 @@ class CmdGive(Command):
     help_category = "General"
 
     def parse(self):
-        lhs, rhs = self.args.split("=", 1) if "=" in self.args else (self.args, "")
-        self.lhs = lhs.strip()
-        self.rhs = rhs.strip()
+        if "=" in self.args:
+            lhs, rhs = self.args.split("=", 1)
+            self.lhs = lhs.strip()
+            self.rhs = rhs.strip()
+        else:
+            parts = self.args.split()
+            if len(parts) >= 2:
+                self.lhs = " ".join(parts[:-1])
+                self.rhs = parts[-1]
+            else:
+                self.lhs = self.args.strip()
+                self.rhs = ""
 
     def func(self):
         caller = self.caller
         if not self.lhs or not self.rhs:
-            caller.msg("Give <item|amount coin> = <target>")
+            caller.msg("Give <item|amount coin> <target>")
             return
 
         target = caller.search(self.rhs)

--- a/typeclasses/tests/test_give_command.py
+++ b/typeclasses/tests/test_give_command.py
@@ -1,0 +1,37 @@
+from unittest.mock import MagicMock
+
+from evennia import create_object
+from evennia.utils.test_resources import EvenniaTest
+from django.test import override_settings
+
+
+@override_settings(DEFAULT_HOME=None)
+class TestGiveCommand(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.char1.msg = MagicMock()
+        self.char2.msg = MagicMock()
+
+    def _create_item(self, name="sword"):
+        return create_object("typeclasses.objects.Object", key=name, location=self.char1)
+
+    def test_give_item_no_equals(self):
+        item = self._create_item("sword")
+        self.char1.execute_cmd(f"give sword {self.char2.key}")
+        self.assertEqual(item.location, self.char2)
+
+    def test_give_coins_no_equals(self):
+        from utils.currency import from_copper, to_copper, COIN_VALUES
+
+        self.char1.db.coins = from_copper(10 * COIN_VALUES["gold"])
+        self.char2.db.coins = from_copper(0)
+
+        self.char1.execute_cmd(f"give 10 gold {self.char2.key}")
+
+        self.assertEqual(to_copper(self.char1.db.coins), 0)
+        self.assertEqual(to_copper(self.char2.db.coins), 10 * COIN_VALUES["gold"])
+
+    def test_give_item_equals_syntax(self):
+        item = self._create_item("sword")
+        self.char1.execute_cmd(f"give sword={self.char2.key}")
+        self.assertEqual(item.location, self.char2)


### PR DESCRIPTION
## Summary
- update give command parse logic
- add support for `give <thing> <target>`
- test giving items and coins via new syntax and old `=` syntax

## Testing
- `evennia migrate`
- `pytest typeclasses/tests/test_give_command.py::TestGiveCommand::test_give_item_no_equals -q`
- `pytest typeclasses/tests/test_give_command.py::TestGiveCommand::test_give_coins_no_equals -q`
- `pytest typeclasses/tests/test_give_command.py::TestGiveCommand::test_give_item_equals_syntax -q`


------
https://chatgpt.com/codex/tasks/task_e_684c95b45760832ca5f59c75cb84efe8