### PR TITLE
Fix leaving combat state

### DIFF
--- a/combat/combat_engine.py
+++ b/combat/combat_engine.py
@@ -299,8 +299,13 @@ class CombatEngine:
         """
         self.participants = [p for p in self.participants if p.actor is not actor]
         self.queue = [p for p in self.queue if p.actor is not actor]
+
+        if hasattr(actor, "db"):
+            actor.db.in_combat = False
+
         if hasattr(actor, "on_exit_combat"):
             actor.on_exit_combat()
+
         if hasattr(actor, "ndb") and hasattr(actor.ndb, "combat_engine"):
             del actor.ndb.combat_engine
 

--- a/typeclasses/tests/test_combat_engine.py
+++ b/typeclasses/tests/test_combat_engine.py
@@ -246,6 +246,20 @@ class TestCombatEngine(unittest.TestCase):
 
         self.assertNotIn(b, [p.actor for p in engine.participants])
 
+    def test_remove_participant_marks_not_in_combat(self):
+        a = Dummy()
+        b = Dummy()
+
+        engine = CombatEngine([a, b], round_time=0)
+
+        a.on_exit_combat.reset_mock()
+
+        engine.remove_participant(a)
+
+        self.assertFalse(a.db.in_combat)
+        a.on_exit_combat.assert_called()
+        self.assertNotIn(a, [p.actor for p in engine.participants])
+
 
 class TestCombatDeath(EvenniaTest):
     def test_npc_death_creates_corpse_and_awards_xp(self):


### PR DESCRIPTION
## Summary
- ensure combat state reset when participants are removed
- test that removed participants no longer marked as in combat

## Testing
- `pytest typeclasses/tests/test_combat_engine.py::TestCombatEngine::test_remove_participant_marks_not_in_combat -q`
- `pytest -q` *(fails: 114 failed, 1 passed)*

------
https://chatgpt.com/codex/tasks/task_e_684d04a05f48832c8f364c3830b4e6cc