### PR TITLE
Improve NPC target selection

### DIFF
--- a/scripts/combat_ai.py
+++ b/scripts/combat_ai.py
@@ -9,7 +9,13 @@ class BaseCombatAI(Script):
         self.persistent = True
 
     def select_target(self):
-        """Return an object to attack or ``None``."""
+        """Return a valid player character in the same room or ``None``."""
+        npc = self.obj
+        if not npc or not npc.location:
+            return None
+        for obj in npc.location.contents:
+            if getattr(obj, "account", None) and not obj.tags.has("unconscious", category="status"):
+                return obj
         return None
 
     def attack_target(self, target):


### PR DESCRIPTION
## Summary
- refine BaseCombatAI.select_target to find a live player character

## Testing
- `pytest -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684da6cf853c832c8ab06ddd3034c332