### PR TITLE
Update combat target logic for skill usage

### DIFF
--- a/combat/combat_utils.py
+++ b/combat/combat_utils.py
@@ -280,19 +280,15 @@ def maybe_start_combat(user, target) -> None:
     mgr.start_combat([user, target])
 
     udb = getattr(user, "db", None)
-    if udb is not None:
-        try:
-            cur = getattr(udb, "combat_target", None)
-            if cur in (None, target):
-                udb.combat_target = target
-        except Exception:  # pragma: no cover - defensive
-            pass
-
     tdb = getattr(target, "db", None)
-    if tdb is not None:
+    if udb is not None and tdb is not None:
         try:
-            cur = getattr(tdb, "combat_target", None)
-            if cur in (None, user):
+            u_cur = getattr(udb, "combat_target", None)
+            t_cur = getattr(tdb, "combat_target", None)
+            if (u_cur is None and t_cur is None) or (
+                u_cur is target and t_cur is user
+            ):
+                udb.combat_target = target
                 tdb.combat_target = user
         except Exception:  # pragma: no cover - defensive
             pass

--- a/typeclasses/tests/test_skill_spell_usage.py
+++ b/typeclasses/tests/test_skill_spell_usage.py
@@ -105,3 +105,19 @@ class TestSkillAndSpellUsage(EvenniaTest):
             self.assertIs(self.char1.db.combat_target, other1)
             self.assertIs(self.char2.db.combat_target, other2)
 
+    def test_use_skill_sets_combat_targets(self):
+        """Using a skill should set combat_target on both combatants."""
+        with patch("combat.combat_utils.CombatRoundManager.get") as mock_get, \
+             patch("world.system.stat_manager.check_hit", return_value=True), \
+             patch("combat.combat_skills.roll_evade", return_value=False), \
+             patch("combat.combat_skills.roll_damage", return_value=1):
+            manager = MagicMock()
+            mock_get.return_value = manager
+            manager.get_combatant_combat.return_value = None
+
+            self.char1.use_skill("cleave", target=self.char2)
+
+            manager.start_combat.assert_called_with([self.char1, self.char2])
+            self.assertEqual(self.char1.db.combat_target, self.char2)
+            self.assertEqual(self.char2.db.combat_target, self.char1)
+


### PR DESCRIPTION
## Summary
- ensure `maybe_start_combat` only sets combat targets when both fighters are untargeted or already mutually targeting each other
- add regression test covering combat target auto-setting on skill usage

## Testing
- `pytest -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684ee6f6b114832c916ab05ca45599a4