### PR TITLE
Add regression test for NPC stat caching on spawn

### DIFF
--- a/typeclasses/tests/test_vnum_mobs.py
+++ b/typeclasses/tests/test_vnum_mobs.py
@@ -287,3 +287,24 @@ class TestVnumMobs(EvenniaTest):
         with self.assertRaises(ValueError):
             register_prototype({"key": "bad", "typeclass": "typeclasses.objects.ObjectParent"}, vnum=65)
 
+    def test_spawn_populates_stat_caches(self):
+        """spawn_from_vnum should set primary and derived stat caches."""
+        proto = {
+            "key": "fighter",
+            "typeclass": "typeclasses.npcs.BaseNPC",
+            "level": 1,
+            "combat_class": "Warrior",
+        }
+        vnum = register_prototype(proto, vnum=80)
+        npc = spawn_from_vnum(vnum, location=self.char1.location)
+
+        self.assertTrue(getattr(npc.db, "primary_stats", None))
+        self.assertTrue(getattr(npc.db, "derived_stats", None))
+
+        from world.system import stat_manager
+
+        self.assertEqual(
+            stat_manager.get_effective_stat(npc, "STR"),
+            npc.db.primary_stats.get("STR"),
+        )
+


### PR DESCRIPTION
## Summary
- add a test to ensure spawned mobs have `primary_stats` and `derived_stats`
  populated so `get_effective_stat` works

## Testing
- `pytest typeclasses/tests/test_vnum_mobs.py::TestVnumMobs::test_spawn_populates_stat_caches -q`

------
https://chatgpt.com/codex/tasks/task_e_684c976d16b4832ca38f585c0848dae6