### PR TITLE
Add SatedDecayScript

### DIFF
--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,1 +1,3 @@
 from .builder_autosave import BuilderAutosave
+from .sated_decay import SatedDecayScript
+

--- a/scripts/sated_decay.py
+++ b/scripts/sated_decay.py
@@ -1,0 +1,33 @@
+from typeclasses.scripts import Script
+
+
+class SatedDecayScript(Script):
+    """Periodically reduce character sated values."""
+
+    def at_script_creation(self):
+        self.key = "sated_decay"
+        self.desc = "Reduce character sated values over time"
+        self.interval = 60
+        self.persistent = True
+
+    def at_repeat(self):
+        from typeclasses.characters import Character
+
+        thresholds = {50: "You feel a bit peckish.",
+                      20: "You are getting hungry.",
+                      1: "You are starving!"}
+
+        for char in Character.objects.all():
+            sated = getattr(char.db, "sated", None)
+            if sated is None or sated <= 0:
+                continue
+            old = sated
+            char.db.sated = max(sated - 1, 0)
+            new_val = char.db.sated
+            for threshold, msg in thresholds.items():
+                if old >= threshold > new_val:
+                    if hasattr(char, "msg"):
+                        char.msg(msg)
+                    break
+
+

--- a/server/conf/at_server_startstop.py
+++ b/server/conf/at_server_startstop.py
@@ -59,6 +59,7 @@ def at_server_start():
     from evennia.utils import create
     from evennia.scripts.models import ScriptDB
     from world.scripts.mob_db import get_mobdb
+    from scripts.sated_decay import SatedDecayScript
 
     script = ScriptDB.objects.filter(db_key="global_tick").first()
     if not script or script.typeclass_path != "typeclasses.scripts.GlobalTick":
@@ -71,6 +72,12 @@ def at_server_start():
         if script:
             script.delete()
         create.create_script("world.area_reset.AreaReset", key="area_reset")
+
+    script = ScriptDB.objects.filter(db_key="sated_decay").first()
+    if not script or script.typeclass_path != "scripts.sated_decay.SatedDecayScript":
+        if script:
+            script.delete()
+        create.create_script("scripts.sated_decay.SatedDecayScript", key="sated_decay")
 
     # Ensure mob database script exists
     get_mobdb()

--- a/typeclasses/tests/test_state_manager.py
+++ b/typeclasses/tests/test_state_manager.py
@@ -162,3 +162,16 @@ class TestStateManager(EvenniaTest):
         for key, regen in expected.items():
             trait = char.traits.get(key)
             self.assertEqual(trait.current, trait.max // 2 + regen)
+
+    def test_sated_decay_script_reduces_sated(self):
+        from scripts.sated_decay import SatedDecayScript
+
+        char = self.char1
+        char.db.sated = 10
+
+        script = SatedDecayScript()
+        script.at_script_creation()
+
+        script.at_repeat()
+
+        self.assertEqual(char.db.sated, 9)


### PR DESCRIPTION
## Summary
- add SatedDecayScript to periodically reduce players' `sated` value
- load SatedDecayScript on server start
- export script in `scripts/__init__.py`
- test that SatedDecayScript.at_repeat lowers `sated`

## Testing
- `pytest -q typeclasses/tests/test_state_manager.py::TestStateManager::test_sated_decay_script_reduces_sated` *(fails: OperationalError no such table)*

------
https://chatgpt.com/codex/tasks/task_e_684cbe4ac99c832c89d5788945d83e87