### PR TITLE
Return instance from maybe_start_combat

### DIFF
--- a/combat/combat_actions.py
+++ b/combat/combat_actions.py
@@ -119,7 +119,7 @@ class AttackAction(Action):
         if not target:
             return CombatResult(self.actor, self.actor, "No target.")
 
-        maybe_start_combat(self.actor, target)
+        instance = maybe_start_combat(self.actor, target)
 
         weapon = self.actor
         if utils.inherits_from(self.actor, "typeclasses.characters.Character"):

--- a/combat/combat_skills.py
+++ b/combat/combat_skills.py
@@ -59,7 +59,7 @@ class ShieldBash(Skill):
         if not getattr(target, "is_alive", lambda: True)():
             return CombatResult(actor=user, target=target, message="They are already down.")
         # ensure combat starts before any hit or evade checks
-        maybe_start_combat(user, target)
+        instance = maybe_start_combat(user, target)
         hit = stat_manager.check_hit(user, target)
         if hit:
             if roll_evade(user, target):
@@ -95,7 +95,7 @@ class Cleave(Skill):
     def resolve(self, user, target):
         if not getattr(target, "is_alive", lambda: True)():
             return CombatResult(actor=user, target=target, message="They are already down.")
-        maybe_start_combat(user, target)
+        instance = maybe_start_combat(user, target)
         if stat_manager.check_hit(user, target):
             if roll_evade(user, target):
                 msg = f"{user.key}'s cleave misses {target.key}."
@@ -120,7 +120,7 @@ class Slash(Skill):
     def resolve(self, user, target):
         if not getattr(target, "is_alive", lambda: True)():
             return CombatResult(actor=user, target=target, message="They are already down.")
-        maybe_start_combat(user, target)
+        instance = maybe_start_combat(user, target)
         if not stat_manager.check_hit(user, target):
             return CombatResult(actor=user, target=target, message=f"{user.key}'s slash misses {target.key}.")
         if roll_evade(user, target):
@@ -145,7 +145,7 @@ class Kick(Skill):
     def resolve(self, user, target):
         if not getattr(target, "is_alive", lambda: True)():
             return CombatResult(actor=user, target=target, message="They are already down.")
-        maybe_start_combat(user, target)
+        instance = maybe_start_combat(user, target)
         if not stat_manager.check_hit(user, target):
             return CombatResult(actor=user, target=target, message=f"{user.key}'s kick misses {target.key}.")
         if roll_evade(user, target):

--- a/combat/combat_utils.py
+++ b/combat/combat_utils.py
@@ -237,11 +237,18 @@ def get_condition_msg(hp: int, max_hp: int) -> str:
     return "is dead."
 
 
-def maybe_start_combat(user, target) -> None:
-    """Start combat between ``user`` and ``target`` if appropriate."""
+def maybe_start_combat(user, target):
+    """Start combat between ``user`` and ``target`` if appropriate.
+
+    Returns
+    -------
+    CombatInstance | None
+        The combat instance the two combatants are (or end up) in, or
+        ``None`` if combat could not be started.
+    """
 
     if not user or not target:
-        return
+        return None
 
     from .engine import _current_hp
 
@@ -258,16 +265,16 @@ def maybe_start_combat(user, target) -> None:
         target_alive = _current_hp(target) > 0
 
     if not user_alive or not target_alive:
-        return
+        return None
 
     if getattr(getattr(user, "db", object()), "decor", False) or getattr(
         user, "decor", False
     ):
-        return
+        return None
     if getattr(getattr(target, "db", object()), "decor", False) or getattr(
         target, "decor", False
     ):
-        return
+        return None
 
     from .round_manager import CombatRoundManager
 
@@ -275,9 +282,9 @@ def maybe_start_combat(user, target) -> None:
     inst_user = mgr.get_combatant_combat(user)
     inst_target = mgr.get_combatant_combat(target)
     if inst_user and inst_user is inst_target:
-        return
+        return inst_user
 
-    mgr.start_combat([user, target])
+    instance = mgr.start_combat([user, target])
 
     udb = getattr(user, "db", None)
     tdb = getattr(target, "db", None)
@@ -290,4 +297,6 @@ def maybe_start_combat(user, target) -> None:
                 tdb.combat_target = user
         except Exception:  # pragma: no cover - defensive
             pass
+
+    return instance
 

--- a/commands/combat.py
+++ b/commands/combat.py
@@ -91,12 +91,10 @@ class CmdAttack(Command):
         manager = CombatRoundManager.get()
         instance = manager.get_combatant_combat(self.caller)
 
-        # If no instance exists, try to start combat
+        # If no instance exists, try to start combat and capture the result
         if not instance:
             try:
-                # ensure combat has begun and combat_target attributes are set
-                maybe_start_combat(self.caller, target)
-                instance = manager.get_combatant_combat(self.caller)
+                instance = maybe_start_combat(self.caller, target)
             except Exception as e:
                 self.msg(f"Failed to initialize combat: {e}")
                 return

--- a/scripts/combat_ai.py
+++ b/scripts/combat_ai.py
@@ -31,9 +31,10 @@ class BaseCombatAI(Script):
         if not npc or not target:
             return
         # Ensure combat has started and queue an attack action directly
-        maybe_start_combat(npc, target)
-        manager = CombatRoundManager.get()
-        instance = manager.get_combatant_combat(npc)
+        instance = maybe_start_combat(npc, target)
+        if not instance:
+            manager = CombatRoundManager.get()
+            instance = manager.get_combatant_combat(npc)
         if instance:
             instance.engine.queue_action(npc, AttackAction(npc, target))
 

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -695,7 +695,7 @@ class Character(ObjectParent, ClothedCharacter):
         self.traits.mana.current -= spell.mana_cost
         state_manager.add_cooldown(self, spell.key, spell.cooldown)
         if target:
-            maybe_start_combat(self, target)
+            instance = maybe_start_combat(self, target)
             self.location.msg_contents(
                 f"{self.get_display_name(self)} casts {spell.key} at {target.get_display_name(self)}!"
             )
@@ -710,7 +710,7 @@ class Character(ObjectParent, ClothedCharacter):
         if new_prof != prev_prof:
             self.db.spells = known
         if target:
-            combat_utils.maybe_start_combat(self, target)
+            instance2 = combat_utils.maybe_start_combat(self, target)
         return True
 
     def get_display_status(self, looker, **kwargs):

--- a/typeclasses/tests/test_combat_ai.py
+++ b/typeclasses/tests/test_combat_ai.py
@@ -38,3 +38,14 @@ class TestBaseCombatAI(EvenniaTest):
             self.script.move()
             mock_move.assert_not_called()
 
+    def test_attack_target_uses_instance(self):
+        """attack_target should queue using the instance returned by maybe_start_combat."""
+        mock_engine = MagicMock()
+        inst = MagicMock(engine=mock_engine)
+        with patch(
+            "scripts.combat_ai.maybe_start_combat", return_value=inst
+        ) as mock_start, patch("scripts.combat_ai.AttackAction"):
+            self.script.attack_target(self.char1)
+            mock_start.assert_called_with(self.npc, self.char1)
+            mock_engine.queue_action.assert_called()
+

--- a/typeclasses/tests/test_skill_spell_usage.py
+++ b/typeclasses/tests/test_skill_spell_usage.py
@@ -81,9 +81,10 @@ class TestSkillAndSpellUsage(EvenniaTest):
             mock_get.return_value = manager
             manager.get_combatant_combat.return_value = None
 
-            maybe_start_combat(self.char1, self.char2)
+            result = maybe_start_combat(self.char1, self.char2)
 
             manager.start_combat.assert_called_with([self.char1, self.char2])
+            self.assertIs(result, manager.start_combat.return_value)
             self.assertEqual(self.char1.db.combat_target, self.char2)
             self.assertEqual(self.char2.db.combat_target, self.char1)
 
@@ -101,9 +102,10 @@ class TestSkillAndSpellUsage(EvenniaTest):
             mock_get.return_value = manager
             manager.get_combatant_combat.return_value = None
 
-            maybe_start_combat(self.char1, self.char2)
+            result = maybe_start_combat(self.char1, self.char2)
 
             manager.start_combat.assert_called_with([self.char1, self.char2])
+            self.assertIs(result, manager.start_combat.return_value)
             self.assertIs(self.char1.db.combat_target, other1)
             self.assertIs(self.char2.db.combat_target, other2)
 
@@ -119,9 +121,10 @@ class TestSkillAndSpellUsage(EvenniaTest):
             mock_get.return_value = manager
             manager.get_combatant_combat.return_value = None
 
-            maybe_start_combat(self.char1, self.char2)
+            result = maybe_start_combat(self.char1, self.char2)
 
             manager.start_combat.assert_called_with([self.char1, self.char2])
+            self.assertIs(result, manager.start_combat.return_value)
             self.assertIs(self.char1.db.combat_target, self.char2)
             self.assertIs(self.char2.db.combat_target, self.char1)
 
@@ -154,9 +157,10 @@ class TestSkillAndSpellUsage(EvenniaTest):
             mock_get.return_value = manager
             manager.get_combatant_combat.return_value = None
 
-            maybe_start_combat(self.char1, self.char2)
+            result = maybe_start_combat(self.char1, self.char2)
 
             manager.start_combat.assert_called_with([self.char1, self.char2])
+            self.assertIs(result, manager.start_combat.return_value)
             self.assertIs(self.char1.db.combat_target, self.char2)
             self.assertIs(self.char2.db.combat_target, self.char1)
 


### PR DESCRIPTION
## Summary
- have `maybe_start_combat` return a `CombatInstance`
- use the returned instance throughout the codebase
- extend tests for the new return behaviour

## Testing
- `pytest --collect-only`
- `pytest -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684f226a5d98832c9bf013b0eb2af487