### PR TITLE
Fix fleeing attribute check in combat

### DIFF
--- a/commands/combat.py
+++ b/commands/combat.py
@@ -77,7 +77,7 @@ class CmdAttack(Command):
             return
 
         # if we were trying to flee, cancel that
-        if "fleeing" in self.caller.db:
+        if self.caller.attributes.has("fleeing"):
             del self.caller.db.fleeing
 
         # it's all good! let's get started!


### PR DESCRIPTION
## Summary
- fix attack command's fleeing flag check to avoid `TypeError`

## Testing
- `pytest typeclasses/tests/test_attack_command.py::TestAttackCommand::test_attack_when_not_fleeing -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684d77c1ba94832c90284dfa60deff2d