### PR TITLE
Replace XP_PER_LEVEL constant

### DIFF
--- a/server/conf/settings.py
+++ b/server/conf/settings.py
@@ -45,10 +45,6 @@ DEFAULT_XP_PER_LEVEL = 10
 # Experience required to advance from ``level`` to ``level + 1``
 XP_TO_LEVEL = lambda level: 100 + (level ** 2 * 20)
 
-# Legacy constant for backwards compatibility
-# (fixed value of 100 XP per level)
-XP_PER_LEVEL = 100
-
 # Whether excess XP carries over when leveling
 XP_CARRY_OVER = False
 

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -250,7 +250,7 @@ class Character(ObjectParent, ClothedCharacter):
         from django.conf import settings
         self.db.level = 1
         self.db.experience = 0
-        self.db.tnl = settings.XP_PER_LEVEL
+        self.db.tnl = settings.XP_TO_LEVEL(1)
         self.db.sated = 5
 
     def at_post_puppet(self, **kwargs):


### PR DESCRIPTION
## Summary
- use `settings.XP_TO_LEVEL(1)` when setting initial TNL
- remove unused `XP_PER_LEVEL` constant from settings

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684dabf31b94832cb16e99aedab71972