### PR TITLE
Add player ability commands

### DIFF
--- a/commands/abilities.py
+++ b/commands/abilities.py
@@ -1,0 +1,115 @@
+from evennia import CmdSet
+from evennia.utils.evtable import EvTable
+
+from .command import Command
+from world.system import proficiency_manager
+from combat.combat_skills import SKILL_CLASSES
+from combat.round_manager import CombatRoundManager
+from combat.combat_actions import SkillAction
+
+
+class CmdSkills(Command):
+    """List known combat abilities and their proficiency."""
+
+    key = "skills"
+
+    def func(self):
+        caller = self.caller
+        skills = caller.db.skills or []
+        if not skills:
+            self.msg("You do not know any abilities.")
+            return
+        table = EvTable("Ability", "Proficiency")
+        for sk in skills:
+            trait = caller.traits.get(sk)
+            prof = getattr(trait, "proficiency", 0)
+            table.add_row(sk, f"{prof}%")
+        self.msg(str(table))
+
+
+class CmdPractice(Command):
+    """Spend one practice session to improve an ability."""
+
+    key = "practice"
+
+    def func(self):
+        caller = self.caller
+        if not self.args:
+            self.msg("Practice what?")
+            return
+        ability = self.args.strip().lower()
+        if ability not in (caller.db.skills or []):
+            self.msg("You do not know that ability.")
+            return
+        trait = caller.traits.get(ability)
+        if not trait:
+            self.msg("You do not know that ability.")
+            return
+        spent, prof = proficiency_manager.practice(caller, trait)
+        if not spent:
+            self.msg("You have no practice sessions left.")
+            return
+        self.msg(f"You practice your {ability} and reach {prof}% proficiency.")
+
+
+class CmdUse(Command):
+    """Queue a combat ability to use."""
+
+    key = "use"
+    help_category = "Combat"
+
+    def parse(self):
+        args = self.args.strip()
+        if " on " in args:
+            self.skillname, self.targetname = args.split(" on ", 1)
+        else:
+            self.skillname = args
+            self.targetname = None
+
+    def func(self):
+        caller = self.caller
+        if not self.skillname:
+            self.msg("Use what?")
+            return
+        skill_key = self.skillname.lower()
+        if skill_key not in (caller.db.skills or []):
+            self.msg("You do not know that ability.")
+            return
+        skill_cls = SKILL_CLASSES.get(skill_key)
+        if not skill_cls:
+            self.msg("You can't use that ability.")
+            return
+        skill = skill_cls()
+        if not caller.cooldowns.ready(skill.name):
+            self.msg("Still recovering.")
+            return
+        stamina = getattr(caller.traits, "stamina", None)
+        if stamina and stamina.current < skill.stamina_cost:
+            self.msg("You are too exhausted to do that.")
+            return
+        if self.targetname:
+            target = caller.search(self.targetname)
+            if not target:
+                return
+        else:
+            target = caller.db.combat_target
+            if not target:
+                self.msg("Use it on whom?")
+                return
+        manager = CombatRoundManager.get()
+        instance = manager.start_combat([caller, target])
+        if caller not in instance.combatants:
+            self.msg("You can't fight right now.")
+            return
+        instance.engine.queue_action(caller, SkillAction(caller, skill, target))
+        self.msg(f"You prepare to use {skill.name} on {target.key}.")
+
+
+class AbilityCmdSet(CmdSet):
+    key = "Ability CmdSet"
+
+    def at_cmdset_creation(self):
+        super().at_cmdset_creation()
+        self.add(CmdSkills)
+        self.add(CmdPractice)
+        self.add(CmdUse)

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -45,6 +45,7 @@ from commands.admin import AdminCmdSet, BuilderCmdSet
 from commands.quests import QuestCmdSet
 from commands.achievements import AchievementCmdSet
 from commands.spells import SpellCmdSet
+from commands.abilities import AbilityCmdSet
 
 
 class CharacterCmdSet(default_cmds.CharacterCmdSet):
@@ -76,6 +77,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(CombatCmdSet)
         self.add(SkillCmdSet)
         self.add(SpellCmdSet)
+        self.add(AbilityCmdSet)
         self.add(InteractCmdSet)
         self.add(InfoCmdSet)
         self.add(LootCmdSet)


### PR DESCRIPTION
## Summary
- implement ability commands for combat skills
- attach ability command set to default character commands

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684e97fd8a5c832cb17682072f9da8ee