### PR TITLE
Add auto combat rounds and XP reward feedback

### DIFF
--- a/combat/round_manager.py
+++ b/combat/round_manager.py
@@ -60,7 +60,7 @@ class CombatRoundManager:
 
     def _schedule_tick(self) -> None:
         """Schedule the next combat tick."""
-        delay(0.3, self.tick)
+        delay(2, self.tick)
 
     def tick(self) -> None:
         for inst in list(self.instances):

--- a/typeclasses/tests/test_leveling.py
+++ b/typeclasses/tests/test_leveling.py
@@ -21,7 +21,7 @@ class TestLeveling(EvenniaTest):
         self.char1.msg.assert_called()
         output = self.char1.msg.call_args[0][0]
         self.assertIn("practice sessions", output)
-        self.assertIn("training point", output)
+        self.assertIn("training session", output)
 
     def test_multiple_level_ups(self):
         self.char1.db.exp = 210
@@ -31,4 +31,4 @@ class TestLeveling(EvenniaTest):
         self.assertEqual(self.char1.db.training_points, 2)
         output = self.char1.msg.call_args[0][0]
         self.assertIn("practice sessions", output)
-        self.assertIn("training point", output)
+        self.assertIn("training session", output)

--- a/typeclasses/tests/test_round_manager.py
+++ b/typeclasses/tests/test_round_manager.py
@@ -19,12 +19,12 @@ class TestCombatRoundManager(EvenniaTest):
     def test_tick_schedules(self):
         with patch("combat.round_manager.delay") as mock_delay:
             self.manager.add_instance(self.script)
-            mock_delay.assert_called_with(0.3, self.manager.tick)
+            mock_delay.assert_called_with(2, self.manager.tick)
             mock_delay.reset_mock()
             with patch.object(CombatEngine, "process_round") as mock_proc:
                 self.manager.tick()
                 mock_proc.assert_called()
-            mock_delay.assert_called_with(0.3, self.manager.tick)
+            mock_delay.assert_called_with(2, self.manager.tick)
 
     def test_initiative_order(self):
         order = []

--- a/world/system/state_manager.py
+++ b/world/system/state_manager.py
@@ -321,9 +321,8 @@ def check_level_up(chara) -> bool:
 
     if leveled:
         chara.db.level = level
-        chara.msg(
-            f"You advance to level {level}! +3 practice sessions and +1 training point awarded."
-        )
+        chara.msg(f"You have reached level {level}!")
+        chara.msg("You gain 3 practice sessions and 1 training session.")
         stat_manager.refresh_stats(chara)
 
     return leveled


### PR DESCRIPTION
## Summary
- implement `award_xp` helper for splitting experience
- auto combat rounds tick every 2 seconds via `CombatRoundManager`
- grant experience after gold drop and show level up messages
- adjust level up text
- update tests for new timing and messages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684cbfe20480832c84676279efd776d1