### PR TITLE
Update combat target setup logic

### DIFF
--- a/combat/combat_utils.py
+++ b/combat/combat_utils.py
@@ -285,9 +285,7 @@ def maybe_start_combat(user, target) -> None:
         try:
             u_cur = getattr(udb, "combat_target", None)
             t_cur = getattr(tdb, "combat_target", None)
-            if (u_cur is None and t_cur is None) or (
-                u_cur is target and t_cur is user
-            ):
+            if (u_cur in (None, target)) and (t_cur in (None, user)):
                 udb.combat_target = target
                 tdb.combat_target = user
         except Exception:  # pragma: no cover - defensive


### PR DESCRIPTION
## Summary
- update combat target setting logic when starting combat
- test single-sided targeting scenario

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684eead2c8b0832c977dfb95bef51e69