### PR TITLE
Improve combat AI navigation logic

### DIFF
--- a/scripts/combat_ai.py
+++ b/scripts/combat_ai.py
@@ -7,6 +7,10 @@ class BaseCombatAI(Script):
     def at_script_creation(self):
         self.interval = 5
         self.persistent = True
+        # Optional flag controlling movement when players are in the same room.
+        # When ``True`` the NPC will remain in place if ``select_target`` finds a
+        # player in the current location.
+        self.db.skip_move_if_target = False
 
     def select_target(self):
         """Return a valid player character in the same room or ``None``."""
@@ -24,14 +28,37 @@ class BaseCombatAI(Script):
             return
         npc.execute_cmd(f"kill {target.key}")
 
+    def _adjacent_exit_to_target(self):
+        """Return an exit leading to a room with a viable target, if any."""
+        npc = self.obj
+        if not npc or not npc.location:
+            return None
+        for ex in npc.location.exits:
+            dest = ex.destination
+            if not dest:
+                continue
+            for obj in dest.contents:
+                if getattr(obj, "account", None) and not obj.tags.has(
+                    "unconscious", category="status"
+                ):
+                    return ex
+        return None
+
     def move(self):
         npc = self.obj
         if not npc or not npc.location:
             return
+        if self.db.skip_move_if_target and self.select_target():
+            return
         exits = npc.location.contents_get(content_type="exit")
-        if exits:
+        if not exits:
+            return
+
+        exit_obj = self._adjacent_exit_to_target()
+        if not exit_obj:
             exit_obj = choice(exits)
-            exit_obj.at_traverse(npc, exit_obj.destination)
+
+        exit_obj.at_traverse(npc, exit_obj.destination)
 
     def at_repeat(self):
         npc = self.obj

--- a/typeclasses/tests/test_combat_ai.py
+++ b/typeclasses/tests/test_combat_ai.py
@@ -1,0 +1,40 @@
+from unittest.mock import patch
+from evennia.utils import create
+from evennia.utils.test_resources import EvenniaTest
+
+from scripts.combat_ai import BaseCombatAI
+from typeclasses.npcs import BaseNPC
+from typeclasses.exits import Exit
+from typeclasses.rooms import Room
+
+
+class TestBaseCombatAI(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.npc = create.create_object(BaseNPC, key="mob", location=self.room1)
+        self.room2 = create.create_object(Room, key="room2")
+        self.room3 = create.create_object(Room, key="room3")
+        self.exit_target = create.create_object(
+            Exit, key="east", location=self.room1, destination=self.room2
+        )
+        self.exit_other = create.create_object(
+            Exit, key="north", location=self.room1, destination=self.room3
+        )
+        self.script = self.npc.scripts.add(BaseCombatAI, key="combat_ai", autostart=False)
+
+    def test_move_prefers_adjacent_target(self):
+        self.char1.location = self.room2
+        with patch("scripts.combat_ai.choice", return_value=self.exit_other), \
+             patch.object(self.exit_target, "at_traverse") as mock_target, \
+             patch.object(self.exit_other, "at_traverse") as mock_other:
+            self.script.move()
+            mock_target.assert_called_with(self.npc, self.room2)
+            mock_other.assert_not_called()
+
+    def test_skip_move_if_target_present(self):
+        self.script.db.skip_move_if_target = True
+        self.char1.location = self.room1
+        with patch.object(self.exit_target, "at_traverse") as mock_move:
+            self.script.move()
+            mock_move.assert_not_called()
+


### PR DESCRIPTION
## Summary
- enhance BaseCombatAI so NPCs check adjacent rooms for targets
- add option to stop moving when a target is in the same room
- test new BaseCombatAI movement behaviour

## Testing
- `pytest -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684db2954974832c8eef7a26b777b1a2