### PR TITLE
Fix active fighter DB check

### DIFF
--- a/combat/round_manager.py
+++ b/combat/round_manager.py
@@ -52,7 +52,9 @@ class CombatInstance:
             hp = _current_hp(fighter)
             if hp <= 0:
                 continue
-            if getattr(fighter, "in_combat", False):
+            # check combat status using the persistent db attribute
+            in_combat = getattr(fighter.db, "in_combat", False)
+            if in_combat:
                 active_fighters.append(fighter)
 
         return len(active_fighters) >= 2


### PR DESCRIPTION
## Summary
- check `in_combat` flag via `fighter.db` in `CombatInstance.has_active_fighters`

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684d0628d66c832cb521820d6c5a4699