### PR TITLE
Ensure deterministic damage calculation

### DIFF
--- a/combat/actions/utils.py
+++ b/combat/actions/utils.py
@@ -43,7 +43,9 @@ def calculate_damage(attacker, weapon, target) -> Tuple[int, object]:
             if db:
                 dmg_map = getattr(db, "damage", None)
                 if dmg_map:
-                    for i, (dt, formula) in enumerate(dmg_map.items()):
+                    for i, (dt, formula) in enumerate(
+                        sorted(dmg_map.items(), key=lambda kv: str(kv[0]))
+                    ):
                         try:
                             roll = roll_dice_string(str(formula))
                         except Exception:


### PR DESCRIPTION
## Summary
- sort damage mappings for deterministic resolution
- add regression test checking mapping iteration order

## Testing
- `pytest utils/tests/test_action_helpers.py::TestActionUtils::test_damage_mapping_stable_order -q`
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684dd1f1ccf8832cbc1777f97c9a1a27