### PR TITLE
Use explicit XP and TNL fields in scroll display

### DIFF
--- a/utils/stats_utils.py
+++ b/utils/stats_utils.py
@@ -177,8 +177,8 @@ def get_display_scroll(chara):
     lines.append(name)
 
     level = _db_get(chara, "level", 1)
-    xp = _db_get(chara, "experience", 0)
-    tnl = _db_get(chara, "tnl", 0)
+    xp = getattr(chara.db, "experience", 0) or 0
+    tnl = getattr(chara.db, "tnl", 0) or 0
     practice_sessions = _db_get(chara, "practice_sessions", 0) or 0
     training_points = _db_get(chara, "training_points", 0) or 0
 

--- a/utils/tests/test_stats_utils.py
+++ b/utils/tests/test_stats_utils.py
@@ -45,3 +45,11 @@ class TestDisplayScroll(EvenniaTest):
         sheet = get_display_scroll(char)
         self.assertIn("Prac", sheet)
         self.assertIn("TP", sheet)
+
+    def test_xp_and_tnl_display(self):
+        char = self.char1
+        char.db.experience = 10
+        char.db.tnl = 90
+        sheet = get_display_scroll(char)
+        self.assertIn("XP|n 10", sheet)
+        self.assertIn("TNL|n 90", sheet)


### PR DESCRIPTION
## Summary
- read `character.db.experience` and `character.db.tnl` in `get_display_scroll`
- add unit test verifying the XP and TNL values show up

## Testing
- `pytest -q utils/tests/test_stats_utils.py::TestDisplayScroll::test_xp_and_tnl_display -vv`
- `pytest -q utils/tests/test_stats_utils.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_684cceeee9d4832c9f5bbd3331fe3e8c