### PR TITLE
Fix unarmed NPC attacks

### DIFF
--- a/combat/combat_actions.py
+++ b/combat/combat_actions.py
@@ -126,7 +126,9 @@ class AttackAction(Action):
                 # Use natural weapon stats when unarmed
                 weapon = self.actor.db.natural_weapon
             else:
-                weapon = self.actor
+                from typeclasses.gear import BareHand
+                # Default to bare hands if no natural weapon is defined
+                weapon = BareHand()
 
         logger.debug("AttackAction weapon=%s", getattr(weapon, "key", weapon))
 


### PR DESCRIPTION
## Summary
- handle missing weapons by falling back to BareHand in AttackAction

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684dfbd4d484832c881136c6edbec92b