### PR TITLE
Fix None check in combat command

### DIFF
--- a/commands/combat.py
+++ b/commands/combat.py
@@ -93,6 +93,15 @@ class CmdAttack(Command):
         manager = CombatRoundManager.get()
         instance = manager.get_combatant_combat(self.caller)
 
+        if not instance:
+            # Try to start combat again in case the initial attempt failed
+            maybe_start_combat(self.caller, target)
+            instance = manager.get_combatant_combat(self.caller)
+
+        if not instance:
+            self.msg("Combat has not been initialized.")
+            return
+
         if self.caller not in instance.combatants:
             if _current_hp(self.caller) <= 0:
                 self.msg("You are in no condition to fight.")


### PR DESCRIPTION
## Summary
- avoid AttributeError when the combat manager hasn't started yet
- retry starting combat if initial attempt fails

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684f1582d654832cb73823bffadf2c41