### PR TITLE
Fix combat join syncing

### DIFF
--- a/combat/round_manager.py
+++ b/combat/round_manager.py
@@ -230,6 +230,8 @@ class CombatRoundManager:
         # Check if instance already exists
         for inst in self.instances:
             if inst.script is script:
+                # ensure any new fighters are added immediately
+                inst.sync_participants()
                 return inst
 
         # Get fighters from script


### PR DESCRIPTION
## Summary
- ensure combat round manager syncs new fighters when retrieving an existing combat instance
- test that joining combat queues an action immediately

## Testing
- `pytest -q` *(fails: OperationalError - no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684d600b2134832c92b7d6d143ab58bc