### PR TITLE
Fix attack cancel flee deletion

### DIFF
--- a/commands/combat.py
+++ b/commands/combat.py
@@ -77,7 +77,8 @@ class CmdAttack(Command):
             return
 
         # if we were trying to flee, cancel that
-        del self.caller.db.fleeing
+        if "fleeing" in self.caller.db:
+            del self.caller.db.fleeing
 
         # it's all good! let's get started!
         combat_script = get_or_create_combat_script(location)

--- a/typeclasses/tests/test_attack_command.py
+++ b/typeclasses/tests/test_attack_command.py
@@ -32,6 +32,19 @@ class TestAttackCommand(EvenniaTest):
         )
         self.assertTrue(queued)
 
+    def test_attack_when_not_fleeing(self):
+        """Attacking without a fleeing flag should not raise errors."""
+        mob = create.create_object(BaseNPC, key="mob", location=self.room1)
+        # ensure the fleeing attribute is not present
+        if self.char1.attributes.has("fleeing"):
+            self.char1.attributes.remove("fleeing")
+
+        # should not raise when no fleeing attribute exists
+        self.char1.execute_cmd("attack mob")
+
+        # fleeing flag should still be absent after attacking
+        self.assertFalse(self.char1.attributes.has("fleeing"))
+
     def test_joining_combat_queues_immediately(self):
         """Joining an ongoing fight should allow immediate actions."""
         from typeclasses.characters import PlayerCharacter


### PR DESCRIPTION
## Summary
- safely remove fleeing attribute when attacking
- add test for attacking without having initiated flee

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684d73d46f54832cacbbc21149092780