### PR TITLE
Refactor combat manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,7 +424,8 @@ active combat instances per room. It ticks every **2 seconds** by default (see
 `tick_delay` at line 214 of `combat/round_manager.py`). Rooms are registered
 with the manager when combat starts via
 `CombatRoundManager.get().add_instance(room)`, which returns a `CombatInstance`
-object and kicks off the automatic round loop.
+object and kicks off the automatic round loop. Instances are stored in
+`manager.instances_by_room` using the room's id as the key for quick lookups.
 
 For a deeper look at how this round system mirrors the classic ROM MUD
 functions like `violence_update` and `multi_hit`, see the documentation in

--- a/commands/admin.py
+++ b/commands/admin.py
@@ -441,7 +441,7 @@ class CmdPeace(Command):
 
         from combat.round_manager import CombatRoundManager
         manager = CombatRoundManager.get()
-        instance = manager.instances_by_room.get(str(location.id))
+        instance = manager.instances_by_room.get(location.id)
         if not instance:
             caller.msg("There is no fighting here.")
             return

--- a/commands/combat.py
+++ b/commands/combat.py
@@ -235,7 +235,7 @@ class CmdFlee(Command):
 
         from combat.round_manager import CombatRoundManager
         manager = CombatRoundManager.get()
-        if instance := manager.instances_by_room.get(str(caller.location.id)):
+        if instance := manager.instances_by_room.get(caller.location.id):
             if not instance.remove_combatant(self.caller):
                 self.msg("You cannot leave combat.")
 

--- a/docs/combat_loop_mapping.md
+++ b/docs/combat_loop_mapping.md
@@ -6,7 +6,8 @@ This project models its turn-based fighting system after the traditional combat 
 
 File: `combat/round_manager.py`
 
-- Maintains a registry of all active combat instances, keyed by room.
+- Maintains a registry of all active combat instances. The
+  `instances_by_room` dictionary maps each room's id to its `CombatInstance`.
 - Ticks every few seconds to drive combat across rooms, much like ROM's `violence_update` that iterates over every character currently fighting.
 - Each tick triggers the associated `CombatEngine` to process a new round.
 

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -426,7 +426,7 @@ class Character(ObjectParent, ClothedCharacter):
             if self.in_combat:
                 from combat.round_manager import CombatRoundManager
                 manager = CombatRoundManager.get()
-                inst = manager.instances_by_room.get(str(self.location.id))
+                inst = manager.instances_by_room.get(self.location.id)
                 if inst and not inst.remove_combatant(self):
                     logger.log_err(
                         f"Could not remove defeated character from combat! Character: {self.name} (#{self.id}) Location: {self.location.name} (#{self.location.id})"
@@ -901,7 +901,7 @@ class PlayerCharacter(Character):
         if self.in_combat:
             from combat.round_manager import CombatRoundManager
             manager = CombatRoundManager.get()
-            inst = manager.instances_by_room.get(str(self.location.id))
+            inst = manager.instances_by_room.get(self.location.id)
             if inst:
                 inst.remove_combatant(self)
         # avoid spawning multiple corpses for repeated calls
@@ -1105,7 +1105,7 @@ class NPC(Character):
         if self.in_combat:
             from combat.round_manager import CombatRoundManager
             manager = CombatRoundManager.get()
-            inst = manager.instances_by_room.get(str(self.location.id))
+            inst = manager.instances_by_room.get(self.location.id)
             if inst:
                 inst.remove_combatant(self)
 
@@ -1231,7 +1231,7 @@ class NPC(Character):
             self.db.fleeing = True
             from combat.round_manager import CombatRoundManager
             manager = CombatRoundManager.get()
-            inst = manager.instances_by_room.get(str(self.location.id))
+            inst = manager.instances_by_room.get(self.location.id)
             if inst and not inst.remove_combatant(self):
                 return dmg
             # there's a 50/50 chance the object will escape forever

--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -67,9 +67,10 @@ class RoomParent(ObjectParent):
         Apply extra hooks when an object enters this room, so things (e.g. NPCs) can react.
         """
         super().at_object_leave(mover, destination, **kwargs)
-        if combat := self.scripts.get("combat"):
-            combat = combat[0]
-            combat.remove_combatant(mover)
+        from combat.round_manager import CombatRoundManager
+        manager = CombatRoundManager.get()
+        if instance := manager.instances_by_room.get(self.id):
+            instance.remove_combatant(mover)
         # only react if the arriving object is a character
         if "character" in mover._content_types:
             for obj in self.contents_get(content_type="character"):

--- a/typeclasses/tests/test_admin_commands.py
+++ b/typeclasses/tests/test_admin_commands.py
@@ -503,7 +503,7 @@ class TestAdminCommands(EvenniaTest):
         self.char1.execute_cmd(f"attack {self.char2.key}")
         from combat.round_manager import CombatRoundManager
         manager = CombatRoundManager.get()
-        instance = manager.instances_by_room.get(str(self.room1.id))
+        instance = manager.instances_by_room.get(self.room1.id)
 
         # defeat the opponent so combat ends
         self.char2.tags.add("dead", category="status")


### PR DESCRIPTION
## Summary
- store combat instances by room id instead of strings
- ensure combat removal uses the manager
- update flee and peace commands for new lookup
- document the instances_by_room dictionary

## Testing
- `pytest -q` *(fails: django.db errors)*

------
https://chatgpt.com/codex/tasks/task_e_684d8a88c660832c87cb0a03d5d6768a