### PR TITLE
Track skill proficiency after combat

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -634,6 +634,9 @@ class Character(ObjectParent, ClothedCharacter):
             self.traits.stamina.current -= skill.stamina_cost
             state_manager.add_cooldown(self, skill.name, skill.cooldown)
             result = skill.resolve(self, target)
+            from world.system import proficiency_manager
+            skill_trait = self.traits.get(skill_name)
+            proficiency_manager.record_use(self, skill_trait)
             for eff in skill.effects:
                 state_manager.add_status_effect(target, eff.key, eff.duration)
             return result

--- a/typeclasses/tests/test_skill_spell_usage.py
+++ b/typeclasses/tests/test_skill_spell_usage.py
@@ -42,3 +42,16 @@ class TestSkillAndSpellUsage(EvenniaTest):
         self.assertEqual(self.char2.hp, 10)
         self.assertIn("misses", result.message)
 
+    def test_use_skill_records_proficiency(self):
+        from world.system import state_manager
+        from combat.combat_actions import CombatResult
+        from combat.combat_skills import Cleave
+
+        state_manager.grant_ability(self.char1, "cleave", mark_new=False)
+
+        with patch("world.system.proficiency_manager.record_use") as mock_rec, \
+             patch.object(Cleave, "resolve", return_value=CombatResult(actor=self.char1, target=self.char2, message="hit")):
+            self.char1.use_skill("cleave", target=self.char2)
+            skill_trait = self.char1.traits.get("cleave")
+            mock_rec.assert_called_with(self.char1, skill_trait)
+


### PR DESCRIPTION
## Summary
- record skill usage proficiency on active skills
- add regression test for skill proficiency calls

## Testing
- `pytest -q` *(fails: OperationalError no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684ec74052c4832c99a9823fbe1d676e