### PR TITLE
Refactor NPC AI registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,10 @@ builder:
 - **wander** – roam randomly through available exits.
 - **scripted** – runs the callback stored in ``npc.db.ai_script``.
 
+Custom behaviors may be added by registering a class with
+``combat.ai.register_ai``. Set ``npc.db.ai_type`` to the registered key
+to enable that behavior on an NPC.
+
 For scripted AI you must assign a callable to ``npc.db.ai_script``. This can be
 either a Python import path or a direct function reference. Callbacks must live
 under the ``scripts`` package. Example::

--- a/combat/ai/__init__.py
+++ b/combat/ai/__init__.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import Type, Dict
+
+__all__ = [
+    "AI_REGISTRY",
+    "BaseAI",
+    "register_ai",
+    "get_ai_class",
+]
+
+AI_REGISTRY: Dict[str, Type["BaseAI"]] = {}
+
+
+class BaseAI:
+    """Base class for simple AI behaviors."""
+
+    key: str = ""
+
+    def execute(self, npc):
+        """Run one AI step for ``npc``."""
+        raise NotImplementedError
+
+
+def register_ai(key: str):
+    """Class decorator for registering AI behaviors."""
+
+    def decorator(cls: Type[BaseAI]):
+        AI_REGISTRY[key] = cls
+        cls.key = key
+        return cls
+
+    return decorator
+
+
+def get_ai_class(key: str) -> Type[BaseAI] | None:
+    """Return the registered AI class for ``key``."""
+    return AI_REGISTRY.get(key)
+
+from . import aggressive, defensive, wander, passive, scripted

--- a/combat/ai/aggressive.py
+++ b/combat/ai/aggressive.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from combat.ai import BaseAI, register_ai
+from combat.ai_combat import npc_take_turn
+
+
+@register_ai("aggressive")
+class AggressiveAI(BaseAI):
+    """Attack the first player seen or continue fighting."""
+
+    def execute(self, npc):
+        if npc.in_combat and npc.db.combat_target:
+            npc_take_turn(None, npc, npc.db.combat_target)
+            return
+        if not npc.location:
+            return
+        for obj in npc.location.contents:
+            if getattr(obj, "has_account", False):
+                npc.enter_combat(obj)
+                break

--- a/combat/ai/defensive.py
+++ b/combat/ai/defensive.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from combat.ai import BaseAI, register_ai
+from combat.ai_combat import npc_take_turn
+
+
+@register_ai("defensive")
+class DefensiveAI(BaseAI):
+    """Attack only when already in combat."""
+
+    def execute(self, npc):
+        if npc.in_combat and npc.db.combat_target:
+            npc_take_turn(None, npc, npc.db.combat_target)

--- a/combat/ai/passive.py
+++ b/combat/ai/passive.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from combat.ai import BaseAI, register_ai
+
+
+@register_ai("passive")
+class PassiveAI(BaseAI):
+    """Non-responsive AI that takes no actions."""
+
+    def execute(self, npc):
+        return

--- a/combat/ai/scripted.py
+++ b/combat/ai/scripted.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from importlib import import_module
+
+from evennia.utils import logger
+
+from combat.ai import BaseAI, register_ai
+
+ALLOWED_CALLBACK_MODULES = ("scripts",)
+
+
+def _import_ai_callback(path: str):
+    """Import the AI callback if within allowed modules."""
+    module, func = path.rsplit(".", 1)
+    if not any(
+        module == allowed or module.startswith(f"{allowed}.")
+        for allowed in ALLOWED_CALLBACK_MODULES
+    ):
+        raise ImportError(f"Module '{module}' is not allowed")
+    mod = import_module(module)
+    return getattr(mod, func)
+
+
+@register_ai("scripted")
+class ScriptedAI(BaseAI):
+    """Run a callback stored on ``npc.db.ai_script``."""
+
+    def execute(self, npc):
+        callback = npc.db.ai_script
+        if not callback:
+            return
+        try:
+            if callable(callback):
+                callback(npc)
+            elif isinstance(callback, str):
+                try:
+                    func = _import_ai_callback(callback)
+                except Exception as err:
+                    logger.log_err(f"Scripted AI import rejected on {npc}: {err}")
+                    return
+                func(npc)
+        except Exception as err:  # pragma: no cover - log errors
+            logger.log_err(f"Scripted AI error on {npc}: {err}")

--- a/combat/ai/wander.py
+++ b/combat/ai/wander.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from random import choice
+
+from combat.ai import BaseAI, register_ai
+
+
+@register_ai("wander")
+class WanderAI(BaseAI):
+    """Move randomly through available exits."""
+
+    def execute(self, npc):
+        if not npc.location:
+            return
+        exits = npc.location.contents_get(content_type="exit")
+        if exits:
+            exit_obj = choice(exits)
+            exit_obj.at_traverse(npc, exit_obj.destination)

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -2821,6 +2821,8 @@ The mob builder offers the same AI step for prototypes saved with
 `@mcreate` or `@mset`. For scripted AI, store a callable path on
 ``npc.db.ai_script`` such as ``scripts.example_ai.patrol_ai``. Only modules
 within the ``scripts`` package can be used.
+Custom behaviors can be added by registering a class with
+``combat.ai.register_ai`` and setting ``npc.db.ai_type`` to the new key.
 
 Related:
     help cnpc
@@ -3606,6 +3608,7 @@ NPC behavior is controlled by an AI type set in the |wcnpc|n builder or
 |wmobbuilder|n. Available types are passive, aggressive, defensive,
 wander and scripted. Scripted AI runs the callback stored on
 |wnpc.db.ai_script|n.
+Additional AI classes can be registered with ``combat.ai.register_ai``.
 """,
     },
     {

--- a/world/npc_handlers/ai.py
+++ b/world/npc_handlers/ai.py
@@ -2,89 +2,9 @@
 
 from __future__ import annotations
 
-from random import choice
-from importlib import import_module
 from evennia import DefaultObject
-from evennia.utils import logger
 from typeclasses.npcs import BaseNPC
-from combat.ai_combat import npc_take_turn
-
-
-ALLOWED_CALLBACK_MODULES = ("scripts",)
-
-
-def _import_ai_callback(path: str):
-    """Import the AI callback if within allowed modules."""
-    module, func = path.rsplit(".", 1)
-    if not any(
-        module == allowed or module.startswith(f"{allowed}.")
-        for allowed in ALLOWED_CALLBACK_MODULES
-    ):
-        raise ImportError(f"Module '{module}' is not allowed")
-    mod = import_module(module)
-    return getattr(mod, func)
-
-
-def _ai_aggressive(npc: DefaultObject) -> None:
-    """Aggressive behavior: enter combat or act if already fighting."""
-    if npc.in_combat and npc.db.combat_target:
-        npc_take_turn(None, npc, npc.db.combat_target)
-        return
-    if not npc.location:
-        return
-    for obj in npc.location.contents:
-        if obj.has_account:
-            npc.enter_combat(obj)
-            break
-
-
-def _ai_wander(npc: DefaultObject) -> None:
-    """Move randomly through available exits."""
-    if not npc.location:
-        return
-    exits = npc.location.contents_get(content_type="exit")
-    if exits:
-        exit_obj = choice(exits)
-        exit_obj.at_traverse(npc, exit_obj.destination)
-
-
-def _ai_defensive(npc: DefaultObject) -> None:
-    """Attack only when already in combat."""
-    if npc.in_combat and npc.db.combat_target:
-        npc_take_turn(None, npc, npc.db.combat_target)
-
-
-def _ai_scripted(npc: DefaultObject) -> None:
-    """Run a custom callback stored on the NPC."""
-    callback = npc.db.ai_script
-    if not callback:
-        return
-    try:
-        if callable(callback):
-            callback(npc)
-        elif isinstance(callback, str):
-            try:
-                func = _import_ai_callback(callback)
-            except Exception as err:
-                logger.log_err(f"Scripted AI import rejected on {npc}: {err}")
-                return
-            func(npc)
-    except Exception as err:  # pragma: no cover - log errors
-        logger.log_err(f"Scripted AI error on {npc}: {err}")
-
-
-def _ai_passive(npc: DefaultObject) -> None:
-    """Non-responsive AI that takes no actions."""
-    return
-
-
-_AI_MAP = {
-    "aggressive": _ai_aggressive,
-    "wander": _ai_wander,
-    "defensive": _ai_defensive,
-    "scripted": _ai_scripted,
-    "passive": _ai_passive,
-}
+from combat.ai import get_ai_class
 
 
 def process_ai(npc: DefaultObject) -> None:
@@ -115,6 +35,6 @@ def process_ai(npc: DefaultObject) -> None:
                     if "assist" in set(obj.db.actflags or []):
                         obj.enter_combat(target)
 
-    handler = _AI_MAP.get(ai_type.lower())
-    if handler:
-        handler(npc)
+    ai_cls = get_ai_class(ai_type.lower())
+    if ai_cls:
+        ai_cls().execute(npc)


### PR DESCRIPTION
## Summary
- add new combat AI classes under `combat.ai`
- register built-in NPC AI behaviors
- rework NPC AI handler to use registry
- document how to register new AI behaviors

## Testing
- `pytest -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684da19a620c832cb560b25fb81f2a93