### PR TITLE
Add cast_type support in Spell dataclass

### DIFF
--- a/commands/spells.py
+++ b/commands/spells.py
@@ -156,7 +156,15 @@ class CmdLearnSpell(Command):
         if (self.caller.db.practice_sessions or 0) <= 0:
             self.msg("You have no practice sessions left.")
             return
-        new_spell = Spell(spell.key, spell.stat, spell.mana_cost, spell.desc, 0)
+        new_spell = Spell(
+            spell.key,
+            spell.stat,
+            spell.mana_cost,
+            spell.desc,
+            0,
+            0,
+            spell.cast_type,
+        )
         spent, prof = proficiency_manager.practice(self.caller, new_spell)
         if spent:
             known.append(new_spell)

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -666,7 +666,15 @@ class Character(ObjectParent, ClothedCharacter):
         srec = None
         for entry in known:
             if isinstance(entry, str) and entry == spell_key:
-                srec = Spell(spell.key, spell.stat, spell.mana_cost, spell.desc, 0)
+                srec = Spell(
+                    spell.key,
+                    spell.stat,
+                    spell.mana_cost,
+                    spell.desc,
+                    0,
+                    0,
+                    spell.cast_type,
+                )
                 idx = known.index(entry)
                 known[idx] = srec
                 self.db.spells = known

--- a/world/spells.py
+++ b/world/spells.py
@@ -1,3 +1,11 @@
+"""Spell definitions and utilities.
+
+Each :class:`Spell` entry defines how a magical ability behaves.  The new
+``cast_type`` attribute determines the command players use to invoke the spell
+(usually ``"cast"`` but other values are possible).  All spells are collected
+in the :data:`SPELLS` dictionary keyed by name.
+"""
+
 from dataclasses import dataclass
 from typing import Dict
 
@@ -9,9 +17,25 @@ class Spell:
     desc: str = ""
     cooldown: int = 0
     proficiency: int = 0
+    cast_type: str = "cast"
+    class_type: str = "spell"
 
 
 SPELLS: Dict[str, Spell] = {
-    "fireball": Spell("fireball", "INT", 10, "Hurl a ball of fire at your target.", cooldown=5),
-    "heal": Spell("heal", "WIS", 8, "Restore a small amount of health.", cooldown=3),
+    "fireball": Spell(
+        "fireball",
+        "INT",
+        10,
+        "Hurl a ball of fire at your target.",
+        cooldown=5,
+        cast_type="cast",
+    ),
+    "heal": Spell(
+        "heal",
+        "WIS",
+        8,
+        "Restore a small amount of health.",
+        cooldown=3,
+        cast_type="cast",
+    ),
 }

--- a/world/system/state_manager.py
+++ b/world/system/state_manager.py
@@ -308,7 +308,17 @@ def grant_ability(chara, ability: str, proficiency: int = 0, mark_new: bool = Fa
         if ability in keys:
             return
         proto = SPELLS[ability]
-        known.append(Spell(proto.key, proto.stat, proto.mana_cost, proto.desc, proto.cooldown, proficiency))
+        known.append(
+            Spell(
+                proto.key,
+                proto.stat,
+                proto.mana_cost,
+                proto.desc,
+                proto.cooldown,
+                proficiency,
+                proto.cast_type,
+            )
+        )
         chara.db.spells = known
         if mark_new:
             new_list = chara.db.new_spells or []


### PR DESCRIPTION
## Summary
- expand `Spell` dataclass with `cast_type` and `class_type`
- store the new attribute when spells are granted or copied
- add module documentation for using `cast_type`

## Testing
- `pytest -q` *(fails: OperationalError no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684ebad019f8832c8a21a7283097e315