### PR TITLE
Ensure combat skills are usable as commands and start combat

### DIFF
--- a/combat/combat_skills.py
+++ b/combat/combat_skills.py
@@ -107,6 +107,33 @@ class Cleave(Skill):
         return CombatResult(actor=user, target=target, message=msg)
 
 
+class Slash(Skill):
+    """Basic slashing attack."""
+
+    name = "slash"
+    category = SkillCategory.MELEE
+    damage = (2, 4)
+    stamina_cost = 10
+    cooldown = 4
+
+    def resolve(self, user, target):
+        if not getattr(target, "is_alive", lambda: True)():
+            return CombatResult(actor=user, target=target, message="They are already down.")
+        if not stat_manager.check_hit(user, target):
+            return CombatResult(actor=user, target=target, message=f"{user.key}'s slash misses {target.key}.")
+        if roll_evade(user, target):
+            return CombatResult(actor=user, target=target, message=f"{target.key} evades {user.key}'s slash.")
+        dmg = roll_damage(self.damage)
+        target.hp = max(target.hp - dmg, 0)
+        maybe_start_combat(user, target)
+        return CombatResult(
+            actor=user,
+            target=target,
+            message=f"{user.key} slashes {target.key} for {dmg} damage!",
+            damage=dmg,
+        )
+
+
 class Kick(Skill):
     """Simple unarmed kick scaling with Strength."""
 
@@ -140,5 +167,6 @@ class Kick(Skill):
 SKILL_CLASSES: Dict[str, type[Skill]] = {
     "shield bash": ShieldBash,
     "cleave": Cleave,
+    "slash": Slash,
     "kick": Kick,
 }

--- a/commands/abilities.py
+++ b/commands/abilities.py
@@ -11,11 +11,13 @@ from .command import MuxCommand
 
 
 def iter_skill_commands():
-    """Yield dynamic MuxCommands for each registered skill ability."""
+    """Yield dynamic MuxCommands for each known combat skill."""
+    keys = set()
     for ability in ABILITY_REGISTRY.values():
-        if getattr(ability, "class_type", "") != "skill":
-            continue
-        key = ability.name.lower()
+        if getattr(ability, "class_type", "") == "skill":
+            keys.add(ability.name.lower())
+    keys.update(SKILL_CLASSES.keys())
+    for key in keys:
         class_name = "Cmd" + "".join(part.capitalize() for part in key.split())
 
         def func(self, _skill=key):

--- a/commands/skills.py
+++ b/commands/skills.py
@@ -12,6 +12,7 @@ SKILL_DICT = {
     "swords": "STR",
     "cooking": "WIS",
     "carving": "STR",
+    "slash": "STR",
     "kick": "STR",
     "unarmed": "DEX",
     "leatherwork": "WIS",

--- a/typeclasses/tests/test_skill_spell_usage.py
+++ b/typeclasses/tests/test_skill_spell_usage.py
@@ -55,3 +55,11 @@ class TestSkillAndSpellUsage(EvenniaTest):
             skill_trait = self.char1.traits.get("cleave")
             mock_rec.assert_called_with(self.char1, skill_trait)
 
+    def test_skill_use_starts_combat(self):
+        with patch("combat.combat_skills.maybe_start_combat") as mock_start, \
+             patch("world.system.stat_manager.check_hit", return_value=True), \
+             patch("combat.combat_skills.roll_evade", return_value=False), \
+             patch("combat.combat_skills.roll_damage", return_value=3):
+            self.char1.use_skill("cleave", target=self.char2)
+            mock_start.assert_called_with(self.char1, self.char2)
+

--- a/world/tests/test_spell_skill_commands.py
+++ b/world/tests/test_spell_skill_commands.py
@@ -24,3 +24,11 @@ class TestSpellAndSkillCommands(EvenniaTest):
             self.char1.execute_cmd(f"kick {self.char2.key}")
             mock_use.assert_called_with("kick", target=self.char2)
             self.char1.location.msg_contents.assert_called_with("hit")
+
+    def test_auto_skill_command_generated_for_skill_classes(self):
+        self.char1.db.skills.append("cleave")
+        self.char1.location.msg_contents.reset_mock()
+        with patch.object(self.char1, "use_skill", return_value=MagicMock(message="hit")) as mock_use:
+            self.char1.execute_cmd(f"cleave {self.char2.key}")
+            mock_use.assert_called_with("cleave", target=self.char2)
+            self.char1.location.msg_contents.assert_called_with("hit")


### PR DESCRIPTION
## Summary
- register all combat skills as commands
- add new "slash" combat skill
- ensure "slash" uses `slash` skill command
- start combat when using any combat skill
- extend tests for new commands and combat start behavior

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684ecd97eed8832c94929384f7e3690e