### PR TITLE
Fix builder autosave script reuse

### DIFF
--- a/commands/cmdmobbuilder.py
+++ b/commands/cmdmobbuilder.py
@@ -163,7 +163,7 @@ class CmdMobProto(Command):
                 caller.ndb.mob_vnum = caller.ndb.buildnpc.get("vnum")
                 caller.ndb.buildnpc_orig = dict(caller.ndb.buildnpc)
                 caller.db.builder_autosave = None
-                caller.scripts.add(BuilderAutosave, key="builder_autosave")
+                npc_builder._ensure_autosave_script(caller)
                 startnode = (
                     "menunode_desc" if caller.ndb.buildnpc.get("key") else "menunode_key"
                 )
@@ -191,7 +191,7 @@ class CmdMobProto(Command):
         caller.ndb.buildnpc = dict(proto)
         caller.ndb.buildnpc_orig = dict(caller.ndb.buildnpc)
         caller.ndb.mob_vnum = vnum
-        caller.scripts.add(BuilderAutosave, key="builder_autosave")
+        npc_builder._ensure_autosave_script(caller)
         startnode = "menunode_desc" if caller.ndb.buildnpc.get("key") else "menunode_key"
         EvMenu(
             caller,

--- a/typeclasses/tests/test_builder_autosave.py
+++ b/typeclasses/tests/test_builder_autosave.py
@@ -44,3 +44,39 @@ class TestBuilderAutosave(EvenniaTest):
         self.assertEqual(self.char1.ndb.buildnpc["desc"], "An orc")
         self.assertIsNone(self.char1.db.builder_autosave)
 
+    def test_autosave_script_single_cnpc(self):
+        with patch("commands.npc_builder.EvMenu"):
+            self.char1.execute_cmd("mobbuilder start goblin")
+        self.assertEqual(len(self.char1.scripts.get("builder_autosave")), 1)
+        scr = self.char1.scripts.get("builder_autosave")[0]
+        scr.at_repeat()
+        self.char1.ndb.buildnpc = None
+        with patch("commands.npc_builder.EvMenu"):
+            self.char1.execute_cmd("cnpc restore")
+        self.assertEqual(len(self.char1.scripts.get("builder_autosave")), 1)
+        scr = self.char1.scripts.get("builder_autosave")[0]
+        scr.at_repeat()
+        self.char1.ndb.buildnpc = None
+        with patch("commands.npc_builder.EvMenu"):
+            self.char1.execute_cmd("cnpc restore")
+        self.assertEqual(len(self.char1.scripts.get("builder_autosave")), 1)
+
+    def test_autosave_script_single_mobproto(self):
+        from utils.mob_proto import register_prototype
+        register_prototype({"key": "orc"}, vnum=2)
+        with patch("commands.npc_builder.EvMenu"):
+            self.char1.execute_cmd("@mobproto edit 2")
+        self.assertEqual(len(self.char1.scripts.get("builder_autosave")), 1)
+        scr = self.char1.scripts.get("builder_autosave")[0]
+        scr.at_repeat()
+        self.char1.ndb.buildnpc = None
+        with patch("commands.npc_builder.EvMenu"):
+            self.char1.execute_cmd("@mobproto edit restore")
+        self.assertEqual(len(self.char1.scripts.get("builder_autosave")), 1)
+        scr = self.char1.scripts.get("builder_autosave")[0]
+        scr.at_repeat()
+        self.char1.ndb.buildnpc = None
+        with patch("commands.npc_builder.EvMenu"):
+            self.char1.execute_cmd("@mobproto edit restore")
+        self.assertEqual(len(self.char1.scripts.get("builder_autosave")), 1)
+


### PR DESCRIPTION
## Summary
- prevent duplicate BuilderAutosave scripts by cleaning up before starting
- delete autosave script on cancel or menu exit
- update mob prototype command to reuse autosave script
- test that only one autosave script exists after multiple restores

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684df39f36b8832c9782bf59b66340d2