### PR TITLE
Apply default XP reward and add test

### DIFF
--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -720,6 +720,9 @@ def finalize_mob_prototype(caller, npc):
     if npc.db.initiative is None:
         npc.db.initiative = stats["initiative"]
 
+    if not npc.db.exp_reward:
+        npc.db.exp_reward = (npc.db.level or 1) * settings.DEFAULT_XP_PER_LEVEL
+
     from world.mobregistry import register_mob_vnum
 
     if npc.db.vnum:


### PR DESCRIPTION
## Summary
- give new NPCs a default XP reward if none is defined
- verify default reward is granted when NPC is killed

## Testing
- `pytest -k test_default_exp_reward_based_on_level -q` *(fails: ObjectDB.DoesNotExist due to environment setup)*

------
https://chatgpt.com/codex/tasks/task_e_684cba965e04832c8e7872c80afacb17