### PR TITLE
Refactor combat engine round handling

### DIFF
--- a/combat/combat_engine.py
+++ b/combat/combat_engine.py
@@ -493,18 +493,13 @@ class CombatEngine:
             ):
                 self.remove_participant(actor)
 
-    def process_round(self) -> None:
-        """Execute all queued actions for the current round.
+    # -------------------------------------------------------------
+    # Round processing helpers
+    # -------------------------------------------------------------
 
-        Side Effects
-        ------------
-        Applies damage, sends combat messages, awards experience and
-        schedules the next round using :func:`evennia.utils.delay`.
-        """
-        self.start_round()
-        self.round_output = []
-        damage_totals: Dict[object, int] = {}
-        actions: list[tuple[int, int, CombatParticipant, Action]] = []
+    def _gather_actions(self) -> list[tuple[int, int, int, CombatParticipant, Action]]:
+        """Collect and sort all actions for this round."""
+        actions: list[tuple[int, int, int, CombatParticipant, Action]] = []
         for participant in list(self.queue):
             actor = participant.actor
             hp = _current_hp(actor)
@@ -520,7 +515,6 @@ class CombatEngine:
             elif target:
                 queued = [AttackAction(actor, target)]
             else:
-                # fallback: attack any valid enemy in the room
                 enemies = [
                     p.actor
                     for p in self.participants
@@ -533,10 +527,8 @@ class CombatEngine:
                     if hasattr(actor, "msg"):
                         actor.msg("You hesitate, unsure of what to do.")
 
-            # add extra attacks based on haste
             haste = state_manager.get_effective_stat(actor, "haste")
             extra = max(0, haste // HASTE_PER_EXTRA_ATTACK)
-            # limit total attacks to prevent runaway bursts
             extra = min(extra, MAX_ATTACKS_PER_ROUND - 1)
             if extra and queued:
                 extras: list[Action] = []
@@ -545,6 +537,7 @@ class CombatEngine:
                         for _ in range(extra):
                             extras.append(AttackAction(actor, action.target))
                 queued.extend(extras)
+
             for idx, action in enumerate(queued):
                 actions.append(
                     (
@@ -557,48 +550,52 @@ class CombatEngine:
                 )
 
         actions.sort(key=lambda t: (t[0], t[1], t[2]), reverse=True)
+        return actions
 
-        for _, _, _, participant, action in actions:
-            actor = participant.actor
-            valid, err = action.validate()
-            if not valid:
-                if hasattr(actor, "msg") and err:
-                    actor.msg(err)
-                if action in participant.next_action:
-                    participant.next_action.remove(action)
-                continue
-            result = action.resolve()
-
+    def _execute_action(
+        self, participant: CombatParticipant, action: Action, damage_totals: Dict[object, int]
+    ) -> None:
+        """Validate and resolve ``action`` for ``participant``."""
+        actor = participant.actor
+        valid, err = action.validate()
+        if not valid:
+            if hasattr(actor, "msg") and err:
+                actor.msg(err)
             if action in participant.next_action:
                 participant.next_action.remove(action)
+            return
 
-            damage_done = 0
-            if result.damage and result.target:
-                dt = result.damage_type
-                if isinstance(dt, str):
-                    try:
-                        dt = DamageType(dt)
-                    except ValueError:
-                        dt = None
-                damage_done = self.apply_damage(actor, result.target, result.damage, dt)
-                if not result.message:
-                    self.dam_message(actor, result.target, damage_done)
-                damage_totals[actor] = damage_totals.get(actor, 0) + damage_done
+        result = action.resolve()
 
-            if result.target:
-                cond = get_health_description(result.target)
-                self.round_output.append(f"The {result.target.key} {cond}")
+        if action in participant.next_action:
+            participant.next_action.remove(action)
 
-            if actor.location and result.message:
-                actor.location.msg_contents(result.message)
-            # track threat from this action before checking defeat so the
-            # killer is properly credited for experience
-            self.track_aggro(result.target, actor)
-            target_hp = _current_hp(result.target)
-            if target_hp <= 0:
-                self.handle_defeat(result.target, actor)
-        self.cleanup_environment()
+        damage_done = 0
+        if result.damage and result.target:
+            dt = result.damage_type
+            if isinstance(dt, str):
+                try:
+                    dt = DamageType(dt)
+                except ValueError:
+                    dt = None
+            damage_done = self.apply_damage(actor, result.target, result.damage, dt)
+            if not result.message:
+                self.dam_message(actor, result.target, damage_done)
+            damage_totals[actor] = damage_totals.get(actor, 0) + damage_done
 
+        if result.target:
+            cond = get_health_description(result.target)
+            self.round_output.append(f"The {result.target.key} {cond}")
+
+        if actor.location and result.message:
+            actor.location.msg_contents(result.message)
+        self.track_aggro(result.target, actor)
+        target_hp = _current_hp(result.target)
+        if target_hp <= 0:
+            self.handle_defeat(result.target, actor)
+
+    def _summarize_damage(self, damage_totals: Dict[object, int]) -> None:
+        """Append a short damage summary to the round output."""
         summary_lines = [
             f"{getattr(att, 'key', att)} dealt {dmg} damage."
             for att, dmg in damage_totals.items()
@@ -606,18 +603,41 @@ class CombatEngine:
         if summary_lines:
             self.round_output.extend(summary_lines)
 
-        if self.round_output:
-            msg = "\n".join(self.round_output)
-            room = None
-            if self.participants:
-                room = getattr(self.participants[0].actor, "location", None)
-            if room:
-                room.msg_contents(msg)
-            else:
-                for participant in self.participants:
-                    actor = participant.actor
-                    if hasattr(actor, "msg"):
-                        actor.msg(msg)
+    def _broadcast_round_output(self) -> None:
+        """Send accumulated round output to the appropriate location."""
+        if not self.round_output:
+            return
+        msg = "\n".join(self.round_output)
+        room = None
+        if self.participants:
+            room = getattr(self.participants[0].actor, "location", None)
+        if room:
+            room.msg_contents(msg)
+        else:
+            for participant in self.participants:
+                actor = participant.actor
+                if hasattr(actor, "msg"):
+                    actor.msg(msg)
+
+    def process_round(self) -> None:
+        """Execute all queued actions for the current round.
+
+        Side Effects
+        ------------
+        Applies damage, sends combat messages, awards experience and
+        schedules the next round using :func:`evennia.utils.delay`.
+        """
+        self.start_round()
+        self.round_output = []
+        damage_totals: Dict[object, int] = {}
+
+        actions = self._gather_actions()
+        for _, _, _, participant, action in actions:
+            self._execute_action(participant, action, damage_totals)
+
+        self.cleanup_environment()
+        self._summarize_damage(damage_totals)
+        self._broadcast_round_output()
 
         self.round += 1
         if self.round_time is not None and any(_current_hp(p.actor) > 0 for p in self.participants):


### PR DESCRIPTION
## Summary
- modularize combat rounds
- helper methods for action gathering, execution, and output

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684d94d4a250832c8be896c7ccf9c708