### PR TITLE
Implement minimum XP share in combat group gain

### DIFF
--- a/combat/combat_engine.py
+++ b/combat/combat_engine.py
@@ -161,7 +161,7 @@ class CombatEngine:
         members = [m for m in members if m]
         if not members or not exp:
             return
-        share = max(1, int(exp / len(members)))
+        share = max(int(exp / len(members)), int(exp * 0.10))
         for member in members:
             member.db.exp = (member.db.exp or 0) + share
             if hasattr(member, "msg"):


### PR DESCRIPTION
## Summary
- ensure each member of a combat group gains at least 10% of total XP
- add regression test for minimum XP share

## Testing
- `pytest typeclasses/tests/test_combat_engine.py::TestCombatEngine::test_group_gain_minimum_share -q` *(fails: AssertionError: 0 != 10)*

------
https://chatgpt.com/codex/tasks/task_e_684cbca48f54832c8a8060d02b5354f3