### PR TITLE
Fix unsaved model aggro issues

### DIFF
--- a/combat/combat_engine.py
+++ b/combat/combat_engine.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import List, Iterable, Dict
+import logging
 import random
 from evennia.utils import delay
 from world.system import state_manager
@@ -19,6 +20,8 @@ from .combat_utils import (
     format_combat_message,
     calculate_initiative,
 )
+
+logger = logging.getLogger(__name__)
 from world.combat import get_health_description
 
 
@@ -276,7 +279,7 @@ class CombatEngine:
         Appends a :class:`CombatParticipant` to :attr:`participants` and
         calls ``actor.on_enter_combat`` if present.
         """
-        if hasattr(actor, "db"):
+        if hasattr(actor, "db") and getattr(actor, "pk", None) is not None:
             actor.db.in_combat = True
         self.participants.append(CombatParticipant(actor=actor))
         if hasattr(actor, "ndb"):
@@ -300,7 +303,7 @@ class CombatEngine:
         self.participants = [p for p in self.participants if p.actor is not actor]
         self.queue = [p for p in self.queue if p.actor is not actor]
 
-        if hasattr(actor, "db"):
+        if hasattr(actor, "db") and getattr(actor, "pk", None) is not None:
             actor.db.in_combat = False
 
         if hasattr(actor, "on_exit_combat"):
@@ -376,7 +379,13 @@ class CombatEngine:
         ------------
         Updates an internal aggro table used when awarding experience.
         """
-        if not target or target is attacker:
+        if (
+            not target
+            or target is attacker
+            or getattr(target, "pk", None) is None
+            or getattr(attacker, "pk", None) is None
+        ):
+            logger.debug("Skipping aggro tracking for unsaved object(s).")
             return
         from world.system import state_manager
 
@@ -452,6 +461,12 @@ class CombatEngine:
         int
             The actual damage dealt after hooks are processed.
         """
+
+        if target is None:
+            return 0
+
+        if getattr(target, "pk", None) is None:
+            logger.debug("Applying damage to unsaved object %s", target)
 
         if hasattr(target, "at_damage"):
             before = getattr(getattr(target, "traits", None), "health", None)

--- a/combat/round_manager.py
+++ b/combat/round_manager.py
@@ -53,7 +53,9 @@ class CombatInstance:
             if hp <= 0:
                 continue
             # check combat status using the persistent db attribute
-            in_combat = getattr(fighter.db, "in_combat", False)
+            in_combat = False
+            if getattr(fighter, "pk", None) is not None:
+                in_combat = getattr(fighter.db, "in_combat", False)
             if in_combat:
                 active_fighters.append(fighter)
 
@@ -83,7 +85,10 @@ class CombatInstance:
             # Remove defeated combatants
             for actor in list(fighters):
                 if _current_hp(actor) <= 0:
-                    if hasattr(actor, "db"):
+                    if (
+                        hasattr(actor, "db")
+                        and getattr(actor, "pk", None) is not None
+                    ):
                         actor.db.in_combat = False
                     if hasattr(self.engine, "remove_participant"):
                         self.engine.remove_participant(actor)
@@ -96,7 +101,8 @@ class CombatInstance:
                     continue
 
                 if _current_hp(fighter) <= 0:
-                    fighter.db.in_combat = False
+                    if getattr(fighter, "pk", None) is not None:
+                        fighter.db.in_combat = False
                     continue
 
                 if not getattr(fighter, "in_combat", False):
@@ -196,7 +202,7 @@ class CombatInstance:
                 fighters = self.engine.fighters
 
             for fighter in fighters:
-                if fighter and hasattr(fighter, "db"):
+                if fighter and hasattr(fighter, "db") and getattr(fighter, "pk", None) is not None:
                     fighter.db.in_combat = False
 
         if reason:


### PR DESCRIPTION
## Summary
- avoid setting in_combat DB attribute on unsaved objects
- skip aggro tracking for unsaved combatants
- guard damage application for unsaved objects
- update round manager cleanup checks

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684d0dcf1548832cbb766f7e2922dcb0