### PR TITLE
Fix idle add_instance behavior

### DIFF
--- a/combat/round_manager.py
+++ b/combat/round_manager.py
@@ -232,6 +232,11 @@ class CombatRoundManager:
             if inst.script is script:
                 # ensure any new fighters are added immediately
                 inst.sync_participants()
+                # If manager is idle, kick off processing right away so queued
+                # actions run without waiting for the next tick
+                if not self.running:
+                    inst.process_round()
+                    self.start_ticking()
                 return inst
 
         # Get fighters from script


### PR DESCRIPTION
## Summary
- trigger a combat round when adding an existing instance to a stopped CombatRoundManager
- test that adding an existing instance while idle immediately processes a round

## Testing
- `pytest typeclasses/tests/test_round_manager.py::TestCombatRoundManager::test_add_existing_triggers_round_when_idle -q` *(fails: evennia.objects.models.ObjectDB.DoesNotExist: settings.DEFAULT_HOME)*

------
https://chatgpt.com/codex/tasks/task_e_684d68bb28fc832cbfab7399c66bd706