### PR TITLE
Add proficiency manager

### DIFF
--- a/world/system/__init__.py
+++ b/world/system/__init__.py
@@ -3,5 +3,6 @@
 from . import state_manager
 from . import stat_manager
 from . import constants
+from . import proficiency_manager
 
-__all__ = ["state_manager", "stat_manager", "constants"]
+__all__ = ["state_manager", "stat_manager", "constants", "proficiency_manager"]

--- a/world/system/proficiency_manager.py
+++ b/world/system/proficiency_manager.py
@@ -1,0 +1,77 @@
+"""Helper utilities for tracking skill and spell proficiency."""
+
+from __future__ import annotations
+
+from typing import Any, Tuple
+
+from . import state_manager
+
+# Maximum proficiency attainable via practice and overall cap
+PRACTICE_CAP = 75
+USE_CAP = 100
+
+__all__ = ["PRACTICE_CAP", "USE_CAP", "practice", "record_use", "scaling_bonus"]
+
+
+def scaling_bonus(chara) -> int:
+    """Return bonus proficiency gain based on INT/WIS/LUCK."""
+    int_stat = state_manager.get_effective_stat(chara, "INT")
+    wis_stat = state_manager.get_effective_stat(chara, "WIS")
+    luck_stat = state_manager.get_effective_stat(chara, "LUCK")
+    return int((int_stat + wis_stat + luck_stat) / 300)
+
+
+def _get_prof(obj: Any) -> int:
+    return int(getattr(obj, "proficiency", 0))
+
+
+def _set_prof(obj: Any, value: int) -> None:
+    setattr(obj, "proficiency", int(value))
+
+
+def practice(chara, prof_obj: Any, sessions: int = 1) -> Tuple[int, int]:
+    """Spend practice sessions to raise ``prof_obj`` proficiency.
+
+    Args:
+        chara: Character using practice sessions.
+        prof_obj: Object with a ``proficiency`` attribute.
+        sessions: Number of sessions to spend.
+
+    Returns:
+        tuple: ``(spent, new_proficiency)``
+    """
+
+    if prof_obj is None:
+        return 0, 0
+
+    prof = _get_prof(prof_obj)
+    spent = 0
+    while spent < sessions and chara.db.practice_sessions > 0 and prof < PRACTICE_CAP:
+        prof = 25 if prof == 0 else min(PRACTICE_CAP, prof + 25)
+        chara.db.practice_sessions -= 1
+        spent += 1
+    _set_prof(prof_obj, prof)
+    return spent, prof
+
+
+def record_use(chara, prof_obj: Any) -> int:
+    """Record usage of ``prof_obj`` and raise proficiency.
+
+    Args:
+        chara: Character using the skill or spell.
+        prof_obj: Object with a ``proficiency`` attribute.
+
+    Returns:
+        int: New proficiency value.
+    """
+
+    if prof_obj is None:
+        return 0
+
+    prof = _get_prof(prof_obj)
+    if prof >= USE_CAP:
+        return prof
+    gain = 1 + scaling_bonus(chara)
+    prof = min(USE_CAP, prof + gain)
+    _set_prof(prof_obj, prof)
+    return prof


### PR DESCRIPTION
## Summary
- add proficiency manager for skills and spells
- update characters and rooms to use proficiency manager
- integrate practice and usage tracking

## Testing
- `black world/system/proficiency_manager.py world/system/__init__.py typeclasses/characters.py typeclasses/rooms.py commands/spells.py`
- `pytest -q` *(fails: django.db.*)


------
https://chatgpt.com/codex/tasks/task_e_684e8fe99280832c8624607893499ce6