### PR TITLE
Add CmdKill command for combat

### DIFF
--- a/commands/combat.py
+++ b/commands/combat.py
@@ -117,6 +117,14 @@ class CmdAttack(Command):
         display_auto_prompt(self.account, self.caller, self.msg)
 
 
+class CmdKill(CmdAttack):
+    """Attack shortcut command using 'kill' syntax."""
+
+    key = "kill"
+    aliases = ("k",)
+    help_category = CmdAttack.help_category
+
+
 class CmdWield(Command):
     """
     Wield a weapon. Usage: wield <weapon> [in <hand>]
@@ -401,6 +409,7 @@ class CombatCmdSet(CmdSet):
         super().at_cmdset_creation()
 
         self.add(CmdAttack)
+        self.add(CmdKill)
         self.add(CmdFlee)
         self.add(CmdBerserk)
         self.add(CmdWield)


### PR DESCRIPTION
## Summary
- subclass CmdKill from CmdAttack
- expose CmdKill in CombatCmdSet along with CmdAttack

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684f1357cb34832c8bd4ef9a93fb6700