### PR TITLE
Refactor NPC combat scripts with reusable AI base

### DIFF
--- a/scripts/bandit_ai.py
+++ b/scripts/bandit_ai.py
@@ -1,29 +1,19 @@
-from random import choice
-from typeclasses.scripts import Script
+from .combat_ai import BaseCombatAI
 
-class BanditAI(Script):
+class BanditAI(BaseCombatAI):
     """Roams around and attacks weaker players."""
 
     def at_script_creation(self):
+        super().at_script_creation()
         self.key = "bandit_ai"
         self.desc = "Bandit combat behavior"
-        self.interval = 5
-        self.persistent = True
 
-    def at_repeat(self):
+    def select_target(self):
         npc = self.obj
         if not npc or not npc.location:
-            return
-        if npc.in_combat:
-            return
-        # look for an easy target
+            return None
         for obj in npc.location.contents:
             if obj.has_account and obj.db.level and npc.db.level:
                 if obj.db.level < npc.db.level:
-                    npc.execute_cmd(f"kill {obj.key}")
-                    return
-        # wander if no target
-        exits = npc.location.contents_get(content_type="exit")
-        if exits:
-            exit_obj = choice(exits)
-            exit_obj.at_traverse(npc, exit_obj.destination)
+                    return obj
+        return None

--- a/scripts/combat_ai.py
+++ b/scripts/combat_ai.py
@@ -1,0 +1,38 @@
+from random import choice
+from typeclasses.scripts import Script
+
+class BaseCombatAI(Script):
+    """Base class for simple combat AI behavior."""
+
+    def at_script_creation(self):
+        self.interval = 5
+        self.persistent = True
+
+    def select_target(self):
+        """Return an object to attack or ``None``."""
+        return None
+
+    def attack_target(self, target):
+        npc = self.obj
+        if not npc or not target:
+            return
+        npc.execute_cmd(f"kill {target.key}")
+
+    def move(self):
+        npc = self.obj
+        if not npc or not npc.location:
+            return
+        exits = npc.location.contents_get(content_type="exit")
+        if exits:
+            exit_obj = choice(exits)
+            exit_obj.at_traverse(npc, exit_obj.destination)
+
+    def at_repeat(self):
+        npc = self.obj
+        if not npc or not npc.location or npc.in_combat:
+            return
+        target = self.select_target()
+        if target:
+            self.attack_target(target)
+        else:
+            self.move()

--- a/scripts/guard_patrol.py
+++ b/scripts/guard_patrol.py
@@ -1,25 +1,29 @@
-from random import choice
-from typeclasses.scripts import Script
+from .combat_ai import BaseCombatAI
 
-class GuardPatrol(Script):
+class GuardPatrol(BaseCombatAI):
     """Walk a patrol path and attack wanted players."""
 
     def at_script_creation(self):
+        super().at_script_creation()
         self.key = "guard_patrol"
         self.desc = "Guard patrol behavior"
         self.interval = 10
-        self.persistent = True
         self.db.patrol = []
         self.db.index = 0
 
-    def at_repeat(self):
+    def select_target(self):
+        npc = self.obj
+        if not npc or not npc.location:
+            return None
+        for obj in npc.location.contents:
+            if obj.tags.get("wanted"):
+                return obj
+        return None
+
+    def move(self):
         npc = self.obj
         if not npc or not npc.location:
             return
-        for obj in npc.location.contents:
-            if obj.tags.get("wanted"):
-                npc.execute_cmd(f"kill {obj.key}")
-                return
         path = self.db.patrol
         if path:
             exit_name = path[self.db.index % len(path)]
@@ -27,8 +31,5 @@ class GuardPatrol(Script):
             exit_obj = npc.search(exit_name, location=npc.location)
             if exit_obj:
                 exit_obj.at_traverse(npc, exit_obj.destination)
-        else:
-            exits = npc.location.contents_get(content_type="exit")
-            if exits:
-                exit_obj = choice(exits)
-                exit_obj.at_traverse(npc, exit_obj.destination)
+                return
+        super().move()


### PR DESCRIPTION
## Summary
- add `BaseCombatAI` helper for simple combat behaviour
- refactor `BanditAI` and `GuardPatrol` to inherit the base class

## Testing
- `pytest -q` *(fails: 76 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_684d94d4a250832c8be896c7ccf9c708