### PR TITLE
Add optional combat tick debug log

### DIFF
--- a/combat/round_manager.py
+++ b/combat/round_manager.py
@@ -8,6 +8,7 @@ from typing import Dict, List, Optional
 
 from evennia.utils import delay
 from evennia.utils.logger import log_trace
+from django.conf import settings
 from .engine import _current_hp
 
 
@@ -362,6 +363,8 @@ class CombatRoundManager:
 
     def _tick(self) -> None:
         self._next_tick_scheduled = False
+        if getattr(settings, "COMBAT_DEBUG_TICKS", False):
+            log_trace("CombatRoundManager tick")
         if not self.running:
             return
 

--- a/docs/combat_loop_mapping.md
+++ b/docs/combat_loop_mapping.md
@@ -10,6 +10,7 @@ File: `combat/round_manager.py`
   `instances_by_room` dictionary maps each room's id to its `CombatInstance`.
 - Ticks every few seconds to drive combat across rooms, much like ROM's `violence_update` that iterates over every character currently fighting.
 - Each tick triggers the associated `CombatEngine` to process a new round.
+- When `COMBAT_DEBUG_TICKS` is `True` in `server/conf/settings.py`, a debug log is emitted each tick.
 
 ## CombatInstance
 

--- a/server/conf/settings.py
+++ b/server/conf/settings.py
@@ -73,6 +73,9 @@ PROTOTYPE_NPC_EXPORT_DIR = Path(GAME_DIR) / "exports" / "npc_prototypes"
 # File tracking used VNUMs
 VNUM_REGISTRY_FILE = Path(GAME_DIR) / "world" / "vnum_registry.json"
 
+# Log each combat tick when set to True
+COMBAT_DEBUG_TICKS = False
+
 # Clothing - https://www.evennia.com/docs/latest/Contribs/Contrib-Clothing.html#configuration
 CLOTHING_WEARSTYLE_MAXLENGTH = 40
 CLOTHING_TYPE_ORDERED = [


### PR DESCRIPTION
## Summary
- log a message at each combat tick
- allow toggling the tick log via `COMBAT_DEBUG_TICKS` setting
- document the new setting

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684dde673a88832c8aa33612ca60a813