### PR TITLE
Add auto prompt helper and refactor combat commands

### DIFF
--- a/commands/combat.py
+++ b/commands/combat.py
@@ -103,11 +103,9 @@ class CmdAttack(Command):
         """
         optional post-command auto prompt
         """
-        # check if we have auto-prompt in settings
-        if self.account and (settings := self.account.db.settings):
-            if settings.get("auto prompt"):
-                status = self.caller.get_display_status(self.caller)
-                self.msg(prompt=status)
+        from utils import display_auto_prompt
+
+        display_auto_prompt(self.account, self.caller, self.msg)
 
 
 class CmdWield(Command):
@@ -279,11 +277,9 @@ class CmdBerserk(Command):
         """
         optional post-command auto prompt
         """
-        # check if we have auto-prompt in settings
-        if self.account and (settings := self.account.db.settings):
-            if settings.get("auto prompt"):
-                status = self.caller.get_display_status(self.caller)
-                self.msg(prompt=status)
+        from utils import display_auto_prompt
+
+        display_auto_prompt(self.account, self.caller, self.msg)
 
 
 class CmdRespawn(Command):
@@ -364,9 +360,10 @@ class CmdStatus(Command):
 
     def func(self):
         if not self.args:
+            from utils import display_auto_prompt
+
             target = self.caller
-            status = target.get_display_status(self.caller)
-            self.msg(prompt=status)
+            display_auto_prompt(self.account, target, self.msg, force=True)
         else:
             target = self.caller.search(self.args.strip())
             if not target:

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -21,3 +21,20 @@ except Exception:  # pragma: no cover - may fail before Django setup
         raise RuntimeError("eval_safe unavailable before Django setup")
 
 from .dice import roll_dice_string
+
+
+def display_auto_prompt(account, caller, msg_func, *, force=False):
+    """Display ``caller``'s status prompt if enabled on ``account``.
+
+    Args:
+        account (Account): The account storing the settings.
+        caller (Object): The character whose status should be displayed.
+        msg_func (callable): Function used to send the prompt.
+        force (bool, optional): If ``True``, always send the prompt
+            regardless of account settings. Defaults to ``False``.
+    """
+
+    if force or (account and (settings := account.db.settings) and settings.get("auto prompt")):
+        status = caller.get_display_status(caller)
+        msg_func(prompt=status)
+

--- a/utils/tests/test_prompt_utils.py
+++ b/utils/tests/test_prompt_utils.py
@@ -1,0 +1,34 @@
+from unittest.mock import MagicMock
+
+from evennia.utils.test_resources import EvenniaTest
+
+
+class TestDisplayAutoPrompt(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.char1.account = MagicMock()
+        self.char1.account.db.settings = {"auto prompt": True}
+        self.char1.get_display_status = MagicMock(return_value="STATUS")
+
+    def test_prompt_sent_when_enabled(self):
+        from utils import display_auto_prompt
+
+        send = MagicMock()
+        display_auto_prompt(self.char1.account, self.char1, send)
+        send.assert_called_with(prompt="STATUS")
+
+    def test_no_prompt_when_disabled(self):
+        from utils import display_auto_prompt
+
+        self.char1.account.db.settings["auto prompt"] = False
+        send = MagicMock()
+        display_auto_prompt(self.char1.account, self.char1, send)
+        send.assert_not_called()
+
+    def test_force_override(self):
+        from utils import display_auto_prompt
+
+        self.char1.account.db.settings["auto prompt"] = False
+        send = MagicMock()
+        display_auto_prompt(self.char1.account, self.char1, send, force=True)
+        send.assert_called_with(prompt="STATUS")


### PR DESCRIPTION
## Summary
- add `display_auto_prompt` helper
- refactor combat commands to use new helper
- test helper behavior

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684daf9701b0832c9e5505a01091e9d5