### PR TITLE
Raise error when combat engine missing

### DIFF
--- a/combat/round_manager.py
+++ b/combat/round_manager.py
@@ -33,9 +33,13 @@ class CombatInstance:
         ]
 
     def add_combatant(self, combatant, **kwargs) -> bool:
-        """Add ``combatant`` to this combat instance."""
+        """Add ``combatant`` to this combat instance.
+
+        Raises:
+            RuntimeError: If the combat engine is missing.
+        """
         if not self.engine:
-            return False
+            raise RuntimeError("Combat engine failed to initialize for room")
         if _current_hp(combatant) <= 0:
             return False
         current = {p.actor for p in self.engine.participants}

--- a/typeclasses/tests/test_round_manager.py
+++ b/typeclasses/tests/test_round_manager.py
@@ -1,6 +1,6 @@
 from unittest.mock import patch
 from evennia.utils.test_resources import EvenniaTest
-from combat.round_manager import CombatRoundManager
+from combat.round_manager import CombatRoundManager, CombatInstance
 from combat.engine import CombatEngine
 
 
@@ -196,3 +196,9 @@ class TestCombatRoundManager(EvenniaTest):
             self.manager._tick()
             self.assertNotIn(inst, self.manager.instances)
             self.assertTrue(inst.combat_ended)
+
+    def test_add_combatant_raises_without_engine(self):
+        """add_combatant should raise RuntimeError if engine is missing."""
+        inst = CombatInstance(self.room1, None)
+        with self.assertRaises(RuntimeError):
+            inst.add_combatant(self.char1)


### PR DESCRIPTION
## Summary
- improve combatant addition in `CombatInstance`
- test that a missing combat engine raises an exception

## Testing
- `pytest -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684dd9819f0c832c9c4e168e526d3280