### PR TITLE
Fix combat_target cleared after kill

### DIFF
--- a/combat/engine/damage_processor.py
+++ b/combat/engine/damage_processor.py
@@ -110,6 +110,8 @@ class DamageProcessor:
 
         if attacker and attacker.location:
             attacker.location.msg_contents(f"{target.key} is defeated by {attacker.key}!")
+        if attacker and getattr(attacker, "db", None) is not None:
+            attacker.db.combat_target = None
 
         self.turn_manager.remove_participant(target)
         for participant in list(self.turn_manager.participants):

--- a/typeclasses/tests/test_combat_engine.py
+++ b/typeclasses/tests/test_combat_engine.py
@@ -567,3 +567,20 @@ class TestUnsavedPrototypeCombat(unittest.TestCase):
             engine.track_aggro(player, npc)
 
         self.assertFalse(engine.aggro)
+
+
+def test_attacker_target_cleared_on_defeat():
+    attacker = Dummy()
+    defender = Dummy()
+    attacker.db.combat_target = defender
+    defender.db.combat_target = attacker
+
+    engine = CombatEngine([attacker, defender], round_time=0)
+    engine.queue_action(attacker, KillAction(attacker, defender))
+
+    with patch("world.system.state_manager.apply_regen"), \
+         patch("random.randint", return_value=0):
+        engine.start_round()
+        engine.process_round()
+
+    assert attacker.db.combat_target is None


### PR DESCRIPTION
## Summary
- ensure attacker's combat target clears on defeat
- add regression test for combat target clearing

## Testing
- `pytest -q` *(fails: django.db.utils.OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684db8794e98832cac15c38a7e5aa9f7