### PR TITLE
Add integration test for sated decay

### DIFF
--- a/utils/tests/test_stats_utils.py
+++ b/utils/tests/test_stats_utils.py
@@ -53,3 +53,15 @@ class TestDisplayScroll(EvenniaTest):
         sheet = get_display_scroll(char)
         self.assertIn("XP|n 10", sheet)
         self.assertIn("TNL|n 90", sheet)
+    def test_sated_decay_updates_display(self):
+        from scripts.sated_decay import SatedDecayScript
+        char = self.char1
+        char.db.sated = 10
+        script = SatedDecayScript()
+        script.at_script_creation()
+        script.at_repeat()
+        sheet = get_display_scroll(char)
+        self.assertIn("|ySated|n", sheet)
+        self.assertIn("9", sheet)
+
+


### PR DESCRIPTION
## Summary
- verify sated decay script and display use same attribute
- test that sated decreases and is shown on the score sheet

## Testing
- `pytest -q` *(fails: OperationalError no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684cd847abb0832cafd93643edac89c3