### PR TITLE
Add configurable combat tick delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,8 +424,8 @@ with VNUM-based NPCs.
 ### Combat Round Manager
 
 The `CombatRoundManager` singleton, found in `combat.round_manager`, manages all
-active combat encounters. It ticks every **2 seconds** by default (see
-`tick_delay` at line 214 of `combat/round_manager.py`). Call
+active combat encounters. It ticks every **2 seconds** by default (configurable
+via the `COMBAT_TICK_DELAY` setting and stored on the manager as `tick_delay`). Call
 `CombatRoundManager.get().start_combat([fighter1, fighter2])` to create a combat
 with those combatants. The manager stores each combat instance by a unique ID
 and uses the `combatant_to_combat` dictionary to map combatants back to their

--- a/combat/round_manager.py
+++ b/combat/round_manager.py
@@ -230,7 +230,8 @@ class CombatRoundManager:
         self.combats: Dict[int, CombatInstance] = {}
         self.combatant_to_combat: Dict[object, int] = {}
         self.running = False
-        self.tick_delay = 2.0
+        # Read delay from settings so combat pacing is configurable
+        self.tick_delay = getattr(settings, "COMBAT_TICK_DELAY", 2.0)
         self._next_tick_scheduled = False
         self._next_id = 1
 

--- a/server/conf/settings.py
+++ b/server/conf/settings.py
@@ -75,6 +75,8 @@ VNUM_REGISTRY_FILE = Path(GAME_DIR) / "world" / "vnum_registry.json"
 
 # Log each combat tick when set to True
 COMBAT_DEBUG_TICKS = False
+# Delay in seconds between combat manager ticks
+COMBAT_TICK_DELAY = 2.0
 
 # Clothing - https://www.evennia.com/docs/latest/Contribs/Contrib-Clothing.html#configuration
 CLOTHING_WEARSTYLE_MAXLENGTH = 40

--- a/typeclasses/tests/test_round_manager.py
+++ b/typeclasses/tests/test_round_manager.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 from evennia.utils.test_resources import EvenniaTest
+from django.conf import settings
 from combat.round_manager import CombatRoundManager, CombatInstance
 from combat.engine import CombatEngine
 
@@ -23,7 +24,7 @@ class TestCombatRoundManager(EvenniaTest):
         ):
             # Adding instance should schedule first tick
             self.manager.create_combat(combatants=[self.char1, self.char2])
-            mock_delay.assert_called_with(self.manager.tick_delay, self.manager._tick)
+            mock_delay.assert_called_with(settings.COMBAT_TICK_DELAY, self.manager._tick)
             
             # First tick should process round
             mock_proc.assert_called()
@@ -35,7 +36,7 @@ class TestCombatRoundManager(EvenniaTest):
             # Manual tick should process round and schedule next tick
             self.manager._tick()
             mock_proc.assert_called()
-            mock_delay.assert_called_with(self.manager.tick_delay, self.manager._tick)
+            mock_delay.assert_called_with(settings.COMBAT_TICK_DELAY, self.manager._tick)
 
     def test_initiative_order(self):
         """Test that initiative order is correctly maintained."""
@@ -108,7 +109,7 @@ class TestCombatRoundManager(EvenniaTest):
 
             self.assertIs(inst, inst2)
             mock_proc.assert_called_once()
-            mock_delay.assert_called_with(self.manager.tick_delay, self.manager._tick)
+            mock_delay.assert_called_with(settings.COMBAT_TICK_DELAY, self.manager._tick)
             self.assertTrue(self.manager.running)
 
     def test_remove_instance(self):


### PR DESCRIPTION
## Summary
- add `COMBAT_TICK_DELAY` setting with default 2 seconds
- read the setting in `CombatRoundManager`
- update tests to use `COMBAT_TICK_DELAY`
- note the setting in the README

## Testing
- `pytest -q` *(fails: `OperationalError: no such table: accounts_accountdb`)*

------
https://chatgpt.com/codex/tasks/task_e_684ded3a8000832ca6f84b908b9f13dd