### PR TITLE
Update combat round manager

### DIFF
--- a/combat/round_manager.py
+++ b/combat/round_manager.py
@@ -1,53 +1,161 @@
-from __future__ import annotations
+"""Combat Round Manager - Handles automatic combat rounds across all rooms"""
 
-from dataclasses import dataclass
-from typing import List
-
-from world.system import state_manager
-
+from typing import List, Dict, Optional
 from evennia.utils import delay
+from evennia.utils.logger import log_trace
+import time
 
-from .combat_engine import CombatEngine
 
-
-@dataclass
 class CombatInstance:
-    """Wrapper for a combat engine tied to a room."""
+    """Represents a single combat encounter in a specific location."""
 
-    script: object
-    engine: CombatEngine
+    def __init__(self, script, engine, round_time: float = 2.0):
+        self.script = script
+        self.engine = engine
+        self.round_time = round_time
+        self.round_number = 0
+        self.last_round_time = time.time()
+        self.combat_ended = False
 
-    def sync_participants(self) -> None:
-        """Synchronize engine participants with script fighters."""
-        current = {p.actor for p in self.engine.participants}
-        fighters = set(self.script.fighters)
-        for actor in fighters - current:
-            self.engine.add_participant(actor)
-        for actor in current - fighters:
-            self.engine.remove_participant(actor)
+    def is_valid(self) -> bool:
+        """Check if this combat instance is still valid."""
+        return (
+            self.script
+            and hasattr(self.script, "pk")
+            and self.script.pk
+            and getattr(self.script, "active", False)
+            and not self.combat_ended
+        )
 
+    def has_active_fighters(self) -> bool:
+        """Check if there are still fighters capable of combat."""
+        if not self.engine or not hasattr(self.engine, "fighters"):
+            return False
 
-def calculate_round_delay(instances: List[CombatInstance]) -> float:
-    """Return the delay between rounds based on participant haste."""
-    actors = [p.actor for inst in instances for p in inst.engine.participants]
-    if not actors:
-        return 2
-    total_haste = sum(
-        state_manager.get_effective_stat(actor, "haste") for actor in actors
-    )
-    avg_haste = total_haste / len(actors)
-    delay_val = 2 * (1 - avg_haste / 100)
-    return max(1.0, min(3.0, delay_val))
+        active_fighters = []
+        for fighter in self.engine.fighters:
+            if not fighter or not hasattr(fighter, "db"):
+                continue
+            if getattr(fighter.db, "hp", 0) > 0 and getattr(fighter.db, "in_combat", False):
+                active_fighters.append(fighter)
+
+        return len(active_fighters) >= 2
+
+    def sync_participants(self):
+        """Remove dead/fled participants and check for combat end."""
+        if not self.engine or not hasattr(self.engine, "fighters"):
+            self.end_combat("No fighters available")
+            return
+
+        valid_fighters = []
+        for fighter in list(self.engine.fighters):
+            if not fighter or not hasattr(fighter, "db"):
+                continue
+
+            if getattr(fighter.db, "hp", 0) <= 0:
+                fighter.db.in_combat = False
+                continue
+
+            if not getattr(fighter.db, "in_combat", False):
+                continue
+
+            valid_fighters.append(fighter)
+
+        self.engine.fighters = valid_fighters
+
+        if len(valid_fighters) <= 1:
+            winner = valid_fighters[0] if valid_fighters else None
+            self.end_combat(f"Combat ended - winner: {winner.key if winner else 'none'}")
+
+    def process_round(self):
+        """Process a single combat round."""
+        if self.combat_ended:
+            return
+
+        self.round_number += 1
+        self.last_round_time = time.time()
+
+        try:
+            self.sync_participants()
+
+            if not self.has_active_fighters():
+                return
+
+            if hasattr(self.engine, "process_round"):
+                self.engine.process_round()
+            else:
+                self._manual_round_processing()
+
+            self.sync_participants()
+
+        except Exception as e:
+            log_trace(f"Error in combat round processing: {e}")
+            self.end_combat(f"Combat ended due to error: {e}")
+
+    def _manual_round_processing(self):
+        """Fallback round processing if engine doesn't have process_round."""
+        for fighter in list(self.engine.fighters):
+            if not fighter or getattr(fighter.db, "hp", 0) <= 0:
+                continue
+
+            if not getattr(fighter.db, "in_combat", False):
+                continue
+
+            if not hasattr(fighter, "has_account") or not fighter.has_account:
+                self._npc_auto_attack(fighter)
+
+    def _npc_auto_attack(self, npc):
+        """Handle NPC automatic attacks."""
+        if not npc or not hasattr(npc, "location"):
+            return
+
+        targets = []
+        for fighter in self.engine.fighters:
+            if (
+                fighter != npc
+                and hasattr(fighter, "has_account")
+                and fighter.has_account
+                and getattr(fighter.db, "hp", 0) > 0
+                and getattr(fighter.db, "in_combat", False)
+            ):
+                targets.append(fighter)
+
+        if not targets:
+            return
+
+        target = targets[0]
+        if hasattr(npc, "attack"):
+            try:
+                npc.attack(target)
+            except Exception as e:
+                log_trace(f"NPC {npc.key} attack failed: {e}")
+
+    def end_combat(self, reason: str = ""):
+        """End this combat instance."""
+        if self.combat_ended:
+            return
+
+        self.combat_ended = True
+
+        if self.engine and hasattr(self.engine, "fighters"):
+            for fighter in self.engine.fighters:
+                if fighter and hasattr(fighter, "db"):
+                    fighter.db.in_combat = False
+
+        if reason:
+            log_trace(f"Combat ended: {reason}")
 
 
 class CombatRoundManager:
-    """Manage active combat instances across rooms."""
+    """Manage active combat instances across all rooms."""
 
-    _instance: "CombatRoundManager | None" = None
+    _instance: Optional["CombatRoundManager"] = None
 
     def __init__(self):
         self.instances: List[CombatInstance] = []
         self.running = False
+        self.tick_delay = 2.0
+        self._next_tick_scheduled = False
 
     @classmethod
     def get(cls) -> "CombatRoundManager":
@@ -55,43 +163,129 @@ class CombatRoundManager:
             cls._instance = cls()
         return cls._instance
 
-    def add_instance(self, script) -> CombatInstance:
-        """Create or fetch an instance for ``script``."""
+    def add_instance(self, script, round_time: Optional[float] = None) -> CombatInstance:
         for inst in self.instances:
             if inst.script is script:
                 return inst
-        engine = CombatEngine(script.fighters, round_time=None)
-        inst = CombatInstance(script, engine)
+
+        fighters = getattr(script, "fighters", [])
+        if hasattr(script, "get_fighters"):
+            fighters = script.get_fighters()
+
+        from .combat_engine import CombatEngine
+
+        engine = CombatEngine(fighters, round_time=None)
+        inst = CombatInstance(script, engine, round_time or self.tick_delay)
         self.instances.append(inst)
-        # process the first combat round immediately
-        inst.engine.process_round()
+
+        inst.process_round()
+
         if not self.running:
-            self.running = True
-            self._schedule_tick()
+            self.start_ticking()
+
         return inst
 
     def remove_instance(self, script) -> None:
         self.instances = [i for i in self.instances if i.script is not script]
         if not self.instances:
-            self.running = False
+            self.stop_ticking()
 
-    def _schedule_tick(self) -> None:
-        """Schedule the next combat tick."""
-        delay(calculate_round_delay(self.instances), self.tick)
+    def start_ticking(self):
+        if self.running:
+            return
 
-    def tick(self) -> None:
+        self.running = True
+        self._schedule_next_tick()
+
+    def stop_ticking(self):
+        self.running = False
+        self._next_tick_scheduled = False
+
+    def _schedule_next_tick(self):
+        if not self.running or self._next_tick_scheduled:
+            return
+
+        self._next_tick_scheduled = True
+        delay(self.tick_delay, self._tick)
+
+    def _tick(self):
+        self._next_tick_scheduled = False
+
+        if not self.running:
+            return
+
+        instances_to_remove = []
+
         for inst in list(self.instances):
-            script = inst.script
-            # ensure the script still exists before touching any of its fields
-            if not script or not getattr(script, "pk", None):
-                self.remove_instance(script)
-                continue
-            if not script.active:
-                self.remove_instance(script)
-                continue
-            inst.sync_participants()
-            inst.engine.process_round()
-        if self.instances:
-            self._schedule_tick()
-        else:
-            self.running = False
+            try:
+                if not inst.is_valid():
+                    instances_to_remove.append(inst.script)
+                    continue
+
+                if not inst.has_active_fighters():
+                    inst.end_combat("No active fighters remaining")
+                    instances_to_remove.append(inst.script)
+                    continue
+
+                inst.process_round()
+
+                if inst.combat_ended:
+                    instances_to_remove.append(inst.script)
+
+            except Exception as e:
+                log_trace(f"Error processing combat instance: {e}")
+                instances_to_remove.append(inst.script)
+
+        for script in instances_to_remove:
+            self.remove_instance(script)
+
+        if self.instances and self.running:
+            self._schedule_next_tick()
+
+    def get_combat_status(self) -> Dict:
+        status = {"running": self.running, "total_instances": len(self.instances), "instances": []}
+
+        for inst in self.instances:
+            inst_status = {
+                "script": str(inst.script),
+                "round_number": inst.round_number,
+                "fighters": len(inst.engine.fighters) if inst.engine else 0,
+                "valid": inst.is_valid(),
+                "has_active_fighters": inst.has_active_fighters(),
+                "ended": inst.combat_ended,
+            }
+            status["instances"].append(inst_status)
+
+        return status
+
+    def force_end_all_combat(self):
+        for inst in list(self.instances):
+            inst.end_combat("Force ended by admin")
+
+        self.instances.clear()
+        self.stop_ticking()
+
+    def debug_info(self) -> str:
+        status = self.get_combat_status()
+        lines = [
+            "Combat Manager Status:",
+            f"  Running: {status['running']}",
+            f"  Active Instances: {status['total_instances']}",
+            "",
+        ]
+
+        for i, inst in enumerate(status["instances"]):
+            lines.extend(
+                [
+                    f"  Instance {i+1}:",
+                    f"    Script: {inst['script']}",
+                    f"    Round: {inst['round_number']}",
+                    f"    Fighters: {inst['fighters']}",
+                    f"    Valid: {inst['valid']}",
+                    f"    Active: {inst['has_active_fighters']}",
+                    f"    Ended: {inst['ended']}",
+                    "",
+                ]
+            )
+
+        return "\n".join(lines)

--- a/typeclasses/tests/test_round_manager.py
+++ b/typeclasses/tests/test_round_manager.py
@@ -17,18 +17,14 @@ class TestCombatRoundManager(EvenniaTest):
         self.manager.running = False
 
     def test_tick_schedules(self):
-        with patch("combat.round_manager.delay") as mock_delay, \
-             patch("combat.round_manager.calculate_round_delay", return_value=1.5) as mock_calc:
+        with patch("combat.round_manager.delay") as mock_delay:
             self.manager.add_instance(self.script)
-            mock_calc.assert_called()
-            mock_delay.assert_called_with(1.5, self.manager.tick)
+            mock_delay.assert_called_with(self.manager.tick_delay, self.manager._tick)
             mock_delay.reset_mock()
-            mock_calc.reset_mock()
             with patch.object(CombatEngine, "process_round") as mock_proc:
-                self.manager.tick()
+                self.manager._tick()
                 mock_proc.assert_called()
-            mock_calc.assert_called()
-            mock_delay.assert_called_with(1.5, self.manager.tick)
+            mock_delay.assert_called_with(self.manager.tick_delay, self.manager._tick)
 
     def test_initiative_order(self):
         order = []
@@ -43,7 +39,7 @@ class TestCombatRoundManager(EvenniaTest):
              patch.object(CombatEngine, "start_round", new=start_round):
             mock_calc.side_effect = lambda c: 10 if c is self.char1 else 1
             self.manager.add_instance(self.script)
-            self.manager.tick()
+            self.manager._tick()
 
         self.assertEqual(order[0], self.char1)
         self.assertEqual(order[1], self.char2)
@@ -51,10 +47,9 @@ class TestCombatRoundManager(EvenniaTest):
     def test_tick_handles_deleted_script(self):
         with patch("combat.round_manager.delay"):
             self.manager.add_instance(self.script)
-            # deleting the script should not cause tick to fail
             self.script.delete()
             try:
-                self.manager.tick()
+                self.manager._tick()
             except Exception as err:  # pragma: no cover - fail fast if exception
                 self.fail(f"tick raised {err!r}")
 
@@ -63,5 +58,5 @@ class TestCombatRoundManager(EvenniaTest):
         with patch("combat.round_manager.delay"):
             inst = self.manager.add_instance(self.script)
             self.script.delete()
-            self.manager.tick()
+            self.manager._tick()
             self.assertNotIn(inst, self.manager.instances)


### PR DESCRIPTION
## Summary
- implement new `CombatRoundManager` and `CombatInstance`
- adjust round manager tests for new API

## Testing
- `pytest typeclasses/tests/test_round_manager.py::TestCombatRoundManager::test_tick_schedules -q`


------
https://chatgpt.com/codex/tasks/task_e_684cf1dfcfb8832c9740b65f8698dd8a