### PR TITLE
Fix aggro tracking when targets deleted

### DIFF
--- a/combat/combat_engine.py
+++ b/combat/combat_engine.py
@@ -378,6 +378,8 @@ class CombatEngine:
         """
         if not target or target is attacker:
             return
+        if hasattr(target, "pk") and target.pk is None:
+            return
         from world.system import state_manager
 
         data = self.aggro.setdefault(target, {})

--- a/typeclasses/tests/test_combat_engine.py
+++ b/typeclasses/tests/test_combat_engine.py
@@ -96,6 +96,15 @@ class TestCombatEngine(unittest.TestCase):
             engine.process_round()
             self.assertIn(a, engine.aggro.get(b, {}))
 
+    def test_track_aggro_skips_missing_pk(self):
+        a = Dummy()
+        b = Dummy()
+        b.pk = None
+        engine = CombatEngine([a, b], round_time=0)
+        with patch('world.system.state_manager.get_effective_stat', return_value=0):
+            engine.track_aggro(b, a)
+        self.assertNotIn(b, engine.aggro)
+
     def test_solo_gain_awards_exp(self):
         attacker = Dummy()
         attacker.db.experience = 0


### PR DESCRIPTION
## Summary
- avoid hashing deleted DB objects in `track_aggro`
- add regression test for unsaved targets

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684d0b40c1a0832ca5a647b850075e14