### PR TITLE
Handle None attacker in damage

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -397,13 +397,16 @@ class Character(ObjectParent, ClothedCharacter):
 
         self.traits.health.current -= damage
         crit_prefix = "|rCritical!|n " if critical else ""
-        self.msg(
-            f"{crit_prefix}You take {damage} damage from {attacker.get_display_name(self)}."
-        )
-        attacker.msg(
-            f"You deal {damage} damage to {self.get_display_name(attacker)}"
-            + ("!" if critical else ".")
-        )
+        if attacker:
+            self.msg(
+                f"{crit_prefix}You take {damage} damage from {attacker.get_display_name(self)}."
+            )
+            attacker.msg(
+                f"You deal {damage} damage to {self.get_display_name(attacker)}"
+                + ("!" if critical else ".")
+            )
+        else:
+            self.msg(f"{crit_prefix}You take {damage} damage.")
         if self.traits.health.value <= 0:
             self.tags.add("unconscious", category="status")
             self.tags.add("lying down", category="status")

--- a/typeclasses/tests/test_characters.py
+++ b/typeclasses/tests/test_characters.py
@@ -41,6 +41,12 @@ class TestCharacterHooks(EvenniaTest):
         self.char2.at_damage(self.char1, 5)
         self.assertEqual(self.char2.ndb.damage_log.get(self.char1), 5)
 
+    def test_at_damage_no_attacker(self):
+        """Calling at_damage with no attacker should not error."""
+        self.char2.at_damage(None, 10)
+        self.char2.msg.assert_called_once_with("You take 10 damage.")
+        self.char1.msg.assert_not_called()
+
     def test_at_wield_unwield(self):
         self.char1.attributes.add("_wielded", {"left": None, "right": None})
         used_hands = self.char1.at_wield(self.obj1)


### PR DESCRIPTION
## Summary
- avoid attribute errors in Character.at_damage
- test calling at_damage with attacker=None

## Testing
- `pytest typeclasses/tests/test_characters.py::TestCharacterHooks::test_at_damage_no_attacker -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684c9ccacc64832ca6c84f47c95475ad