### PR TITLE
Fix tick_delay reference in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ with VNUM-based NPCs.
 
 The `CombatRoundManager` singleton, found in `combat.round_manager`, manages all
 active combat encounters. It ticks every **2 seconds** by default (see
-`tick_delay` at line 214 of `combat/round_manager.py`). Call
+`tick_delay` in `combat/round_manager.py`). Call
 `CombatRoundManager.get().start_combat([fighter1, fighter2])` to create a combat
 with those combatants. The manager stores each combat instance by a unique ID
 and uses the `combatant_to_combat` dictionary to map combatants back to their


### PR DESCRIPTION
## Summary
- update README to reference the tick delay constant without a hard-coded line number

## Testing
- `pytest -q` *(fails: OperationalError: no such table)*

------
https://chatgpt.com/codex/tasks/task_e_684f1ef2ccac832ca03a6c47db7c2bb2