### PR TITLE
Colorize XP and loot messages

### DIFF
--- a/combat/combat_utils.py
+++ b/combat/combat_utils.py
@@ -33,7 +33,7 @@ def award_xp(killer, total_xp: int, participants: Iterable | None = None) -> Non
     share = max(int(total_xp / len(members)), int(total_xp * 0.10))
     for member in members:
         if hasattr(member, "msg"):
-            member.msg(f"You gain {share} experience points!")
+            member.msg(f"You gain |Y{share}|n experience points!")
         state_manager.gain_xp(member, share)
 
 

--- a/combat/engine/damage_processor.py
+++ b/combat/engine/damage_processor.py
@@ -64,7 +64,7 @@ class DamageProcessor:
         if not exp or not chara:
             return
         if hasattr(chara, "msg"):
-            chara.msg(f"You gain {exp} experience.")
+            chara.msg(f"You gain |Y{exp}|n experience points.")
         state_manager.gain_xp(chara, exp)
 
     def group_gain(self, members: List[object], exp: int) -> None:
@@ -74,7 +74,7 @@ class DamageProcessor:
         share = max(int(exp / len(members)), int(exp * 0.10))
         for member in members:
             if hasattr(member, "msg"):
-                member.msg(f"You gain {share} experience.")
+                member.msg(f"You gain |Y{share}|n experience points.")
             state_manager.gain_xp(member, share)
 
     def apply_damage(self, attacker, target, amount: int, damage_type: DamageType | None) -> int:

--- a/commands/quests.py
+++ b/commands/quests.py
@@ -445,7 +445,7 @@ class CmdCompleteQuest(Command):
 
         title = quest.title or quest_key
         if rewards:
-            self.msg(f"Quest '{title}' completed! You receive: {', '.join(rewards)}.")
+            self.msg(f"Quest '{title}' completed! You receive |Y{', '.join(rewards)}|n.")
         else:
             self.msg(f"Quest '{title}' completed!")
         if quest.complete_dialogue:

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -1066,7 +1066,8 @@ class NPC(Character):
                 wallet = killer.db.coins or {}
                 killer.db.coins = from_copper(to_copper(wallet) + total_copper)
                 if hasattr(killer, "msg"):
-                    killer.msg(f"You receive {format_wallet(from_copper(total_copper))}.")
+                    coins = format_wallet(from_copper(total_copper))
+                    killer.msg(f"You receive |Y{coins}|n.")
             else:
                 for coin, amt in from_copper(total_copper).items():
                     if amt:
@@ -1090,7 +1091,7 @@ class NPC(Character):
         if not attacker or not exp:
             return
         if hasattr(attacker, "msg"):
-            attacker.msg(f"You gain {exp} experience.")
+            attacker.msg(f"You gain |Y{exp}|n experience points.")
         state_manager.gain_xp(attacker, exp)
 
     def on_death(self, attacker):

--- a/typeclasses/objects.py
+++ b/typeclasses/objects.py
@@ -412,7 +412,7 @@ class CoinPile(Object):
             wallet[ctype] = int(wallet.get(ctype, 0)) + int(self.db.amount or 0)
             dest.db.coins = wallet
             dest.msg(
-                f"You receive {self.db.amount} {ctype} coin{'s' if int(self.db.amount or 0) != 1 else ''}."
+                f"You receive |Y{self.db.amount} {ctype} coin{'s' if int(self.db.amount or 0) != 1 else ''}|n."
             )
             self.db.from_pouch = False
             # when picked up via `get`, Evennia will call `at_get` after this

--- a/typeclasses/tests/test_coin_pouch.py
+++ b/typeclasses/tests/test_coin_pouch.py
@@ -29,7 +29,7 @@ class TestCoinPouchCoins(EvenniaTest):
 
         self.assertEqual(to_copper(self.char1.db.coins), 20)
         self.assertIsNone(coin.pk)
-        self.char1.msg.assert_any_call("You receive 5 copper coins.")
+        self.char1.msg.assert_any_call("You receive |Y5 copper coins|n.")
 
     def test_give_coins_auto_deposit(self):
         self.char1.db.coins = from_copper(10)
@@ -48,7 +48,7 @@ class TestCoinPouchCoins(EvenniaTest):
         ]
         self.assertFalse(piles)
 
-        self.char2.msg.assert_any_call("You receive 5 copper coins.")
+        self.char2.msg.assert_any_call("You receive |Y5 copper coins|n.")
 
     def test_getall_auto_deposit(self):
         self.char1.db.coins = from_copper(30)
@@ -65,5 +65,5 @@ class TestCoinPouchCoins(EvenniaTest):
 
         self.assertEqual(to_copper(self.char1.db.coins), 30)
         self.assertIsNone(coin.pk)
-        self.char1.msg.assert_any_call("You receive 10 copper coins.")
+        self.char1.msg.assert_any_call("You receive |Y10 copper coins|n.")
 


### PR DESCRIPTION
## Summary
- highlight XP awards in combat utils and combat engine
- colorize NPC XP awards and loot notifications
- improve quest reward formatting
- adjust CoinPile messages and tests for colorized output

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684e0bdd36ac832c9a76a5dcba677072