### PR TITLE
Fix active combatant check

### DIFF
--- a/typeclasses/scripts.py
+++ b/typeclasses/scripts.py
@@ -62,7 +62,11 @@ class CombatScript(Script):
         return [
             obj
             for obj in self.fighters
-            if not any(obj.tags.has(["unconscious", "dead", "defeated"]))
+            if not obj.tags.has([
+                "unconscious",
+                "dead",
+                "defeated",
+            ], category="status")
         ]
 
     def at_script_creation(self):


### PR DESCRIPTION
## Summary
- fix `CombatScript.active` to not call `any` on a boolean

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684cb42d2e94832ca0cccf351f1f48dd