### PR TITLE
Show haste stat in sheets

### DIFF
--- a/utils/tests/test_stats_utils.py
+++ b/utils/tests/test_stats_utils.py
@@ -65,4 +65,8 @@ class TestDisplayScroll(EvenniaTest):
         self.assertIn("|ySated|n", sheet)
         self.assertIn("9", sheet)
 
+    def test_haste_stat_displayed(self):
+        sheet = get_display_scroll(self.char1)
+        self.assertIn("Haste", sheet)
+
 

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -2673,7 +2673,7 @@ These are the secondary stats that can be modified by gear creation commands.
 Evasion, Armor, Magic Resist, Dodge, Block Rate, Parry Rate, Status Resist,
 Critical Resist, Attack Power, Spell Power, Critical Chance, Critical Damage
 Bonus, Accuracy, Armor Penetration, Spell Penetration, Health Regen, Mana Regen,
-Stamina Regen, Lifesteal, Leech, Cooldown Reduction, Initiative, Stealth,
+Stamina Regen, Lifesteal, Leech, Cooldown Reduction, Initiative, Haste, Stealth,
 Detection, Threat, Crafting Bonus.
 """,
     },

--- a/world/system/stat_manager.py
+++ b/world/system/stat_manager.py
@@ -557,7 +557,8 @@ def display_stat_block(obj) -> str:
     lines.append(primaries)
 
     secondaries = "  ".join(
-        f"{key}: |w{get_secondary_stat(obj, key)}|n" for key in SECONDARY_STATS
+        f"{(key if key.isupper() else key.title())}: |w{get_secondary_stat(obj, key)}|n"
+        for key in SECONDARY_STATS
     )
     lines.append(secondaries)
 


### PR DESCRIPTION
## Summary
- include Haste display in stat blocks
- mention Haste in help for gear stat mods
- verify character sheets list the Haste stat

## Testing
- `pytest -q utils/tests/test_stats_utils.py::TestDisplayScroll::test_haste_stat_displayed -q` *(fails: ObjectDB DoesNotExist)*

------
https://chatgpt.com/codex/tasks/task_e_684ceedaa080832c948d3b0e7c7be883