### PR TITLE
Refactor combat system to id-based manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,14 +424,12 @@ with VNUM-based NPCs.
 ### Combat Round Manager
 
 The `CombatRoundManager` singleton, found in `combat.round_manager`, manages all
-active combat instances per room. It ticks every **2 seconds** by default (see
-`tick_delay` at line 214 of `combat/round_manager.py`). Rooms are registered
-with the manager when combat starts via
-`CombatRoundManager.get().add_instance(room)`, which returns a `CombatInstance`
-object and kicks off the automatic round loop. Instances are stored in
-`manager.instances_by_room` using the room's id as the key for quick lookups.
-If the underlying `CombatEngine` fails to initialize for any reason,
-`add_instance` will raise a `RuntimeError` to signal the error.
+active combat encounters. It ticks every **2 seconds** by default (see
+`tick_delay` at line 214 of `combat/round_manager.py`). Combat is started with
+`CombatRoundManager.get().start_combat(combatants)` which returns a
+`CombatInstance` keyed by a unique combat id. The manager tracks which combat
+each combatant belongs to for quick lookups. If the underlying `CombatEngine`
+fails to initialize for any reason, `start_combat` will raise a `RuntimeError`.
 
 For a deeper look at how this round system mirrors the classic ROM MUD
 functions like `violence_update` and `multi_hit`, see the documentation in

--- a/commands/admin.py
+++ b/commands/admin.py
@@ -441,14 +441,19 @@ class CmdPeace(Command):
 
         from combat.round_manager import CombatRoundManager
         manager = CombatRoundManager.get()
-        instance = manager.instances_by_room.get(location.id)
+        instance = manager.get_combatant_combat(caller)
+        if not instance:
+            for inst in manager.combats.values():
+                if any(getattr(f, "location", None) == location for f in inst.combatants):
+                    instance = inst
+                    break
         if not instance:
             caller.msg("There is no fighting here.")
             return
 
         for p in list(instance.engine.participants):
             instance.remove_combatant(p.actor)
-        manager.remove_instance(location)
+        manager.remove_combat(instance.combat_id)
         location.msg_contents("Peace falls over the area.")
 
 

--- a/commands/combat.py
+++ b/commands/combat.py
@@ -83,9 +83,10 @@ class CmdAttack(Command):
         # it's all good! let's get started!
         from combat.round_manager import CombatRoundManager
 
-        instance = CombatRoundManager.get().add_instance(location)
+        manager = CombatRoundManager.get()
+        instance = manager.start_combat([self.caller, target])
 
-        if not instance.add_combatant(self.caller):
+        if self.caller not in instance.combatants:
             if _current_hp(self.caller) <= 0:
                 self.msg("You are in no condition to fight.")
             else:
@@ -237,7 +238,7 @@ class CmdFlee(Command):
 
         from combat.round_manager import CombatRoundManager
         manager = CombatRoundManager.get()
-        if instance := manager.instances_by_room.get(caller.location.id):
+        if instance := manager.get_combatant_combat(caller):
             if not instance.remove_combatant(self.caller):
                 self.msg("You cannot leave combat.")
 

--- a/docs/combat_loop_mapping.md
+++ b/docs/combat_loop_mapping.md
@@ -6,8 +6,8 @@ This project models its turn-based fighting system after the traditional combat 
 
 File: `combat/round_manager.py`
 
-- Maintains a registry of all active combat instances. The
-  `instances_by_room` dictionary maps each room's id to its `CombatInstance`.
+- Maintains a registry of all active combat instances keyed by a unique combat id.
+- Tracks which combat each combatant belongs to for quick lookup.
 - Ticks every few seconds to drive combat across rooms, much like ROM's `violence_update` that iterates over every character currently fighting.
 - Each tick triggers the associated `CombatEngine` to process a new round.
 - When `COMBAT_DEBUG_TICKS` is `True` in `server/conf/settings.py`, a debug log is emitted each tick.

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -426,7 +426,7 @@ class Character(ObjectParent, ClothedCharacter):
             if self.in_combat:
                 from combat.round_manager import CombatRoundManager
                 manager = CombatRoundManager.get()
-                inst = manager.instances_by_room.get(self.location.id)
+                inst = manager.get_combatant_combat(self)
                 if inst and not inst.remove_combatant(self):
                     logger.log_err(
                         f"Could not remove defeated character from combat! Character: {self.name} (#{self.id}) Location: {self.location.name} (#{self.location.id})"
@@ -901,7 +901,7 @@ class PlayerCharacter(Character):
         if self.in_combat:
             from combat.round_manager import CombatRoundManager
             manager = CombatRoundManager.get()
-            inst = manager.instances_by_room.get(self.location.id)
+            inst = manager.get_combatant_combat(self)
             if inst:
                 inst.remove_combatant(self)
         # avoid spawning multiple corpses for repeated calls
@@ -1105,7 +1105,7 @@ class NPC(Character):
         if self.in_combat:
             from combat.round_manager import CombatRoundManager
             manager = CombatRoundManager.get()
-            inst = manager.instances_by_room.get(self.location.id)
+            inst = manager.get_combatant_combat(self)
             if inst:
                 inst.remove_combatant(self)
 
@@ -1231,7 +1231,7 @@ class NPC(Character):
             self.db.fleeing = True
             from combat.round_manager import CombatRoundManager
             manager = CombatRoundManager.get()
-            inst = manager.instances_by_room.get(self.location.id)
+            inst = manager.get_combatant_combat(self)
             if inst and not inst.remove_combatant(self):
                 return dmg
             # there's a 50/50 chance the object will escape forever
@@ -1267,9 +1267,10 @@ class NPC(Character):
 
         from combat.round_manager import CombatRoundManager
 
-        instance = CombatRoundManager.get().add_instance(location)
+        manager = CombatRoundManager.get()
+        instance = manager.start_combat([self, target])
         self.db.combat_target = target
-        if not instance.add_combatant(self):
+        if self not in instance.combatants:
             return
 
         engine = getattr(instance, "engine", None)

--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -69,7 +69,7 @@ class RoomParent(ObjectParent):
         super().at_object_leave(mover, destination, **kwargs)
         from combat.round_manager import CombatRoundManager
         manager = CombatRoundManager.get()
-        if instance := manager.instances_by_room.get(self.id):
+        if instance := manager.get_combatant_combat(mover):
             instance.remove_combatant(mover)
         # only react if the arriving object is a character
         if "character" in mover._content_types:

--- a/typeclasses/tests/test_admin_commands.py
+++ b/typeclasses/tests/test_admin_commands.py
@@ -466,7 +466,7 @@ class TestAdminCommands(EvenniaTest):
         cmd.func()
 
         from combat.round_manager import CombatRoundManager
-        self.assertFalse(CombatRoundManager.get().instances)
+        self.assertFalse(CombatRoundManager.get().combats)
 
     def test_peace_after_victory(self):
         """Peace should handle the combat script being deleted already."""
@@ -474,7 +474,7 @@ class TestAdminCommands(EvenniaTest):
         from combat.round_manager import CombatRoundManager
 
         manager = CombatRoundManager.get()
-        instance = manager.add_instance(self.room1, fighters=[self.char1, self.char2])
+        instance = manager.start_combat([self.char1, self.char2])
 
         # defeat the opponent
         self.char2.tags.add("dead", category="status")
@@ -482,7 +482,7 @@ class TestAdminCommands(EvenniaTest):
         manager._tick()
 
         # combat instance should now be deleted
-        self.assertFalse(manager.instances)
+        self.assertFalse(manager.combats)
 
         self.char1.msg.reset_mock()
         self.char1.execute_cmd("peace")
@@ -503,7 +503,7 @@ class TestAdminCommands(EvenniaTest):
         self.char1.execute_cmd(f"attack {self.char2.key}")
         from combat.round_manager import CombatRoundManager
         manager = CombatRoundManager.get()
-        instance = manager.instances_by_room.get(self.room1.id)
+        instance = manager.get_combatant_combat(self.char1)
 
         # defeat the opponent so combat ends
         self.char2.tags.add("dead", category="status")
@@ -511,7 +511,7 @@ class TestAdminCommands(EvenniaTest):
 
         # ensure instance is removed
         manager._tick()
-        self.assertFalse(manager.instances)
+        self.assertFalse(manager.combats)
 
         self.char1.msg.reset_mock()
         self.char1.execute_cmd("peace")
@@ -537,5 +537,5 @@ class TestAdminCommands(EvenniaTest):
         cmd.func()
 
         from combat.round_manager import CombatRoundManager
-        self.assertFalse(CombatRoundManager.get().instances)
+        self.assertFalse(CombatRoundManager.get().combats)
 

--- a/typeclasses/tests/test_attack_command.py
+++ b/typeclasses/tests/test_attack_command.py
@@ -23,8 +23,8 @@ class TestAttackCommand(EvenniaTest):
         from combat.combat_actions import AttackAction
 
         manager = CombatRoundManager.get()
-        self.assertTrue(manager.instances)
-        engine = manager.instances[0].engine
+        self.assertTrue(manager.combats)
+        engine = list(manager.combats.values())[0].engine
         queued = any(
             isinstance(act, AttackAction)
             for p in engine.participants
@@ -67,7 +67,7 @@ class TestAttackCommand(EvenniaTest):
             char3.execute_cmd("attack char2")
 
         manager = CombatRoundManager.get()
-        engine = manager.instances[0].engine
+        engine = list(manager.combats.values())[0].engine
 
         self.assertIn(char3, [p.actor for p in engine.participants])
         queued = [

--- a/typeclasses/tests/test_characters.py
+++ b/typeclasses/tests/test_characters.py
@@ -173,7 +173,7 @@ class TestCharacterProperties(EvenniaTest):
         from combat.round_manager import CombatRoundManager
 
         manager = CombatRoundManager.get()
-        instance = manager.add_instance(self.room1, fighters=[self.char1, self.char2])
+        instance = manager.start_combat([self.char1, self.char2])
         self.assertFalse(self.char1.in_combat)
         instance.add_combatant(self.char1)
         self.assertTrue(self.char1.in_combat)

--- a/typeclasses/tests/test_combat_engine.py
+++ b/typeclasses/tests/test_combat_engine.py
@@ -387,8 +387,8 @@ class TestCombatDeath(EvenniaTest):
 
         from combat.round_manager import CombatRoundManager
         manager = CombatRoundManager.get()
-        instance = manager.add_instance(self.room1, fighters=[player, npc])
-        manager.remove_instance(self.room1)
+        instance = manager.start_combat([player, npc])
+        manager.remove_combat(instance.combat_id)
 
         # should not raise when combat script has been removed
         npc.on_death(player)

--- a/typeclasses/tests/test_combat_full_fight.py
+++ b/typeclasses/tests/test_combat_full_fight.py
@@ -21,7 +21,7 @@ class TestCombatFullFight(EvenniaTest):
     def test_fight_runs_until_defeat(self):
         with patch("combat.round_manager.delay"):
             manager = CombatRoundManager.get()
-            instance = manager.add_instance(self.room1, fighters=[self.char1, self.char2])
+            instance = manager.start_combat([self.char1, self.char2])
             engine = instance.engine
 
             # give both characters small amounts of health

--- a/typeclasses/tests/test_mob_ai.py
+++ b/typeclasses/tests/test_mob_ai.py
@@ -78,7 +78,7 @@ class TestMobAIBehaviors(EvenniaTest):
         ally.db.ai_type = "defensive"
         ally.db.actflags = []
         manager = CombatRoundManager.get()
-        instance = manager.add_instance(self.room1, fighters=[ally, self.char1])
+        instance = manager.start_combat([ally, self.char1])
 
         helper = create.create_object(BaseNPC, key="helper", location=self.room1)
         helper.db.actflags = ["assist"]

--- a/typeclasses/tests/test_npc_ai.py
+++ b/typeclasses/tests/test_npc_ai.py
@@ -130,7 +130,7 @@ class TestAIBehaviors(EvenniaTest):
         self.char1.location = self.room1
         from combat.round_manager import CombatRoundManager
         manager = CombatRoundManager.get()
-        manager.add_instance(self.room1, fighters=[self.char1, self.char2])
+        manager.start_combat([self.char1, self.char2])
 
         with patch.object(npc, "enter_combat") as mock:
             ai.process_ai(npc)
@@ -145,7 +145,7 @@ class TestAIBehaviors(EvenniaTest):
         caller.db.actflags = ["call_for_help"]
         from combat.round_manager import CombatRoundManager
         manager = CombatRoundManager.get()
-        manager.add_instance(self.room1, fighters=[caller, self.char1])
+        manager.start_combat([caller, self.char1])
 
         ally = create.create_object(BaseNPC, key="ally", location=self.room1)
         ally.db.ai_type = "passive"


### PR DESCRIPTION
## Summary
- remove room from `CombatInstance` and manage fighters via `combat_id`
- replace `instances_by_room` with combat/participant maps
- provide migration cleanup for old room based combats
- update command and character modules to new API
- adjust tests and docs for id-based combat manager

## Testing
- `pytest -q` *(fails: django.db errors)*

------
https://chatgpt.com/codex/tasks/task_e_684de25896f4832c8888eff4168f9782