### PR TITLE
Handle AI script activation via actflags

### DIFF
--- a/typeclasses/npcs/__init__.py
+++ b/typeclasses/npcs/__init__.py
@@ -8,7 +8,9 @@ class BaseNPC(NPC):
 
     def at_object_creation(self):
         super().at_object_creation()
-        if self.db.ai_type:
+        ai_flags = {"aggressive", "scavenger", "assist", "call_for_help"}
+        flags = set(self.db.actflags or [])
+        if self.db.ai_type or ai_flags.intersection(flags):
             from scripts.npc_ai_script import NPCAIScript
 
             if not self.scripts.get("npc_ai"):

--- a/typeclasses/tests/test_mob_ai.py
+++ b/typeclasses/tests/test_mob_ai.py
@@ -47,6 +47,20 @@ class TestMobAIBehaviors(EvenniaTest):
             mob_ai.process_mob_ai(npc)
             mock.assert_called_with(self.char1)
 
+    def test_aggressive_flag_spawns_script_and_attacks(self):
+        from typeclasses.npcs import BaseNPC
+
+        npc = create.create_object(BaseNPC, key="flag", location=self.room1)
+        npc.db.actflags = ["aggressive"]
+        npc.at_object_creation()
+
+        script = npc.scripts.get("npc_ai")[0]
+        self.assertTrue(script)
+
+        with patch.object(npc, "enter_combat") as mock:
+            script.at_repeat()
+            mock.assert_called_with(self.char1)
+
     def test_memory_attack(self):
         from typeclasses.npcs import BaseNPC
 


### PR DESCRIPTION
## Summary
- trigger NPCAIScript when NPC is aggressive or has related AI flags
- test that aggressive actflag spawns AI script and causes combat

## Testing
- `pytest -q typeclasses/tests/test_mob_ai.py::TestMobAIBehaviors::test_aggressive_flag_spawns_script_and_attacks -q`
- `pytest -q` *(fails: OperationalError: no such table)*

------
https://chatgpt.com/codex/tasks/task_e_684d7d3af034832c8143801e97ea8470