### PR TITLE
Ensure combat ends during server shutdowns

### DIFF
--- a/server/conf/at_server_startstop.py
+++ b/server/conf/at_server_startstop.py
@@ -111,6 +111,8 @@ def at_server_stop():
     of it is for a reload, reset or shutdown.
     """
     logger.log_info("at_server_stop: cleaning up")
+    from combat.round_manager import CombatRoundManager
+    CombatRoundManager.get().force_end_all_combat()
     _clear_caches()
     ServerConfig.objects.conf("server_start_time", delete=True)
 
@@ -128,6 +130,8 @@ def at_server_reload_stop():
     This is called only time the server stops before a reload.
     """
     logger.log_info("at_server_reload_stop: reload complete")
+    from combat.round_manager import CombatRoundManager
+    CombatRoundManager.get().force_end_all_combat()
     ServerConfig.objects.conf("reload_started", delete=True)
 
 


### PR DESCRIPTION
## Summary
- halt ongoing combats before clearing caches during shutdown
- halt ongoing combats before clearing caches during reload

## Testing
- `pytest -q` *(fails: KeyboardInterrupt, multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_684df0073848832cb865a32049960bdf