### PR TITLE
Improve combat defeat handling

### DIFF
--- a/combat/round_manager.py
+++ b/combat/round_manager.py
@@ -104,6 +104,7 @@ class CombatInstance:
                         actor.db.in_combat = False
                     if hasattr(self.engine, "remove_participant"):
                         self.engine.remove_participant(actor)
+                    self.combatants.discard(actor)
         
         # Handle legacy fighter-based engines
         elif hasattr(self.engine, "fighters"):
@@ -114,6 +115,7 @@ class CombatInstance:
 
                 if _current_hp(fighter) <= 0:
                     fighter.db.in_combat = False
+                    self.combatants.discard(fighter)
                     continue
 
                 if not getattr(fighter, "in_combat", False):

--- a/world/tests/test_combat_engine_minimal.py
+++ b/world/tests/test_combat_engine_minimal.py
@@ -84,6 +84,21 @@ class TestCombatEngineMinimal(unittest.TestCase):
         self.assertNotIn(defender, participants)
         defender.on_exit_combat.assert_called()
 
+    def test_action_skipped_if_target_dead(self):
+        attacker = Dummy(key="attacker")
+        defender = Dummy(hp=0, key="defender")
+        room = MagicMock()
+        attacker.location = defender.location = room
+        engine = CombatEngine([attacker, defender], round_time=0)
+        engine.queue_action(attacker, DamageAction(attacker, defender))
+        with patch("world.system.state_manager.apply_regen"), patch(
+            "combat.engine.damage_processor.delay"
+        ), patch("random.randint", return_value=0):
+            engine.start_round()
+            engine.process_round()
+
+        room.msg_contents.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- clear combat refs on defeat
- skip actions against defeated targets
- drop dead combatants in sync
- regression test for dead-target actions

## Testing
- `python -m pytest world/tests/test_combat_engine_minimal.py::TestCombatEngineMinimal::test_action_skipped_if_target_dead -q -s`

------
https://chatgpt.com/codex/tasks/task_e_684e0d301f94832c8a6ace9419855a0b