### PR TITLE
Ensure spells start combat on use

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -707,6 +707,8 @@ class Character(ObjectParent, ClothedCharacter):
         new_prof = proficiency_manager.record_use(self, srec)
         if new_prof != prev_prof:
             self.db.spells = known
+        if target:
+            combat_utils.maybe_start_combat(self, target)
         return True
 
     def get_display_status(self, looker, **kwargs):

--- a/typeclasses/tests/test_skill_spell_usage.py
+++ b/typeclasses/tests/test_skill_spell_usage.py
@@ -63,3 +63,10 @@ class TestSkillAndSpellUsage(EvenniaTest):
             self.char1.use_skill("cleave", target=self.char2)
             mock_start.assert_called_with(self.char1, self.char2)
 
+    def test_spell_cast_starts_combat(self):
+        with patch("combat.combat_utils.maybe_start_combat") as mock_start, \
+             patch("world.system.state_manager.add_cooldown"), \
+             patch.object(self.char1, "location"):
+            self.char1.cast_spell("fireball", target=self.char2)
+            mock_start.assert_called_with(self.char1, self.char2)
+


### PR DESCRIPTION
## Summary
- start combat when casting spells
- cover new behavior in tests

## Testing
- `pytest typeclasses/tests/test_skill_spell_usage.py::TestSkillAndSpellUsage::test_spell_cast_starts_combat` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684ed00e7694832caa70bdc7d5588ea6