### PR TITLE
Update combat docs for ID-based instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,11 +425,12 @@ with VNUM-based NPCs.
 
 The `CombatRoundManager` singleton, found in `combat.round_manager`, manages all
 active combat encounters. It ticks every **2 seconds** by default (see
-`tick_delay` at line 214 of `combat/round_manager.py`). Combat is started with
-`CombatRoundManager.get().start_combat(combatants)` which returns a
-`CombatInstance` keyed by a unique combat id. The manager tracks which combat
-each combatant belongs to for quick lookups. If the underlying `CombatEngine`
-fails to initialize for any reason, `start_combat` will raise a `RuntimeError`.
+`tick_delay` at line 214 of `combat/round_manager.py`). Call
+`CombatRoundManager.get().start_combat([fighter1, fighter2])` to create a combat
+with those combatants. The manager stores each combat instance by a unique ID
+and uses the `combatant_to_combat` dictionary to map combatants back to their
+current combat for quick lookups. If the underlying `CombatEngine` fails to
+initialize for any reason, `start_combat` will raise a `RuntimeError`.
 
 For a deeper look at how this round system mirrors the classic ROM MUD
 functions like `violence_update` and `multi_hit`, see the documentation in

--- a/combat/round_manager.py
+++ b/combat/round_manager.py
@@ -436,11 +436,12 @@ class CombatRoundManager:
         return "\n".join(lines)
 
 
-def cleanup_room_based_combat() -> None:
-    """End any existing room-based combat instances left from older versions."""
+def cleanup_legacy_room_combat() -> None:
+    """Clean up any leftover room-based combat stored in `instances_by_room`."""
     mgr = CombatRoundManager._instance
     if not mgr:
         return
+    # Older revisions stored combats in `instances_by_room`. Remove any that remain.
     if hasattr(mgr, "instances_by_room"):
         for inst in list(getattr(mgr, "instances_by_room", {}).values()):
             try:
@@ -452,4 +453,4 @@ def cleanup_room_based_combat() -> None:
             mgr.instances.clear()
 
 
-cleanup_room_based_combat()
+cleanup_legacy_room_combat()

--- a/docs/combat_loop_mapping.md
+++ b/docs/combat_loop_mapping.md
@@ -8,15 +8,15 @@ File: `combat/round_manager.py`
 
 - Maintains a registry of all active combat instances keyed by a unique combat id.
 - Tracks which combat each combatant belongs to for quick lookup.
-- Ticks every few seconds to drive combat across rooms, much like ROM's `violence_update` that iterates over every character currently fighting.
+- Ticks every few seconds to drive all active combats, much like ROM's `violence_update` that iterates over every character currently fighting.
 - Each tick triggers the associated `CombatEngine` to process a new round.
 - When `COMBAT_DEBUG_TICKS` is `True` in `server/conf/settings.py`, a debug log is emitted each tick.
 
 ## CombatInstance
 
-Created by `CombatRoundManager` for a room when combat starts.
-- Tracks participants in that room and syncs them with the `CombatEngine`.
-- Replaces the old room-attached script and mirrors ROM's per-room fight list.
+Created by `CombatRoundManager` when a new combat begins.
+- Tracks its participants and keeps them synchronized with the `CombatEngine`.
+- Replaces the old room-attached scripts used in earlier versions.
 
 ## CombatEngine
 


### PR DESCRIPTION
## Summary
- describe combat instances via unique IDs in docs
- mention combatant_to_combat map in README
- clean up legacy room combat code and docs

## Testing
- `pytest -q` *(fails: django.db errors and others)*

------
https://chatgpt.com/codex/tasks/task_e_684de62b05d0832cb4c51535ecaedfee