### PR TITLE
Add tearDown cleanup for attack command tests

### DIFF
--- a/typeclasses/tests/base.py
+++ b/typeclasses/tests/base.py
@@ -1,0 +1,13 @@
+from evennia.utils.test_resources import EvenniaTest
+
+
+class AttackCommandTestBase(EvenniaTest):
+    """Base class for attack command tests."""
+
+    def tearDown(self):
+        from combat.round_manager import CombatRoundManager
+
+        manager = CombatRoundManager.get()
+        manager.combats.clear()
+        manager.combatant_to_combat.clear()
+        super().tearDown()

--- a/typeclasses/tests/test_attack_command.py
+++ b/typeclasses/tests/test_attack_command.py
@@ -1,13 +1,13 @@
 from unittest.mock import MagicMock, patch
 from django.test import override_settings
 from evennia.utils import create
-from evennia.utils.test_resources import EvenniaTest
+from .base import AttackCommandTestBase
 from typeclasses.npcs import BaseNPC
 from commands.combat import CombatCmdSet
 
 
 @override_settings(DEFAULT_HOME=None)
-class TestAttackCommand(EvenniaTest):
+class TestAttackCommand(AttackCommandTestBase):
     def setUp(self):
         super().setUp()
         self.char1.msg = MagicMock()


### PR DESCRIPTION
## Summary
- provide `AttackCommandTestBase` with `tearDown`
- use new base for `TestAttackCommand`

## Testing
- `pytest -q` *(fails: django.db utils errors)*

------
https://chatgpt.com/codex/tasks/task_e_684ef7930e94832c95f41cbc082c5142