### PR TITLE
Update XP reward prompt

### DIFF
--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -216,6 +216,7 @@ REVIEW_SECTIONS = [
     ("Role Details", "menunode_role_details"),
     ("Rewards", "menunode_exp_reward"),
     ("EXP Reward", "menunode_exp_reward"),
+    ("Edit XP reward", "menunode_exp_reward"),
     ("Coin Drop", "menunode_coin_drop"),
     ("Loot Table", "menunode_loot_table"),
     ("Combat Stats", "menunode_resources_prompt"),

--- a/world/menus/mob_builder_menu.py
+++ b/world/menus/mob_builder_menu.py
@@ -602,6 +602,7 @@ def menunode_exp_reward(caller, raw_string="", **kwargs):
         f"""
         |wEXP reward|n [default: {default}]
         Example: |w{level * settings.DEFAULT_XP_PER_LEVEL}|n
+        Leave blank for level \xd7 DEFAULT_XP_PER_LEVEL
         (back to go back, skip for default)
         """
     )


### PR DESCRIPTION
## Summary
- clarify EXP reward prompt to mention leaving blank uses level × `DEFAULT_XP_PER_LEVEL`
- add `Edit XP reward` entry to review options

## Testing
- `pytest -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684cbfa908f4832c91037d2f5c37528a