### PR TITLE
Refactor combat manager join logic

### DIFF
--- a/combat/round_manager.py
+++ b/combat/round_manager.py
@@ -306,6 +306,26 @@ class CombatRoundManager:
                 return inst
         return self.create_combat(combatants)
 
+    def add_combatant_to_combat(
+        self, combatant: object, instance: CombatInstance
+    ) -> CombatInstance:
+        """Add ``combatant`` to ``instance`` and return the combat instance."""
+
+        if combatant in instance.combatants:
+            return instance
+
+        current = self.get_combatant_combat(combatant)
+        if current:
+            return current
+
+        if instance.add_combatant(combatant):
+            self.combatant_to_combat[combatant] = instance.combat_id
+
+        if not self.running:
+            self.start_ticking()
+
+        return instance
+
     # ------------------------------------------------------------------
     # ticking logic
     # ------------------------------------------------------------------

--- a/typeclasses/tests/test_round_manager.py
+++ b/typeclasses/tests/test_round_manager.py
@@ -146,7 +146,7 @@ class TestCombatRoundManager(EvenniaTest):
     def test_force_end_all_combat(self):
         """Test that all combat can be force-ended."""
         with patch("combat.round_manager.delay"):
-            inst = self.manager.add_instance(self.room1)
+            inst = self.manager.start_combat([self.char1])
             self.assertTrue(self.manager.running)
             
             self.manager.force_end_all_combat()


### PR DESCRIPTION
## Summary
- add `add_combatant_to_combat` helper for joining an existing combat
- adjust round manager tests to use `start_combat`

## Testing
- `pytest -q` *(fails: django.db errors)*

------
https://chatgpt.com/codex/tasks/task_e_684de7ed97dc832c960f6af14e16c2d4