### PR TITLE
Remove SatedDecayScript usage

### DIFF
--- a/server/conf/at_server_startstop.py
+++ b/server/conf/at_server_startstop.py
@@ -76,7 +76,6 @@ def at_server_start():
     from evennia.utils import create
     from evennia.scripts.models import ScriptDB
     from world.scripts.mob_db import get_mobdb
-    from scripts.sated_decay import SatedDecayScript
 
     script = ScriptDB.objects.filter(db_key="global_tick").first()
     if not script or script.typeclass_path != "typeclasses.scripts.GlobalTick":
@@ -89,12 +88,6 @@ def at_server_start():
         if script:
             script.delete()
         create.create_script("world.area_reset.AreaReset", key="area_reset")
-
-    script = ScriptDB.objects.filter(db_key="sated_decay").first()
-    if not script or script.typeclass_path != "scripts.sated_decay.SatedDecayScript":
-        if script:
-            script.delete()
-        create.create_script("scripts.sated_decay.SatedDecayScript", key="sated_decay")
 
     # Ensure mob database script exists
     get_mobdb()

--- a/typeclasses/tests/test_state_manager.py
+++ b/typeclasses/tests/test_state_manager.py
@@ -163,15 +163,3 @@ class TestStateManager(EvenniaTest):
             trait = char.traits.get(key)
             self.assertEqual(trait.current, trait.max // 2 + regen)
 
-    def test_sated_decay_script_reduces_sated(self):
-        from scripts.sated_decay import SatedDecayScript
-
-        char = self.char1
-        char.db.sated = 10
-
-        script = SatedDecayScript()
-        script.at_script_creation()
-
-        script.at_repeat()
-
-        self.assertEqual(char.db.sated, 9)

--- a/utils/tests/test_stats_utils.py
+++ b/utils/tests/test_stats_utils.py
@@ -53,13 +53,14 @@ class TestDisplayScroll(EvenniaTest):
         sheet = get_display_scroll(char)
         self.assertIn("XP|n 10", sheet)
         self.assertIn("TNL|n 90", sheet)
-    def test_sated_decay_updates_display(self):
-        from scripts.sated_decay import SatedDecayScript
+    def test_tick_updates_display(self):
+        from world.system import state_manager
+
         char = self.char1
         char.db.sated = 10
-        script = SatedDecayScript()
-        script.at_script_creation()
-        script.at_repeat()
+
+        state_manager.tick_character(char)
+
         sheet = get_display_scroll(char)
         self.assertIn("|ySated|n", sheet)
         self.assertIn("9", sheet)


### PR DESCRIPTION
## Summary
- stop creating the unused `SatedDecayScript`
- remove the SatedDecayScript test
- adjust display test to tick characters directly

## Testing
- `pytest utils/tests/test_stats_utils.py::TestDisplayScroll::test_tick_updates_display -q`
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684ce62f0930832c8b0fb8881bc8d216