### PR TITLE
Add CLASS_ABILITY_TABLE with starting unlocks

### DIFF
--- a/world/abilities/__init__.py
+++ b/world/abilities/__init__.py
@@ -2,9 +2,10 @@
 
 from .base import Ability
 from .bash import Bash
+from .ability_table import CLASS_ABILITY_TABLE
 
 ABILITY_REGISTRY = {
     Bash.name: Bash,
 }
 
-__all__ = ["Ability", "Bash", "ABILITY_REGISTRY"]
+__all__ = ["Ability", "Bash", "ABILITY_REGISTRY", "CLASS_ABILITY_TABLE"]

--- a/world/abilities/ability_table.py
+++ b/world/abilities/ability_table.py
@@ -1,0 +1,24 @@
+"""Default unlocked abilities for each combat class."""
+
+# Mapping: class name -> {level: [abilities]}
+CLASS_ABILITY_TABLE = {
+    "Warrior": {1: ["slash"]},
+    "Mystic": {1: ["slash"]},
+    "Wizard": {1: ["fireball"]},
+    "Sorcerer": {1: ["fireball"]},
+    "Mage": {1: ["fireball"]},
+    "Battlemage": {1: ["slash", "fireball"]},
+    "Necromancer": {1: ["fireball"]},
+    "Spellbinder": {1: ["fireball"]},
+    "Priest": {1: ["heal"]},
+    "Paladin": {1: ["slash", "heal"]},
+    "Druid": {1: ["heal"]},
+    "Shaman": {1: ["fireball", "heal"]},
+    "Rogue": {1: ["slash"]},
+    "Ranger": {1: ["slash"]},
+    "Warlock": {1: ["fireball"]},
+    "Bard": {1: ["slash", "heal"]},
+    "Swashbuckler": {1: ["slash"]},
+}
+
+__all__ = ["CLASS_ABILITY_TABLE"]


### PR DESCRIPTION
## Summary
- define the `CLASS_ABILITY_TABLE` mapping classes to unlocked abilities
- expose the table through `world.abilities`

## Testing
- `pytest -q` *(fails: django.db OperationalError)*

------
https://chatgpt.com/codex/tasks/task_e_684e8e6db1c8832cbdb45c343d0f063c