### PR TITLE
Add haste stat

### DIFF
--- a/utils/stats_utils.py
+++ b/utils/stats_utils.py
@@ -15,6 +15,7 @@ ALIAS_MAP = {
     "def": "DEF",
     "acc": "ACC",
     "eva": "EVA",
+    "haste": "haste",
     "per": "perception",
     "critical_chance": "crit_chance",
     "critchance": "crit_chance",

--- a/world/stats.py
+++ b/world/stats.py
@@ -69,6 +69,7 @@ REGEN_STATS: List[Stat] = [
 TEMPO_STATS: List[Stat] = [
     Stat("cooldown_reduction", "Cooldown Reduction", stat="WIS"),
     Stat("initiative", "Initiative", stat="DEX"),
+    Stat("haste", "Haste", stat="DEX"),
 ]
 
 # Utility / miscellaneous stats

--- a/world/system/stat_manager.py
+++ b/world/system/stat_manager.py
@@ -22,7 +22,7 @@ from world.scripts import races, classes
 
 # Primary and secondary stat keys
 PRIMARY_STATS = stats.CORE_STAT_KEYS
-SECONDARY_STATS = ["HP", "MP", "SP", "ATK", "DEF", "ACC", "EVA"]
+SECONDARY_STATS = ["HP", "MP", "SP", "ATK", "DEF", "ACC", "EVA", "haste"]
 
 # Mapping of derived stat keys to weighted primary stats
 STAT_SCALING: Dict[str, Dict[str, float]] = {
@@ -56,6 +56,7 @@ STAT_SCALING: Dict[str, Dict[str, float]] = {
     # Tempo stats
     "cooldown_reduction": {"INT": 0.1, "WIS": 0.1},
     "initiative": {"perception": 0.3, "DEX": 0.2},
+    "haste": {"DEX": 0.3, "perception": 0.2},
     # Utility stats
     "stealth": {"DEX": 0.2, "perception": 0.2, "LUCK": 0.1},
     "detection": {"perception": 0.4, "WIS": 0.2},


### PR DESCRIPTION
## Summary
- add a haste stat definition in `TEMPO_STATS`
- include haste in secondary stat tracking and scaling
- allow `normalize_stat_key` to handle `haste`

## Testing
- `pytest -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684ced69e09c832ca7aad895a3944282