### PR TITLE
Add damage color scaling and report commands

### DIFF
--- a/combat/combat_utils.py
+++ b/combat/combat_utils.py
@@ -186,18 +186,30 @@ def format_combat_message(
     crit: bool = False,
     miss: bool = False,
 ) -> str:
-    """Return a standardized combat log message."""
+    """Return a standardized combat log message with color coding."""
 
     a_name = getattr(actor, "key", str(actor))
     t_name = getattr(target, "key", str(target))
+
     if miss:
-        return f"{a_name}'s {action} misses {t_name}!"
-    parts = [f"{a_name} {action} {t_name}"]
+        return f"|C{a_name}'s {action} misses {t_name}!|n"
+
     if damage is not None:
-        parts.append(f"for {damage} damage")
-    if crit:
-        parts.append("(critical)")
-    return " ".join(parts) + "!"
+        if damage >= 50:
+            color = "|R"  # bright red for massive damage
+        elif damage >= 25:
+            color = "|r"  # red for heavy damage
+        elif damage >= 10:
+            color = "|y"  # yellow for moderate damage
+        elif damage > 0:
+            color = "|g"  # green for low damage
+        else:
+            color = "|w"  # white for 0
+
+        crit_text = " (critical)" if crit else ""
+        return f"{color}{a_name} {action} {t_name} for {damage} damage{crit_text}!|n"
+
+    return f"{a_name} {action} {t_name}!"
 
 
 def get_condition_msg(hp: int, max_hp: int) -> str:

--- a/commands/admin.py
+++ b/commands/admin.py
@@ -457,6 +457,41 @@ class CmdPeace(Command):
         location.msg_contents("Peace falls over the area.")
 
 
+class CmdForceMobReport(Command):
+    """Force a target to broadcast their HP/MP/SP."""
+
+    key = "force mob report"
+    locks = "cmd:perm(Admin)"
+    help_category = "Admin"
+
+    def func(self):
+        if not self.args:
+            self.msg("Usage: force mob report <target>")
+            return
+
+        target = self.caller.search(self.args.strip())
+        if not target:
+            return
+
+        traits = getattr(target, "traits", None)
+        if not traits:
+            self.msg(f"{target.key} has no trait system.")
+            return
+
+        hp = traits.get("health")
+        mp = traits.get("mana")
+        sp = traits.get("stamina")
+
+        values = [
+            f"|rHP|n: {hp.current}/{hp.max}" if hp else "No HP",
+            f"|bMP|n: {mp.current}/{mp.max}" if mp else "No MP",
+            f"|gSP|n: {sp.current}/{sp.max}" if sp else "No SP",
+        ]
+        self.caller.location.msg_contents(
+            f"|Y{target.key} status:|n {'  '.join(values)}"
+        )
+
+
 def _create_gear(
     caller,
     typeclass,
@@ -1360,6 +1395,7 @@ class AdminCmdSet(CmdSet):
         self.add(CmdRestoreAll)
         self.add(CmdPurge)
         self.add(CmdPeace)
+        self.add(CmdForceMobReport)
         self.add(CmdScan)
 
 

--- a/commands/info.py
+++ b/commands/info.py
@@ -765,6 +765,22 @@ class CmdPrompt(Command):
         caller.refresh_prompt()
 
 
+class CmdReport(Command):
+    """Broadcast your status to the room."""
+
+    key = "report"
+    help_category = "General"
+
+    def func(self):
+        prompt = self.caller.get_display_status(self.caller)
+        location = self.caller.location
+        if location:
+            location.msg_contents(
+                f"{self.caller.key} reports:\n{prompt}", exclude=self.caller
+            )
+        self.caller.msg("|gYou report your current status.|n")
+
+
 class CmdScan(Command):
     """
     Look around and into adjacent rooms.
@@ -863,4 +879,5 @@ class InfoCmdSet(CmdSet):
         self.add(CmdBuffs)
         self.add(CmdTitle)
         self.add(CmdPrompt)
+        self.add(CmdReport)
         self.add(CmdScan)

--- a/typeclasses/tests/test_admin_commands.py
+++ b/typeclasses/tests/test_admin_commands.py
@@ -539,3 +539,15 @@ class TestAdminCommands(EvenniaTest):
         from combat.round_manager import CombatRoundManager
         self.assertFalse(CombatRoundManager.get().combats)
 
+    def test_force_mob_report(self):
+        from commands.admin import CmdForceMobReport
+
+        cmd = CmdForceMobReport()
+        cmd.caller = self.char1
+        cmd.args = self.char2.key
+        self.room1.msg_contents = MagicMock()
+        cmd.func()
+        output = self.room1.msg_contents.call_args[0][0]
+        self.assertIn(self.char2.key, output)
+        self.assertIn("HP", output)
+

--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -931,3 +931,18 @@ class TestFlagCommands(EvenniaTest):
         self.assertTrue(self.obj1.tags.has("equipment", category="flag"))
         self.char1.execute_cmd(f"removeflag {self.obj1.key} equipment")
         self.assertFalse(self.obj1.tags.has("equipment", category="flag"))
+
+
+class TestReportCommand(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.char1.msg = MagicMock()
+        self.room1.msg_contents = MagicMock()
+
+    def test_report_broadcasts_status(self):
+        prompt = self.char1.get_display_status(self.char1)
+        self.char1.execute_cmd("report")
+        self.room1.msg_contents.assert_called_with(
+            f"{self.char1.key} reports:\n{prompt}", exclude=self.char1
+        )
+        self.char1.msg.assert_any_call("|gYou report your current status.|n")

--- a/utils/tests/test_combat_utils.py
+++ b/utils/tests/test_combat_utils.py
@@ -97,6 +97,24 @@ class TestCombatUtils(EvenniaTest):
         self.assertIn("5", msg)
         self.assertIn("critical", msg)
 
+    def test_format_combat_message_colors(self):
+        from combat import combat_utils
+
+        levels = [
+            (60, "|R"),
+            (30, "|r"),
+            (15, "|y"),
+            (5, "|g"),
+            (0, "|w"),
+        ]
+        for dmg, code in levels:
+            msg = combat_utils.format_combat_message(
+                self.char1, self.char2, "hits", damage=dmg
+            )
+            self.assertTrue(msg.startswith(code))
+            self.assertIn(str(dmg), msg)
+            self.assertTrue(msg.endswith("|n"))
+
     def test_get_condition_msg(self):
         from combat.combat_utils import get_condition_msg
 


### PR DESCRIPTION
## Summary
- colorize combat damage by severity
- add `report` command for players
- support `force mob report` for admins
- test damage color ranges and new commands

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684e030e2b24832ca883f1763a57be15