### PR TITLE
Fix HP checks in combat round manager

### DIFF
--- a/combat/round_manager.py
+++ b/combat/round_manager.py
@@ -8,6 +8,7 @@ from typing import Dict, List, Optional
 
 from evennia.utils import delay
 from evennia.utils.logger import log_trace
+from .combat_engine import _current_hp
 
 
 @dataclass
@@ -48,7 +49,7 @@ class CombatInstance:
         for fighter in fighters:
             if not fighter:
                 continue
-            hp = getattr(fighter, "hp", 0)
+            hp = _current_hp(fighter)
             if hp <= 0:
                 continue
             if getattr(fighter, "in_combat", False):
@@ -79,7 +80,7 @@ class CombatInstance:
             
             # Remove defeated combatants
             for actor in list(fighters):
-                if getattr(actor, "hp", 0) <= 0:
+                if _current_hp(actor) <= 0:
                     if hasattr(actor, "db"):
                         actor.db.in_combat = False
                     if hasattr(self.engine, "remove_participant"):
@@ -92,7 +93,7 @@ class CombatInstance:
                 if not fighter:
                     continue
 
-                if getattr(fighter, "hp", 0) <= 0:
+                if _current_hp(fighter) <= 0:
                     fighter.db.in_combat = False
                     continue
 
@@ -139,7 +140,7 @@ class CombatInstance:
         fighters = getattr(self.engine, "fighters", [])
         
         for fighter in list(fighters):
-            if not fighter or getattr(fighter, "hp", 0) <= 0:
+            if not fighter or _current_hp(fighter) <= 0:
                 continue
 
             if not getattr(fighter, "in_combat", False):
@@ -162,7 +163,7 @@ class CombatInstance:
                 fighter != npc
                 and hasattr(fighter, "has_account")
                 and fighter.has_account
-                and getattr(fighter, "hp", 0) > 0
+                and _current_hp(fighter) > 0
                 and getattr(fighter, "in_combat", False)
             ):
                 targets.append(fighter)


### PR DESCRIPTION
## Summary
- use `_current_hp` helper in `CombatRoundManager`
- ensure participants with trait-based health are recognized

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684cfe19c4a4832ca9a35aa675f86885