### PR TITLE
Add debug flag for damage summary

### DIFF
--- a/combat/engine/damage_processor.py
+++ b/combat/engine/damage_processor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Dict, List
 from evennia.utils import delay
+from django.conf import settings
 
 from .common import CombatParticipant, _current_hp
 from ..combat_utils import format_combat_message
@@ -190,6 +191,9 @@ class DamageProcessor:
                 self.handle_defeat(result.target, actor)
 
     def _summarize_damage(self, damage_totals: Dict[object, int]) -> None:
+        if not getattr(settings, "COMBAT_DEBUG_SUMMARY", False):
+            return
+
         summary_lines = [
             f"{getattr(att, 'key', att)} dealt {dmg} damage."
             for att, dmg in damage_totals.items()

--- a/server/conf/settings.py
+++ b/server/conf/settings.py
@@ -75,6 +75,8 @@ VNUM_REGISTRY_FILE = Path(GAME_DIR) / "world" / "vnum_registry.json"
 
 # Log each combat tick when set to True
 COMBAT_DEBUG_TICKS = False
+# When True, include a damage summary at the end of each combat round
+COMBAT_DEBUG_SUMMARY = False
 
 # Clothing - https://www.evennia.com/docs/latest/Contribs/Contrib-Clothing.html#configuration
 CLOTHING_WEARSTYLE_MAXLENGTH = 40

--- a/typeclasses/tests/test_combat_engine.py
+++ b/typeclasses/tests/test_combat_engine.py
@@ -8,6 +8,7 @@ from utils.currency import from_copper, to_copper
 from combat.combat_utils import get_condition_msg
 from commands import npc_builder
 from django.conf import settings
+from django.test import override_settings
 
 
 class KillAction(Action):
@@ -219,6 +220,7 @@ class TestCombatEngine(unittest.TestCase):
             self.assertTrue(any(f"The {b.key} {expected}" in msg for msg in calls))
             room.reset_mock()
 
+    @override_settings(COMBAT_DEBUG_SUMMARY=True)
     def test_damage_summary_broadcast(self):
         class DamageAction(Action):
             def resolve(self):


### PR DESCRIPTION
## Summary
- toggle round damage summaries with `COMBAT_DEBUG_SUMMARY`
- disable summaries by default
- update combat engine test for new setting

## Testing
- `pytest -q` *(fails: OperationalError - no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684df5904d48832c9583583183e555fe