### PR TITLE
Refactor combat message color logic

### DIFF
--- a/combat/combat_utils.py
+++ b/combat/combat_utils.py
@@ -195,19 +195,25 @@ def format_combat_message(
         return f"|C{a_name}'s {action} misses {t_name}!|n"
 
     if damage is not None:
-        if damage >= 50:
-            color = "|R"  # bright red for massive damage
-        elif damage >= 25:
-            color = "|r"  # red for heavy damage
-        elif damage >= 10:
-            color = "|y"  # yellow for moderate damage
-        elif damage > 0:
-            color = "|g"  # green for low damage
-        else:
-            color = "|w"  # white for 0
+        max_range = state_manager.get_effective_stat(actor, "attack_power")
+        if not max_range:
+            level = getattr(getattr(actor, "db", None), "level", 0) or 0
+            max_range = level * 5
+        max_range = max(max_range, 1)
 
-        crit_text = " (critical)" if crit else ""
-        return f"{color}{a_name} {action} {t_name} for {damage} damage{crit_text}!|n"
+        if damage >= 0.9 * max_range:
+            color = "|R"
+        elif damage >= 0.6 * max_range:
+            color = "|r"
+        elif damage >= 0.3 * max_range:
+            color = "|y"
+        elif damage > 0:
+            color = "|g"
+        else:
+            color = "|w"
+
+        crit_text = " |y(critical)|n" if crit else ""
+        return f"{a_name} {action} {t_name} for {color}{damage}|n damage{crit_text}"
 
     return f"{a_name} {action} {t_name}!"
 

--- a/utils/tests/test_combat_utils.py
+++ b/utils/tests/test_combat_utils.py
@@ -100,20 +100,23 @@ class TestCombatUtils(EvenniaTest):
     def test_format_combat_message_colors(self):
         from combat import combat_utils
 
-        levels = [
-            (60, "|R"),
-            (30, "|r"),
-            (15, "|y"),
-            (5, "|g"),
-            (0, "|w"),
-        ]
-        for dmg, code in levels:
-            msg = combat_utils.format_combat_message(
-                self.char1, self.char2, "hits", damage=dmg
-            )
-            self.assertTrue(msg.startswith(code))
-            self.assertIn(str(dmg), msg)
-            self.assertTrue(msg.endswith("|n"))
+        self.char1.db.level = 20
+        with patch("world.system.state_manager.get_effective_stat", return_value=0):
+            max_range = self.char1.db.level * 5
+            levels = [
+                (int(max_range * 0.95), "|R"),
+                (int(max_range * 0.65), "|r"),
+                (int(max_range * 0.35), "|y"),
+                (1, "|g"),
+                (0, "|w"),
+            ]
+            for dmg, code in levels:
+                msg = combat_utils.format_combat_message(
+                    self.char1, self.char2, "hits", damage=dmg
+                )
+                self.assertIn(f"{code}{dmg}|n", msg)
+                self.assertTrue(msg.startswith("Attacker"))
+                self.assertIn("damage", msg)
 
     def test_get_condition_msg(self):
         from combat.combat_utils import get_condition_msg


### PR DESCRIPTION
## Summary
- enhance `format_combat_message` with stat-based ranges
- color only the damage numbers in combat log
- fix unit tests to use the new dynamic thresholds

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684e0a18f928832c912f9f90bb4727ae