### PR TITLE
Allow negative modifiers in stat parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ cweapon "epee" offhand 2d6 3 STR+1, Attack Power+2 A balanced offhand blade.
 inspect epee-2
 ```
 
-Modifiers use the form `Stat+Value` separated by commas. Quote names that
+Modifiers use the form `Stat+Value` or `Stat-Value` separated by commas. Quote names that
 contain spaces or ANSI colour codes, as shown above.
 
 Add `/unidentified` before the name to create the weapon unidentified.

--- a/commands/README.md
+++ b/commands/README.md
@@ -51,7 +51,7 @@ Builders and admins can adjust object attributes with these commands:
 ## Object Creation Commands
 
 * `cweapon <name> <slot> <damage> [weight] [stat_mods] <description>` - create a
-  melee weapon in your inventory. Modifiers use `Stat+Value`, comma separated,
+  melee weapon in your inventory. Modifiers use `Stat+Value` or `Stat-Value`, comma separated,
   and multiword or ANSI-coloured names must be quoted. The item's key stays
   exactly as typed. A
   lowercase alias plus a numbered alias like `name-1`, `name-2`, and so forth is

--- a/commands/admin.py
+++ b/commands/admin.py
@@ -94,7 +94,7 @@ def parse_stat_mods(text):
         return bonuses, desc
 
     pieces = [p.strip() for p in text.split(",")]
-    pattern = re.compile(r"([A-Za-z][A-Za-z _]*?)\+(-?\d+)")
+    pattern = re.compile(r"([A-Za-z][A-Za-z _]*?)([+-]\d+)")
     desc_parts = []
 
     for i, piece in enumerate(pieces):
@@ -114,7 +114,7 @@ def parse_stat_mods(text):
                 desc_parts.extend(p.strip() for p in pieces[i + 1 :])
                 break
         else:
-            if "+" in piece:
+            if "+" in piece or "-" in piece:
                 raise ValueError(piece)
             desc_parts.append(piece)
             desc_parts.extend(p.strip() for p in pieces[i + 1 :])
@@ -726,39 +726,13 @@ class CmdCWeapon(Command):
                 self.msg("Damage must be a number or NdN dice string.")
                 return
 
-        if rest:
-            pieces = [p.strip() for p in rest.split(",")]
-            pattern = re.compile(r"([A-Za-z][A-Za-z _]*?)\+(-?\d+)")
-            desc_parts = []
-            for piece in pieces:
-                if not piece:
-                    continue
-                match = pattern.match(piece)
-                if match:
-                    stat_name = match.group(1).strip()
-                    amount = int(match.group(2))
-                    key = normalize_stat_key(stat_name)
-                    if key not in VALID_STATS:
-                        self.msg(
-                            f"Invalid stat modifier: {stat_name}. See 'help statmods' for valid stats."
-                        )
-                        return
-                    bonuses[key] = amount
-                    remainder = piece[match.end() :].strip()
-                    if remainder:
-                        desc_parts.append(remainder)
-                        desc_parts.extend(
-                            p.strip() for p in pieces[pieces.index(piece) + 1 :]
-                        )
-                        break
-                else:
-                    desc_parts.append(piece)
-                    desc_parts.extend(
-                        p.strip() for p in pieces[pieces.index(piece) + 1 :]
-                    )
-                    break
-            if desc_parts:
-                desc = ", ".join(desc_parts).strip()
+        try:
+            bonuses, desc = parse_stat_mods(rest)
+        except ValueError as err:
+            self.msg(
+                f"Invalid stat modifier: {err}. See 'help statmods' for valid stats."
+            )
+            return
         if desc is None and rest:
             desc = rest.strip()
 
@@ -868,39 +842,13 @@ class CmdCShield(Command):
 
         bonuses = {}
         desc = None
-        if rest:
-            pieces = [p.strip() for p in rest.split(",")]
-            pattern = re.compile(r"([A-Za-z][A-Za-z _]*?)\+(-?\d+)")
-            desc_parts = []
-            for piece in pieces:
-                if not piece:
-                    continue
-                match = pattern.match(piece)
-                if match:
-                    stat_name = match.group(1).strip()
-                    amount = int(match.group(2))
-                    key = normalize_stat_key(stat_name)
-                    if key not in VALID_STATS:
-                        self.msg(
-                            f"Invalid stat modifier: {stat_name}. See 'help statmods' for valid stats."
-                        )
-                        return
-                    bonuses[key] = amount
-                    remainder = piece[match.end() :].strip()
-                    if remainder:
-                        desc_parts.append(remainder)
-                        desc_parts.extend(
-                            p.strip() for p in pieces[pieces.index(piece) + 1 :]
-                        )
-                        break
-                else:
-                    desc_parts.append(piece)
-                    desc_parts.extend(
-                        p.strip() for p in pieces[pieces.index(piece) + 1 :]
-                    )
-                    break
-            if desc_parts:
-                desc = ", ".join(desc_parts).strip()
+        try:
+            bonuses, desc = parse_stat_mods(rest)
+        except ValueError as err:
+            self.msg(
+                f"Invalid stat modifier: {err}. See 'help statmods' for valid stats."
+            )
+            return
         if desc is None and rest:
             desc = rest.strip()
 

--- a/utils/tests/test_parse_stat_mods.py
+++ b/utils/tests/test_parse_stat_mods.py
@@ -1,6 +1,7 @@
 from evennia.utils.test_resources import EvenniaTest
 from commands.admin import parse_stat_mods
 
+
 class TestParseStatMods(EvenniaTest):
     def test_alias_and_lowercase(self):
         mods, desc = parse_stat_mods("armor_pen+5, crit_chance+3 test")
@@ -16,3 +17,7 @@ class TestParseStatMods(EvenniaTest):
     def test_underscore_names(self):
         mods, _ = parse_stat_mods("critical_chance+2")
         self.assertEqual(mods, {"crit_chance": 2})
+
+    def test_negative_modifier(self):
+        mods, _ = parse_stat_mods("accuracy-3")
+        self.assertEqual(mods, {"accuracy": -3})

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -431,7 +431,7 @@ Notes:
     the item as given.
     - Optional stat modifiers can be provided as comma separated entries like
     |wSTR+2, Attack Power+5|n. Valid stats include all core and derived values.
-    - Modifiers use the form |wStat+Value|n and are comma separated.
+    - Modifiers use the form |wStat+Value|n or |wStat-Value|n and are comma separated.
     - Enclose multiword or ANSI-colored names in quotes.
     - The item is a |ctypeclasses.gear.MeleeWeapon|n.
     - ANSI color codes are supported.
@@ -466,7 +466,7 @@ Notes:
     - Optional comma separated modifiers may be given, such as
     |wBlock Rate+3|n or |wSTR+2, Attack Power+5|n. Valid stats include
     all core and derived values.
-    - Modifiers use the form |wStat+Value|n and are comma separated.
+    - Modifiers use the form |wStat+Value|n or |wStat-Value|n and are comma separated.
     - Enclose multiword or ANSI-colored names in quotes.
     - Add |w/unidentified|n before the name to create the shield unidentified.
 
@@ -497,7 +497,7 @@ Examples:
 Notes:
     - Slot becomes the clothing type.
     - Add |w/unidentified|n before the name to create the armor unidentified.
-    - Modifiers use the form |wStat+Value|n and are comma separated.
+    - Modifiers use the form |wStat+Value|n or |wStat-Value|n and are comma separated.
     - Enclose multiword or ANSI-colored names in quotes.
 
 Related:
@@ -526,7 +526,7 @@ Examples:
 
 Notes:
     - The tag is added with category 'crafting_tool'.
-    - Modifiers use the form |wStat+Value|n and are comma separated.
+    - Modifiers use the form |wStat+Value|n or |wStat-Value|n and are comma separated.
     - Enclose multiword or ANSI-colored names in quotes.
 
 Related:
@@ -556,7 +556,7 @@ Examples:
 Notes:
     - Creates an object of the given typeclass and places it in your inventory.
     - Add |w/unidentified|n before the name to create the item unidentified.
-    - Modifiers use the form |wStat+Value|n and are comma separated.
+    - Modifiers use the form |wStat+Value|n or |wStat-Value|n and are comma separated.
     - Enclose multiword or ANSI-colored names in quotes.
 
 Related:
@@ -586,7 +586,7 @@ Examples:
 Notes:
     - Slot defaults to ring1. Use ring2 for the other finger.
     - Add |w/unidentified|n before the name to create the ring unidentified.
-    - Modifiers use the form |wStat+Value|n and are comma separated.
+    - Modifiers use the form |wStat+Value|n or |wStat-Value|n and are comma separated.
     - Enclose multiword or ANSI-colored names in quotes.
 
 Related:
@@ -616,7 +616,7 @@ Examples:
 Notes:
     - Trinkets occupy the dedicated trinket slot.
     - Add |w/unidentified|n before the name to create the item unidentified.
-    - Modifiers use the form |wStat+Value|n and are comma separated.
+    - Modifiers use the form |wStat+Value|n or |wStat-Value|n and are comma separated.
     - Enclose multiword or ANSI-colored names in quotes.
 
 Related:
@@ -702,7 +702,7 @@ Examples:
 Notes:
     - Items are flagged edible automatically.
     - Weight is set to 1.
-    - Modifiers use the form |wStat+Value|n and are comma separated.
+    - Modifiers use the form |wStat+Value|n or |wStat-Value|n and are comma separated.
 
 Related:
     help ansi

--- a/world/system/stat_manager.py
+++ b/world/system/stat_manager.py
@@ -146,7 +146,7 @@ def collect_item_mods(item) -> Dict[str, int]:  # pragma: no cover - helper
         for tag in tags:
             if not isinstance(tag, str):
                 continue
-            m = re.match(r"([A-Z_]+)\+(\-?\d+)$", tag)
+            m = re.match(r"([A-Z_]+)([+-]\d+)$", tag)
             if m:
                 stat, amt = m.groups()
                 stat = normalize_stat_key(stat)


### PR DESCRIPTION
## Summary
- allow `parse_stat_mods` to recognize `-` sign
- deduplicate weapon/shield creation code by calling `parse_stat_mods`
- support negative modifier tags in `collect_item_mods`
- document `Stat+Value` **or** `Stat-Value` syntax
- test parsing negative modifiers

## Testing
- `black --check commands/admin.py utils/tests/test_parse_stat_mods.py world/system/stat_manager.py world/help_entries.py`
- `pytest -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684ca58f91ec832c89fd4862f96c1341