### PR TITLE
Add XP_PER_LEVEL setting

### DIFF
--- a/server/conf/settings.py
+++ b/server/conf/settings.py
@@ -42,6 +42,9 @@ COMMAND_DEFAULT_CLASS = "commands.command.MuxCommand"
 # Default experience reward given per NPC level when creating mobs
 DEFAULT_XP_PER_LEVEL = 10
 
+# Experience required to reach the next character level
+XP_PER_LEVEL = 100
+
 ######################################################################
 # Config for contrib packages
 ######################################################################

--- a/utils/stats_utils.py
+++ b/utils/stats_utils.py
@@ -178,7 +178,9 @@ def get_display_scroll(chara):
 
     level = _db_get(chara, "level", 1)
     xp = _db_get(chara, "exp", 0)
-    tnl = max(level * 100 - xp, 0)
+    from django.conf import settings
+
+    tnl = max(level * settings.XP_PER_LEVEL - xp, 0)
     practice_sessions = _db_get(chara, "practice_sessions", 0) or 0
     training_points = _db_get(chara, "training_points", 0) or 0
 

--- a/world/system/state_manager.py
+++ b/world/system/state_manager.py
@@ -4,6 +4,7 @@ from typing import Dict, List
 from world import stats
 from world.system import stat_manager
 from world.effects import EFFECTS
+from django.conf import settings
 from .constants import MAX_SATED, MAX_LEVEL
 
 
@@ -313,7 +314,7 @@ def check_level_up(chara) -> bool:
     level = int(chara.db.level or 1)
     leveled = False
 
-    while level < MAX_LEVEL and exp >= level * 100:
+    while level < MAX_LEVEL and exp >= level * settings.XP_PER_LEVEL:
         level += 1
         leveled = True
         chara.db.practice_sessions = (chara.db.practice_sessions or 0) + 3


### PR DESCRIPTION
## Summary
- add `XP_PER_LEVEL` setting to configure leveling costs
- allow state manager to use settings.XP_PER_LEVEL
- show XP_PER_LEVEL when calculating `TNL` in stats_utils

## Testing
- `pytest -q` *(fails: django.db errors)*

------
https://chatgpt.com/codex/tasks/task_e_684cc31be6d8832c875ca8329812381f