### PR TITLE
Implement automatic combat start for offensive skills

### DIFF
--- a/combat/combat_skills.py
+++ b/combat/combat_skills.py
@@ -15,7 +15,7 @@ class SkillCategory(str, Enum):
     MAGIC = "magic"
 
 from .combat_actions import CombatResult
-from .combat_utils import roll_damage, roll_evade
+from .combat_utils import roll_damage, roll_evade, maybe_start_combat
 from .combat_states import CombatState
 from world.system import stat_manager
 
@@ -68,6 +68,7 @@ class ShieldBash(Skill):
                 )
             dmg = roll_damage(self.damage)
             target.hp = max(target.hp - dmg, 0)
+            maybe_start_combat(user, target)
             return CombatResult(
                 actor=user,
                 target=target,
@@ -99,6 +100,7 @@ class Cleave(Skill):
             else:
                 dmg = roll_damage(self.damage)
                 target.hp = max(target.hp - dmg, 0)
+                maybe_start_combat(user, target)
                 msg = f"{user.key} cleaves {target.key} for {dmg} damage!"
         else:
             msg = f"{user.key}'s cleave misses {target.key}."
@@ -125,6 +127,7 @@ class Kick(Skill):
         prof = getattr(trait, "proficiency", 0)
         dmg = int(dmg * (1 + prof / 100))
         target.hp = max(target.hp - dmg, 0)
+        maybe_start_combat(user, target)
         return CombatResult(
             actor=user,
             target=target,

--- a/combat/combat_utils.py
+++ b/combat/combat_utils.py
@@ -235,3 +235,47 @@ def get_condition_msg(hp: int, max_hp: int) -> str:
     if percent > 0:
         return "is in awful condition."
     return "is dead."
+
+
+def maybe_start_combat(user, target) -> None:
+    """Start combat between ``user`` and ``target`` if appropriate."""
+
+    if not user or not target:
+        return
+
+    from .engine import _current_hp
+
+    try:
+        alive = getattr(user, "is_alive", None)
+        user_alive = alive() if callable(alive) else _current_hp(user) > 0
+    except Exception:  # pragma: no cover - fail safe
+        user_alive = _current_hp(user) > 0
+
+    try:
+        alive = getattr(target, "is_alive", None)
+        target_alive = alive() if callable(alive) else _current_hp(target) > 0
+    except Exception:  # pragma: no cover - fail safe
+        target_alive = _current_hp(target) > 0
+
+    if not user_alive or not target_alive:
+        return
+
+    if getattr(getattr(user, "db", object()), "decor", False) or getattr(
+        user, "decor", False
+    ):
+        return
+    if getattr(getattr(target, "db", object()), "decor", False) or getattr(
+        target, "decor", False
+    ):
+        return
+
+    from .round_manager import CombatRoundManager
+
+    mgr = CombatRoundManager.get()
+    inst_user = mgr.get_combatant_combat(user)
+    inst_target = mgr.get_combatant_combat(target)
+    if inst_user and inst_user is inst_target:
+        return
+
+    mgr.start_combat([user, target])
+


### PR DESCRIPTION
## Summary
- add `maybe_start_combat` utility
- call new helper from Kick, Cleave, ShieldBash

## Testing
- `pytest typeclasses/tests/test_skill_spell_usage.py::TestSkillAndSpellUsage::test_use_skill_applies_cost_and_cooldown -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684ec8fcd518832c97460ea3595f8729