### PR TITLE
Start combat immediately when instance added

### DIFF
--- a/combat/round_manager.py
+++ b/combat/round_manager.py
@@ -48,6 +48,8 @@ class CombatRoundManager:
         engine = CombatEngine(script.fighters, round_time=None)
         inst = CombatInstance(script, engine)
         self.instances.append(inst)
+        # process the first combat round immediately
+        inst.engine.process_round()
         if not self.running:
             self.running = True
             self._schedule_tick()


### PR DESCRIPTION
## Summary
- trigger the first combat round when a new instance is registered

## Testing
- `pytest typeclasses/tests/test_round_manager.py::TestCombatRoundManager::test_tick_schedules -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684cead70400832c9a297b7347800591