### PR TITLE
Improve CmdAttack parse handling

### DIFF
--- a/commands/combat.py
+++ b/commands/combat.py
@@ -1,4 +1,5 @@
 from random import choice
+import re
 from evennia import CmdSet
 from evennia.utils import iter_to_str
 from evennia.utils.evtable import EvTable
@@ -29,15 +30,17 @@ class CmdAttack(Command):
         """
         self.args = self.args.strip()
 
-        # split on variations of "with"
-        if " with " in self.args:
-            self.target, self.weapon = self.args.split(" with ", maxsplit=1)
-        elif " w " in self.args:
-            self.target, self.weapon = self.args.split(" w ", maxsplit=1)
-        elif " w/" in self.args:
-            self.target, self.weapon = self.args.split(" w/", maxsplit=1)
+        target, sep, weapon = self.args.partition(" with ")
+        if sep:
+            self.target = target.strip()
+            self.weapon = weapon.strip()
+            return
+
+        match = re.match(r"^(?P<target>.+?)\s+w(?:/)?(?:\s+)?(?P<weapon>.+)$", self.args, re.I)
+        if match:
+            self.target = match.group("target").strip()
+            self.weapon = match.group("weapon").strip()
         else:
-            # no splitters, it's all target
             self.target = self.args
             self.weapon = None
 

--- a/typeclasses/tests/test_attack_command.py
+++ b/typeclasses/tests/test_attack_command.py
@@ -145,3 +145,26 @@ class TestAttackCommand(AttackCommandTestBase):
         self._assert_combat_targets_set(self.char1, self.char2)
         self._assert_combat_initiated()
 
+    @patch("combat.round_manager.delay")
+    def test_attack_separator_variants(self, _):
+        """Separators 'with', 'w' and 'w/' should all parse correctly."""
+        weapon = create.create_object(
+            "typeclasses.gear.MeleeWeapon", key="sword", location=self.char1
+        )
+        weapon.tags.add("equipment", category="flag")
+        weapon.tags.add("identified", category="flag")
+
+        for sep in ("with", "w", "w/"):
+            cmd = f"attack char2 {sep} sword"
+            self.char1.execute_cmd(cmd)
+            self._assert_combat_targets_set(self.char1, self.char2)
+            self._assert_combat_initiated(actor=self.char1)
+
+            from combat.round_manager import CombatRoundManager
+
+            manager = CombatRoundManager.get()
+            manager.combats.clear()
+            manager.combatant_to_combat.clear()
+            self.char1.db.combat_target = None
+            self.char2.db.combat_target = None
+


### PR DESCRIPTION
## Summary
- make CmdAttack parse optional weapon using partition and regex
- allow `w` and `w/` separators in the attack command
- test additional separator options

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684f119be834832c95114f223519c8b0