### PR TITLE
Add admin ability update command

### DIFF
--- a/scripts/backfill_abilities.py
+++ b/scripts/backfill_abilities.py
@@ -3,26 +3,31 @@
 import os
 import sys
 import django
+from django.apps import apps
+from django.conf import settings
 
-# 👇 Add this line to set the Django settings module
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "server.conf.settings")
 
 # Include project root so "server" package is importable when run directly
 ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
-if ROOT_DIR not in sys.path:
-    sys.path.insert(0, ROOT_DIR)
 
-# 👇 Setup Django environment
-django.setup()
 
-from evennia.utils import logger
-from typeclasses.characters import Character
-from world.abilities import CLASS_ABILITY_TABLE
-from world.system import state_manager
+def _ensure_django():
+    """Ensure Django is configured and apps are ready."""
+    if not settings.configured or not apps.ready:
+        os.environ.setdefault("DJANGO_SETTINGS_MODULE", "server.conf.settings")
+        if ROOT_DIR not in sys.path:
+            sys.path.insert(0, ROOT_DIR)
+        django.setup()
 
 
 def backfill():
     """Grant abilities unlocked by level to all characters."""
+    _ensure_django()
+    from evennia.utils import logger
+    from typeclasses.characters import Character
+    from world.abilities import CLASS_ABILITY_TABLE
+    from world.system import state_manager
+
     added = 0
     for char in Character.objects.all():
         charclass = char.db.charclass
@@ -48,4 +53,8 @@ def backfill():
 
 
 if __name__ == "__main__":
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "server.conf.settings")
+    if ROOT_DIR not in sys.path:
+        sys.path.insert(0, ROOT_DIR)
+    django.setup()
     backfill()


### PR DESCRIPTION
## Summary
- implement `CmdUpdate` to re-grant level-based abilities
- wire command into the Admin command set
- load CLASS_ABILITY_TABLE and state_manager in admin module

## Testing
- `python -m py_compile commands/admin.py`
- `python scripts/backfill_abilities.py` *(fails: ModuleNotFoundError: No module named 'django')*
- `pytest -q` *(fails to import Django)*


------
https://chatgpt.com/codex/tasks/task_e_684eafa051b0832c8db4af5e3875a5fc