### PR TITLE
Add help entry for training skills

### DIFF
--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -3509,6 +3509,19 @@ Usage:
 """,
     },
     {
+        "key": "train",
+        "category": "General",
+        "text": """Help for train
+
+Spend practice sessions to improve a combat skill. Each session increases
+proficiency by 25% up to 75%. Skills improve from 75% to 100% through
+repeated use in combat.
+
+Usage:
+    train <sessions>
+""",
+    },
+    {
         "key": "spells",
         "category": "General",
         "text": """Help for spells


### PR DESCRIPTION
## Summary
- document how to train skills up to 75%
- mention that skills improve from 75% to 100% through combat use

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684ecab06e34832c8a5ee64492d8b8c9