### PR TITLE
Fix ability backfill script

### DIFF
--- a/scripts/backfill_abilities.py
+++ b/scripts/backfill_abilities.py
@@ -1,10 +1,16 @@
 """One-time script to grant characters any missing level-based abilities."""
 
 import os
+import sys
 import django
 
 # 👇 Add this line to set the Django settings module
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "server.conf.settings")
+
+# Include project root so "server" package is importable when run directly
+ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
 
 # 👇 Setup Django environment
 django.setup()

--- a/server/conf/at_server_startstop.py
+++ b/server/conf/at_server_startstop.py
@@ -62,6 +62,16 @@ def _migrate_experience():
         logger.log_info(f"Migrated experience on {migrated} characters")
 
 
+def _backfill_abilities():
+    """Ensure all characters know abilities for their current level."""
+    try:
+        from scripts.backfill_abilities import backfill
+    except Exception as err:
+        logger.log_err(f"Ability backfill failed to import: {err}")
+    else:
+        backfill()
+
+
 def at_server_init():
     """Called as the service layer initializes."""
 
@@ -113,6 +123,7 @@ def at_server_start():
                 npc.tags.add("npc_ai")
 
     _migrate_experience()
+    _backfill_abilities()
 
     _build_caches()
     ServerConfig.objects.conf("server_start_time", time.time())


### PR DESCRIPTION
## Summary
- include project root on path for `backfill_abilities.py`
- automatically run ability backfill when the server starts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684eaa688850832cb31d377e31895941