### PR TITLE
Ensure combat starts for attacks and spells

### DIFF
--- a/combat/combat_actions.py
+++ b/combat/combat_actions.py
@@ -7,6 +7,7 @@ from typing import Optional, Iterable
 import logging
 
 from .actions.utils import calculate_damage, check_hit, apply_critical
+from .combat_utils import maybe_start_combat
 from world.system import stat_manager
 
 from evennia.utils import utils
@@ -117,6 +118,8 @@ class AttackAction(Action):
         target = self.target
         if not target:
             return CombatResult(self.actor, self.actor, "No target.")
+
+        maybe_start_combat(self.actor, target)
 
         weapon = self.actor
         if utils.inherits_from(self.actor, "typeclasses.characters.Character"):

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -21,6 +21,7 @@ from world.spells import Spell
 from combat.combat_actions import CombatResult
 from world.combat import get_health_description
 from combat import combat_utils
+from combat.combat_utils import maybe_start_combat
 
 from .objects import ObjectParent
 from world.mob_constants import BODYPARTS
@@ -694,6 +695,7 @@ class Character(ObjectParent, ClothedCharacter):
         self.traits.mana.current -= spell.mana_cost
         state_manager.add_cooldown(self, spell.key, spell.cooldown)
         if target:
+            maybe_start_combat(self, target)
             self.location.msg_contents(
                 f"{self.get_display_name(self)} casts {spell.key} at {target.get_display_name(self)}!"
             )


### PR DESCRIPTION
## Summary
- start combat when an `AttackAction` executes
- engage combat when casting a targeted spell

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684ed00e7694832caa70bdc7d5588ea6