### PR TITLE
Add race and class to score and who outputs

### DIFF
--- a/commands/who.py
+++ b/commands/who.py
@@ -21,7 +21,7 @@ class CmdWho(MuxCommand):
             return
 
         is_admin = caller.check_permstring("Admins")
-        headers = ["Character", "Title", "Idle"]
+        headers = ["Character", "Title", "Class (Race)", "Idle"]
         if is_admin:
             headers.insert(0, "Account")
         table = EvTable(*headers, border="cells")
@@ -35,9 +35,11 @@ class CmdWho(MuxCommand):
             idle = time_format(delta_cmd, 0)
             title = puppet.db.title if puppet else ""
             char = puppet.get_display_name(caller) if puppet else "None"
+            race = puppet.db.race or "Unknown" if puppet else "Unknown"
+            charclass = puppet.db.charclass or "Unknown" if puppet else "Unknown"
             if not puppet and not is_admin:
                 continue
-            row = [char, title, idle]
+            row = [char, title, f"{charclass} ({race})", idle]
             if is_admin:
                 row.insert(0, account.key)
             table.add_row(*row)

--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -98,6 +98,12 @@ class TestInfoCommands(EvenniaTest):
         self.assertIn("PRIMARY STATS", out)
         self.assertIn("+", out)
 
+    def test_score_shows_race_and_class(self):
+        self.char1.execute_cmd("score")
+        out = self.char1.msg.call_args[0][0]
+        self.assertIn("Race: Elf", out)
+        self.assertIn("Class: Mage", out)
+
     def test_score_shows_gear_bonus(self):
         from evennia.utils import create
         from world.system import stat_manager
@@ -436,6 +442,12 @@ class TestInfoCommands(EvenniaTest):
         out = self.char1.msg.call_args[0][0]
         self.assertIn(self.char1.key, out)
         self.assertNotIn(self.char1.account.key, out)
+
+    def test_who_shows_race_and_class(self):
+        self.char1.execute_cmd("who")
+        out = self.char1.msg.call_args[0][0]
+        self.assertIn("Elf", out)
+        self.assertIn("Mage", out)
 
 
 class TestBountySmall(EvenniaTest):

--- a/utils/stats_utils.py
+++ b/utils/stats_utils.py
@@ -177,6 +177,10 @@ def get_display_scroll(chara):
         name += f" - {title}"
     lines.append(name)
 
+    race = _db_get(chara, "race", "Unknown") or "Unknown"
+    charclass = _db_get(chara, "charclass", "Unknown") or "Unknown"
+    lines.append(f"Race: {race:<10} Class: {charclass}")
+
     level = _db_get(chara, "level", 1)
     xp = getattr(chara.db, "experience", 0) or 0
     tnl = getattr(chara.db, "tnl", 0) or 0


### PR DESCRIPTION
## Summary
- display race and class near the top of the score sheet
- show character class and race in `who` command list
- test that score and who outputs include race/class

## Testing
- `pytest -k 'score_shows_race_and_class or who_shows_race_and_class' -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684e9c064974832ca8e31192f3f0c0db