### PR TITLE
Fix crash when attacking a dead target

### DIFF
--- a/commands/combat.py
+++ b/commands/combat.py
@@ -93,6 +93,10 @@ class CmdAttack(Command):
                 self.msg("You can't fight right now.")
             return
 
+        if getattr(target, "pk", None) is None:
+            self.msg(f"{target.get_display_name(self.caller)} is already dead.")
+            return
+
         self.caller.db.combat_target = target
         target.db.combat_target = self.caller
 

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -1273,6 +1273,8 @@ class NPC(Character):
 
         manager = CombatRoundManager.get()
         instance = manager.start_combat([self, target])
+        if getattr(target, "pk", None) is None:
+            return
         self.db.combat_target = target
         if self not in instance.combatants:
             return


### PR DESCRIPTION
## Summary
- avoid storing deleted objects as combat targets
- check for deleted targets when NPCs enter combat

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_684dfa9f2718832cba1ba8010e3a8c2b