### PR TITLE
Update end_combat cleanup

### DIFF
--- a/combat/round_manager.py
+++ b/combat/round_manager.py
@@ -212,6 +212,7 @@ class CombatInstance:
             return
 
         self.combat_ended = True
+        CombatRoundManager.get().remove_instance(self.room)
 
         # Clean up fighter states
         if self.engine:


### PR DESCRIPTION
## Summary
- clean up combat round instance when combat ends

## Testing
- `pytest -q` *(fails: OperationalError - no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684daa8c7718832c97fde59f32522f3a