### PR TITLE
Implement haste-based extra attacks

### DIFF
--- a/typeclasses/tests/test_combat_flow.py
+++ b/typeclasses/tests/test_combat_flow.py
@@ -262,3 +262,32 @@ def test_auto_attack_uses_combat_target():
         engine.process_round()
         assert defender.hp == 0
 
+
+def test_haste_grants_extra_attacks():
+    attacker = Dummy()
+    defender = Dummy()
+    attacker.location = defender.location
+    attacker.db.natural_weapon = {"damage": 1, "damage_type": DamageType.BLUDGEONING}
+    attacker.db.combat_target = defender
+
+    engine = CombatEngine([attacker, defender], round_time=0)
+
+    with patch("combat.combat_actions.utils.inherits_from", return_value=True), \
+         patch("world.system.state_manager.apply_regen"), \
+         patch("world.system.state_manager.get_effective_stat") as mock_get, \
+         patch("evennia.utils.delay"), \
+         patch("combat.combat_utils.roll_evade", return_value=False), \
+         patch("world.system.stat_manager.randint", return_value=1):
+
+        def getter(obj, stat):
+            if obj is attacker and stat == "haste":
+                return 55
+            return 0
+
+        mock_get.side_effect = getter
+
+        engine.start_round()
+        engine.process_round()
+
+    assert defender.hp == 8
+


### PR DESCRIPTION
## Summary
- add a haste constant to combat engine
- queue additional attack actions based on haste
- test extra attacks in combat flow

## Testing
- `pytest typeclasses/tests/test_combat_flow.py::test_haste_grants_extra_attacks -q`
- `pytest typeclasses/tests/test_combat_flow.py -q` *(fails: fixture 'self' not found, assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_684cf19c6b50832c875d7e13cfe36328