### PR TITLE
Update round delay using haste

### DIFF
--- a/typeclasses/tests/test_round_manager.py
+++ b/typeclasses/tests/test_round_manager.py
@@ -17,14 +17,18 @@ class TestCombatRoundManager(EvenniaTest):
         self.manager.running = False
 
     def test_tick_schedules(self):
-        with patch("combat.round_manager.delay") as mock_delay:
+        with patch("combat.round_manager.delay") as mock_delay, \
+             patch("combat.round_manager.calculate_round_delay", return_value=1.5) as mock_calc:
             self.manager.add_instance(self.script)
-            mock_delay.assert_called_with(2, self.manager.tick)
+            mock_calc.assert_called()
+            mock_delay.assert_called_with(1.5, self.manager.tick)
             mock_delay.reset_mock()
+            mock_calc.reset_mock()
             with patch.object(CombatEngine, "process_round") as mock_proc:
                 self.manager.tick()
                 mock_proc.assert_called()
-            mock_delay.assert_called_with(2, self.manager.tick)
+            mock_calc.assert_called()
+            mock_delay.assert_called_with(1.5, self.manager.tick)
 
     def test_initiative_order(self):
         order = []


### PR DESCRIPTION
## Summary
- compute combat round delay from participant haste
- respect new delay when scheduling combat rounds
- check for proper delay in unit tests

## Testing
- `pytest typeclasses/tests/test_round_manager.py::TestCombatRoundManager::test_tick_schedules -q` *(fails: no such table)*

------
https://chatgpt.com/codex/tasks/task_e_684cebca18ec832ca348f1cc2319276a