### PR TITLE
Update combat round manager

### DIFF
--- a/combat/round_manager.py
+++ b/combat/round_manager.py
@@ -1,53 +1,91 @@
+"""Combat round management across all active rooms."""
+
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import List
-
-from world.system import state_manager
+import time
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
 
 from evennia.utils import delay
+from evennia.utils.logger import log_trace
 
 from .combat_engine import CombatEngine
 
 
 @dataclass
 class CombatInstance:
-    """Wrapper for a combat engine tied to a room."""
+    """Container for a combat engine tied to a room."""
 
     script: object
     engine: CombatEngine
+    round_time: float = 2.0
+    round_number: int = 0
+    last_round_time: float = field(default_factory=time.time)
+    combat_ended: bool = False
+
+    def is_valid(self) -> bool:
+        """Return ``True`` if the underlying script is still active."""
+        return (
+            self.script
+            and getattr(self.script, "pk", None)
+            and bool(getattr(self.script, "active", False))
+            and not self.combat_ended
+        )
+
+    def has_active_fighters(self) -> bool:
+        """Return ``True`` if at least two participants can still fight."""
+        fighters = [p.actor for p in self.engine.participants]
+        active = [f for f in fighters if getattr(f, "hp", 0) > 0]
+        return len(active) >= 2
 
     def sync_participants(self) -> None:
-        """Synchronize engine participants with script fighters."""
+        """Keep engine participants aligned with ``script.fighters``."""
         current = {p.actor for p in self.engine.participants}
         fighters = set(self.script.fighters)
         for actor in fighters - current:
             self.engine.add_participant(actor)
         for actor in current - fighters:
             self.engine.remove_participant(actor)
+        # remove defeated combatants
+        for actor in list(fighters):
+            if getattr(actor, "hp", 0) <= 0:
+                self.engine.remove_participant(actor)
 
+    def process_round(self) -> None:
+        """Process a single combat round for this instance."""
+        if self.combat_ended:
+            return
+        self.round_number += 1
+        self.last_round_time = time.time()
+        try:
+            self.sync_participants()
+            if not self.has_active_fighters():
+                return
+            self.engine.process_round()
+            self.sync_participants()
+        except Exception as err:  # pragma: no cover - defensive
+            log_trace(f"Error in combat round processing: {err}")
+            self.end_combat(f"Combat ended due to error: {err}")
 
-def calculate_round_delay(instances: List[CombatInstance]) -> float:
-    """Return the delay between rounds based on participant haste."""
-    actors = [p.actor for inst in instances for p in inst.engine.participants]
-    if not actors:
-        return 2
-    total_haste = sum(
-        state_manager.get_effective_stat(actor, "haste") for actor in actors
-    )
-    avg_haste = total_haste / len(actors)
-    delay_val = 2 * (1 - avg_haste / 100)
-    return max(1.0, min(3.0, delay_val))
+    def end_combat(self, reason: str = "") -> None:
+        """Mark this instance as ended."""
+        if self.combat_ended:
+            return
+        self.combat_ended = True
+        if reason:
+            log_trace(f"Combat ended: {reason}")
 
 
 class CombatRoundManager:
-    """Manage active combat instances across rooms."""
+    """Manage all active combat instances."""
 
-    _instance: "CombatRoundManager | None" = None
+    _instance: Optional["CombatRoundManager"] = None
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.instances: List[CombatInstance] = []
         self.running = False
+        self.tick_delay = 2.0
+        self._next_tick_scheduled = False
 
     @classmethod
     def get(cls) -> "CombatRoundManager":
@@ -55,43 +93,121 @@ class CombatRoundManager:
             cls._instance = cls()
         return cls._instance
 
-    def add_instance(self, script) -> CombatInstance:
-        """Create or fetch an instance for ``script``."""
+    # ------------------------------------------------------------------
+    # instance management
+    # ------------------------------------------------------------------
+    def add_instance(
+        self, script, round_time: Optional[float] = None
+    ) -> CombatInstance:
+        """Create or fetch a combat instance for ``script``."""
         for inst in self.instances:
             if inst.script is script:
                 return inst
         engine = CombatEngine(script.fighters, round_time=None)
-        inst = CombatInstance(script, engine)
+        inst = CombatInstance(script, engine, round_time or self.tick_delay)
         self.instances.append(inst)
-        # process the first combat round immediately
-        inst.engine.process_round()
+        inst.process_round()
         if not self.running:
-            self.running = True
-            self._schedule_tick()
+            self.start_ticking()
         return inst
 
     def remove_instance(self, script) -> None:
+        """Remove ``script``'s instance from management."""
         self.instances = [i for i in self.instances if i.script is not script]
         if not self.instances:
-            self.running = False
+            self.stop_ticking()
 
-    def _schedule_tick(self) -> None:
-        """Schedule the next combat tick."""
-        delay(calculate_round_delay(self.instances), self.tick)
+    # ------------------------------------------------------------------
+    # ticking logic
+    # ------------------------------------------------------------------
+    def start_ticking(self) -> None:
+        if self.running:
+            return
+        self.running = True
+        self._schedule_next_tick()
 
-    def tick(self) -> None:
+    def stop_ticking(self) -> None:
+        self.running = False
+        self._next_tick_scheduled = False
+
+    def _schedule_next_tick(self) -> None:
+        if not self.running or self._next_tick_scheduled:
+            return
+        self._next_tick_scheduled = True
+        delay(self.tick_delay, self._tick)
+
+    def _tick(self) -> None:
+        self._next_tick_scheduled = False
+        if not self.running:
+            return
+        remove: List[object] = []
         for inst in list(self.instances):
-            script = inst.script
-            # ensure the script still exists before touching any of its fields
-            if not script or not getattr(script, "pk", None):
-                self.remove_instance(script)
-                continue
-            if not script.active:
-                self.remove_instance(script)
-                continue
-            inst.sync_participants()
-            inst.engine.process_round()
-        if self.instances:
-            self._schedule_tick()
-        else:
-            self.running = False
+            try:
+                if not inst.is_valid():
+                    remove.append(inst.script)
+                    continue
+                if not inst.has_active_fighters():
+                    inst.end_combat("No active fighters remaining")
+                    remove.append(inst.script)
+                    continue
+                inst.process_round()
+                if inst.combat_ended:
+                    remove.append(inst.script)
+            except Exception as err:  # pragma: no cover - defensive
+                log_trace(f"Error processing combat instance: {err}")
+                remove.append(inst.script)
+        for script in remove:
+            self.remove_instance(script)
+        if self.instances and self.running:
+            self._schedule_next_tick()
+
+    # ------------------------------------------------------------------
+    # debugging helpers
+    # ------------------------------------------------------------------
+    def get_combat_status(self) -> Dict:
+        status = {
+            "running": self.running,
+            "total_instances": len(self.instances),
+            "instances": [],
+        }
+        for inst in self.instances:
+            status["instances"].append(
+                {
+                    "script": str(inst.script),
+                    "round_number": inst.round_number,
+                    "fighters": len(inst.engine.participants),
+                    "valid": inst.is_valid(),
+                    "has_active_fighters": inst.has_active_fighters(),
+                    "ended": inst.combat_ended,
+                }
+            )
+        return status
+
+    def force_end_all_combat(self) -> None:
+        for inst in list(self.instances):
+            inst.end_combat("Force ended by admin")
+        self.instances.clear()
+        self.stop_ticking()
+
+    def debug_info(self) -> str:
+        status = self.get_combat_status()
+        lines = [
+            "Combat Manager Status:",
+            f"  Running: {status['running']}",
+            f"  Active Instances: {status['total_instances']}",
+            "",
+        ]
+        for i, inst in enumerate(status["instances"]):
+            lines.extend(
+                [
+                    f"  Instance {i + 1}:",
+                    f"    Script: {inst['script']}",
+                    f"    Round: {inst['round_number']}",
+                    f"    Fighters: {inst['fighters']}",
+                    f"    Valid: {inst['valid']}",
+                    f"    Active: {inst['has_active_fighters']}",
+                    f"    Ended: {inst['ended']}",
+                    "",
+                ]
+            )
+        return "\n".join(lines)

--- a/typeclasses/tests/test_round_manager.py
+++ b/typeclasses/tests/test_round_manager.py
@@ -17,18 +17,18 @@ class TestCombatRoundManager(EvenniaTest):
         self.manager.running = False
 
     def test_tick_schedules(self):
-        with patch("combat.round_manager.delay") as mock_delay, \
-             patch("combat.round_manager.calculate_round_delay", return_value=1.5) as mock_calc:
+        with (
+            patch("combat.round_manager.delay") as mock_delay,
+            patch.object(CombatEngine, "process_round") as mock_proc,
+        ):
             self.manager.add_instance(self.script)
-            mock_calc.assert_called()
-            mock_delay.assert_called_with(1.5, self.manager.tick)
+            mock_delay.assert_called_with(self.manager.tick_delay, self.manager._tick)
+            mock_proc.assert_called()
             mock_delay.reset_mock()
-            mock_calc.reset_mock()
-            with patch.object(CombatEngine, "process_round") as mock_proc:
-                self.manager.tick()
-                mock_proc.assert_called()
-            mock_calc.assert_called()
-            mock_delay.assert_called_with(1.5, self.manager.tick)
+            mock_proc.reset_mock()
+            self.manager._tick()
+            mock_proc.assert_called()
+            mock_delay.assert_called_with(self.manager.tick_delay, self.manager._tick)
 
     def test_initiative_order(self):
         order = []
@@ -38,12 +38,14 @@ class TestCombatRoundManager(EvenniaTest):
             order.extend([p.actor for p in self.queue])
 
         original = CombatEngine.start_round
-        with patch("combat.round_manager.delay"), \
-             patch("combat.combat_utils.calculate_initiative") as mock_calc, \
-             patch.object(CombatEngine, "start_round", new=start_round):
+        with (
+            patch("combat.round_manager.delay"),
+            patch("combat.combat_utils.calculate_initiative") as mock_calc,
+            patch.object(CombatEngine, "start_round", new=start_round),
+        ):
             mock_calc.side_effect = lambda c: 10 if c is self.char1 else 1
             self.manager.add_instance(self.script)
-            self.manager.tick()
+            self.manager._tick()
 
         self.assertEqual(order[0], self.char1)
         self.assertEqual(order[1], self.char2)
@@ -54,7 +56,7 @@ class TestCombatRoundManager(EvenniaTest):
             # deleting the script should not cause tick to fail
             self.script.delete()
             try:
-                self.manager.tick()
+                self.manager._tick()
             except Exception as err:  # pragma: no cover - fail fast if exception
                 self.fail(f"tick raised {err!r}")
 
@@ -63,5 +65,5 @@ class TestCombatRoundManager(EvenniaTest):
         with patch("combat.round_manager.delay"):
             inst = self.manager.add_instance(self.script)
             self.script.delete()
-            self.manager.tick()
+            self.manager._tick()
             self.assertNotIn(inst, self.manager.instances)


### PR DESCRIPTION
## Summary
- improve combat round manager to handle multiple instances and periodic ticks
- update combat round manager tests for new API

## Testing
- `black combat/round_manager.py typeclasses/tests/test_round_manager.py`
- `pytest -q` *(fails: 75 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_684cf1dfcfb8832c9740b65f8698dd8a