### PR TITLE
Add basic ability system

### DIFF
--- a/world/abilities/__init__.py
+++ b/world/abilities/__init__.py
@@ -1,0 +1,10 @@
+"""Ability registry and convenience imports."""
+
+from .base import Ability
+from .bash import Bash
+
+ABILITY_REGISTRY = {
+    Bash.name: Bash,
+}
+
+__all__ = ["Ability", "Bash", "ABILITY_REGISTRY"]

--- a/world/abilities/base.py
+++ b/world/abilities/base.py
@@ -1,0 +1,20 @@
+from dataclasses import dataclass
+from typing import Any
+
+@dataclass
+class Ability:
+    """Base class for character abilities."""
+
+    name: str = ""
+    level_required: int = 0
+    cooldown: int = 0
+    cost: int = 0
+    description: str = ""
+
+    def apply(self, user: Any, target: Any) -> Any:
+        """Apply this ability's effect."""
+        raise NotImplementedError
+
+    def calculate_power(self, user: Any) -> int:
+        """Return the power of this ability based on ``user``."""
+        return 0

--- a/world/abilities/bash.py
+++ b/world/abilities/bash.py
@@ -1,0 +1,23 @@
+"""Example ability implementation."""
+
+from typing import Any
+
+from .base import Ability
+
+
+class Bash(Ability):
+    """Simple melee ability used for demonstration."""
+
+    name = "bash"
+    level_required = 1
+    cooldown = 5
+    cost = 10
+    description = "Strike the target with a heavy bash."
+
+    def apply(self, user: Any, target: Any) -> str:
+        """Apply the bash effect to ``target``."""
+        return f"{getattr(user, 'key', user)} bashes {getattr(target, 'key', target)}!"
+
+    def calculate_power(self, user: Any) -> int:
+        """Damage is based on the user's level by default."""
+        return getattr(user, "level", 1)


### PR DESCRIPTION
## Summary
- add `Ability` base class with core attributes
- implement a sample `Bash` ability
- maintain a simple registry of abilities

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684e8d0d51f0832c86243d4302652e59