### PR TITLE
Add ROM MUD combat loop docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,10 @@ script if one is not already present. Calling
 `CombatRoundManager.get().add_instance(script)` registers that script with the
 manager and begins the automatic round loop.
 
+For a deeper look at how this round system mirrors the classic ROM MUD
+functions like `violence_update` and `multi_hit`, see the documentation in
+[`docs/combat_loop_mapping.md`](docs/combat_loop_mapping.md).
+
 
 ## Running the Tests
 

--- a/docs/combat_loop_mapping.md
+++ b/docs/combat_loop_mapping.md
@@ -1,0 +1,37 @@
+# Combat Loop Mapping
+
+This project models its turn-based fighting system after the traditional combat loops used in **ROM MUD**. The following sections outline how the core components correspond to classic functions like `violence_update` and `multi_hit`.
+
+## CombatRoundManager
+
+File: `combat/round_manager.py`
+
+- Maintains a registry of all active `CombatScript` instances.
+- Ticks every few seconds to drive combat across rooms, much like ROM's `violence_update` that iterates over every character currently fighting.
+- Each tick triggers the associated `CombatEngine` to process a new round.
+
+## CombatScript
+
+File: `typeclasses/scripts.py`
+
+- Attached to a room when combat begins and keeps track of the two opposing teams of fighters.
+- Starts or stops the room's `CombatEngine` and exposes helper methods for adding and removing combatants.
+- Serves the role of ROM's per-room fight list, organizing combatants so that `CombatRoundManager` can handle them as a group.
+
+## CombatEngine
+
+File: `combat/combat_engine.py`
+
+- Executes the actual round logic: rolling initiative, queueing actions and resolving them in order.
+- The `process_round` method performs multiple attacks when haste allows, providing functionality similar to ROM's `multi_hit` routine.
+- Handles defeat, regeneration and experience rewards after each round.
+
+## NPC AI
+
+File: `world/npc_handlers/mob_ai.py`
+
+- Contains `process_mob_ai`, which evaluates behaviours for NPCs each tick.
+- When an NPC is in combat, it chooses actions through the combat engine, mirroring how ROM's AI hooks into `violence_update` to decide attacks.
+
+Together these components recreate the familiar combat loop of a ROM MUD within Evennia while remaining fully scriptable.
+


### PR DESCRIPTION
## Summary
- document mapping from Evennia combat components to ROM MUD loops
- link new doc from README

## Testing
- `pytest -q` *(fails: django.db errors)*

------
https://chatgpt.com/codex/tasks/task_e_684d6c77a478832c990b34493e0c7597