### PR TITLE
Fix NPC target clearing on death

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -1140,6 +1140,10 @@ class NPC(Character):
             contributors = list(log.keys()) or ([attacker] if attacker else [])
             contributors = [c for c in contributors if c]
             award_xp(attacker, xp, contributors)
+
+        if attacker and getattr(attacker.db, "combat_target", None) is self:
+            attacker.db.combat_target = None
+
         self.delete()
 
     # property to mimic weapons


### PR DESCRIPTION
## Summary
- stop NPC targets from persisting after they die

## Testing
- `pytest -q` *(fails: django.db...)*

------
https://chatgpt.com/codex/tasks/task_e_684df23698dc832c9fc2bd122595ab1f