### PR TITLE
Add CombatEngine init check

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,8 @@ with the manager when combat starts via
 `CombatRoundManager.get().add_instance(room)`, which returns a `CombatInstance`
 object and kicks off the automatic round loop. Instances are stored in
 `manager.instances_by_room` using the room's id as the key for quick lookups.
+If the underlying `CombatEngine` fails to initialize for any reason,
+`add_instance` will raise a `RuntimeError` to signal the error.
 
 For a deeper look at how this round system mirrors the classic ROM MUD
 functions like `violence_update` and `multi_hit`, see the documentation in

--- a/combat/round_manager.py
+++ b/combat/round_manager.py
@@ -284,6 +284,8 @@ class CombatRoundManager:
             raise ImportError("Combat engine could not be imported") from err
 
         engine = CombatEngine(fighters, round_time=None)
+        if not engine:
+            raise RuntimeError("CombatEngine failed to initialize")
 
         # Create instance
         inst = CombatInstance(room, engine, round_time or self.tick_delay)


### PR DESCRIPTION
## Summary
- ensure CombatEngine initializes in `CombatRoundManager.add_instance`
- mention the RuntimeError in README

## Testing
- `pytest -q` *(fails: django.db errors)*

------
https://chatgpt.com/codex/tasks/task_e_684ddcf3d434832cba51223a9a7d6d43