### PR TITLE
Remove combat damage summaries

### DIFF
--- a/combat/engine/damage_processor.py
+++ b/combat/engine/damage_processor.py
@@ -12,7 +12,6 @@ from .turn_manager import TurnManager
 from .aggro_tracker import AggroTracker
 from ..damage_types import DamageType
 from world.system import state_manager
-from world.combat import get_health_description
 
 
 class DamageProcessor:
@@ -177,10 +176,6 @@ class DamageProcessor:
             if not result.message:
                 self.dam_message(actor, result.target, damage_done)
             damage_totals[actor] = damage_totals.get(actor, 0) + damage_done
-
-        if result.target:
-            cond = get_health_description(result.target)
-            self.round_output.append(f"The {result.target.key} {cond}")
 
         if actor.location and result.message:
             actor.location.msg_contents(result.message)

--- a/typeclasses/gear.py
+++ b/typeclasses/gear.py
@@ -77,9 +77,6 @@ class BareHand:
             )
             dealt = target.at_damage(wielder, damage, "bludgeon", critical=crit)
             combat_utils.apply_lifesteal(wielder, dealt)
-            condition = get_health_description(target)
-            if wielder.location:
-                wielder.location.msg_contents(f"The {target.key} {condition}")
             if status := getattr(self, "status_effect", None):
                 effect, chance = status
                 if stat_manager.roll_status(wielder, target, int(chance)):
@@ -196,9 +193,6 @@ class MeleeWeapon(Object):
             )
             dealt = target.at_damage(wielder, damage, damage_type, critical=crit)
             combat_utils.apply_lifesteal(wielder, dealt)
-            condition = get_health_description(target)
-            if wielder.location:
-                wielder.location.msg_contents(f"The {target.key} {condition}")
             if status := getattr(self.db, "status_effect", None):
                 effect, chance = status
                 if stat_manager.roll_status(wielder, target, int(chance)):

--- a/typeclasses/tests/test_attack_condition_messages.py
+++ b/typeclasses/tests/test_attack_condition_messages.py
@@ -21,12 +21,12 @@ class TestAttackConditionMessages(EvenniaTest):
         target.traits.health.current -= amount
         return amount
 
-    def _expect_condition_message(self, target):
+    def _expect_no_condition_message(self, target):
         expected = get_condition_msg(
             target.traits.health.current, target.traits.health.max
         )
         calls = [c.args[0] for c in self.room1.msg_contents.call_args_list]
-        self.assertTrue(any(f"The {target.key} {expected}" in msg for msg in calls))
+        self.assertFalse(any(f"The {target.key} {expected}" in msg for msg in calls))
 
     def test_barehand_condition(self):
         self.char2.at_damage = self._simple_damage
@@ -42,7 +42,7 @@ class TestAttackConditionMessages(EvenniaTest):
         ), patch("combat.combat_utils.apply_lifesteal"):
             BareHand().at_attack(self.char1, self.char2)
 
-        self._expect_condition_message(self.char2)
+        self._expect_no_condition_message(self.char2)
 
     def test_melee_weapon_condition(self):
         weapon = create.create_object(
@@ -65,5 +65,5 @@ class TestAttackConditionMessages(EvenniaTest):
         ), patch("combat.combat_utils.apply_lifesteal"):
             weapon.at_attack(self.char1, self.char2)
 
-        self._expect_condition_message(self.char2)
+        self._expect_no_condition_message(self.char2)
 

--- a/typeclasses/tests/test_combat_engine.py
+++ b/typeclasses/tests/test_combat_engine.py
@@ -217,7 +217,7 @@ class TestCombatEngine(unittest.TestCase):
 
             expected = get_condition_msg(b.hp, b.traits.health.max)
             calls = [c.args[0] for c in room.msg_contents.call_args_list]
-            self.assertTrue(any(f"The {b.key} {expected}" in msg for msg in calls))
+            self.assertFalse(any(f"The {b.key} {expected}" in msg for msg in calls))
             room.reset_mock()
 
     @override_settings(COMBAT_DEBUG_SUMMARY=True)


### PR DESCRIPTION
## Summary
- stop broadcasting condition messages after each attack
- update tests for removed combat messages

## Testing
- `pytest -q` *(fails: 80 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_684dfddffe9c832ca97d3ca8ad97a85a