### PR TITLE
Fix header docstring

### DIFF
--- a/typeclasses/tests/test_attack_command.py
+++ b/typeclasses/tests/test_attack_command.py
@@ -1,3 +1,10 @@
+"""Tests for attack and kill commands.
+
+The :class:`TestAttackCommand` suite verifies that issuing ``attack`` or
+its ``kill``/``k`` aliases correctly initiates combat, queues actions and
+handles joining ongoing fights.
+"""
+
 from unittest.mock import MagicMock, patch
 from django.test import override_settings
 from evennia.utils import create


### PR DESCRIPTION
## Summary
- document the attack and kill command tests with a module header

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684f00daedfc832cbd235c8cf2fe114f