### PR TITLE
Improve add_combatant return semantics

### DIFF
--- a/combat/round_manager.py
+++ b/combat/round_manager.py
@@ -36,6 +36,8 @@ class CombatInstance:
         """Add ``combatant`` to this combat instance."""
         if not self.engine:
             return False
+        if _current_hp(combatant) <= 0:
+            return False
         current = {p.actor for p in self.engine.participants}
         if combatant in current:
             return True

--- a/commands/combat.py
+++ b/commands/combat.py
@@ -2,6 +2,7 @@ from random import choice
 from evennia import CmdSet
 from evennia.utils import iter_to_str
 from evennia.utils.evtable import EvTable
+from combat.engine import _current_hp
 
 from .command import Command
 from typeclasses.gear import BareHand
@@ -85,7 +86,10 @@ class CmdAttack(Command):
         instance = CombatRoundManager.get().add_instance(location)
 
         if not instance.add_combatant(self.caller):
-            self.msg("You can't fight right now.")
+            if _current_hp(self.caller) <= 0:
+                self.msg("You are in no condition to fight.")
+            else:
+                self.msg("You can't fight right now.")
             return
 
         self.caller.db.combat_target = target


### PR DESCRIPTION
## Summary
- prevent adding defeated combatants to a combat instance
- use returned value in `CmdAttack` to give better feedback

## Testing
- `pytest -q` *(fails: OperationalError no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684dad208bb0832c8ec76beddde24567