### PR TITLE
Add dynamic skill commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,8 @@ Choose from `passive`, `aggressive`, `defensive`, `wander` or
 These options let builders quickly create enemies that fight or roam on
 their own. The combat command set includes `attack`, `wield`, `unwield`,
 `flee`, `berserk`, `respawn`, `revive` and `status`.
+Once learned, any skill may be triggered directly by its name, e.g.
+`kick goblin` will attempt to use the Kick ability on the target.
 
 ### Helper Utilities
 


### PR DESCRIPTION
## Summary
- generate skill commands from the ability registry
- add them to AbilityCmdSet
- document direct skill commands in README

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684ebec16e64832ca87f30847f647f36