### PR TITLE
Fix round_manager test

### DIFF
--- a/typeclasses/tests/test_round_manager.py
+++ b/typeclasses/tests/test_round_manager.py
@@ -146,7 +146,7 @@ class TestCombatRoundManager(EvenniaTest):
     def test_force_end_all_combat(self):
         """Test that all combat can be force-ended."""
         with patch("combat.round_manager.delay"):
-            inst = self.manager.add_instance(self.room1)
+            inst = self.manager.create_combat(combatants=[self.char1])
             self.assertTrue(self.manager.running)
             
             self.manager.force_end_all_combat()


### PR DESCRIPTION
## Summary
- use `create_combat` instead of removed `add_instance` in round manager test

## Testing
- `pytest -q` *(fails: ImportError and many missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_684f08caa5dc832cbc1e42dc9ba691d9