### PR TITLE
Add gain_xp and level_up tests

### DIFF
--- a/typeclasses/tests/test_leveling.py
+++ b/typeclasses/tests/test_leveling.py
@@ -59,3 +59,34 @@ class TestExperienceCarryOver(EvenniaTest):
             self.char1.db.experience, settings.XP_PER_LEVEL + 10
         )
         self.assertEqual(self.char1.db.tnl, settings.XP_PER_LEVEL - 10)
+
+
+class TestGainXpAndLevelUp(EvenniaTest):
+    """Tests for gain_xp and level_up helpers."""
+
+    def setUp(self):
+        super().setUp()
+        self.char1.db.level = 1
+        self.char1.db.experience = 0
+        self.char1.db.tnl = settings.XP_PER_LEVEL
+        self.char1.db.practice_sessions = 0
+        self.char1.db.training_points = 0
+        self.char1.msg = MagicMock()
+
+    def test_gain_xp_lowers_tnl(self):
+        state_manager.gain_xp(self.char1, 5)
+        self.assertEqual(self.char1.db.tnl, settings.XP_PER_LEVEL - 5)
+
+    def test_gain_xp_levels_when_tnl_zero(self):
+        state_manager.gain_xp(self.char1, settings.XP_PER_LEVEL)
+        self.assertEqual(self.char1.db.level, 2)
+        self.assertEqual(self.char1.db.practice_sessions, 3)
+        self.assertEqual(self.char1.db.training_points, 1)
+        self.assertEqual(self.char1.db.tnl, settings.XP_PER_LEVEL)
+
+    def test_level_up_awards_resources(self):
+        state_manager.level_up(self.char1)
+        self.assertEqual(self.char1.db.level, 2)
+        self.assertEqual(self.char1.db.practice_sessions, 3)
+        self.assertEqual(self.char1.db.training_points, 1)
+        self.assertEqual(self.char1.db.tnl, settings.XP_PER_LEVEL)


### PR DESCRIPTION
## Summary
- test leveling resources via gain_xp and level_up

## Testing
- `pytest typeclasses/tests/test_leveling.py::TestGainXpAndLevelUp::test_gain_xp_lowers_tnl -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684cd4207c04832c922d5dc33b62442a