### PR TITLE
Propagate round_time to CombatEngine

### DIFF
--- a/combat/round_manager.py
+++ b/combat/round_manager.py
@@ -257,7 +257,8 @@ class CombatRoundManager:
 
         try:
             from .engine import CombatEngine
-            engine = CombatEngine(fighters, round_time=None)
+            eng_round_time = self.tick_delay if round_time is None else round_time
+            engine = CombatEngine(fighters, round_time=eng_round_time)
         except Exception as err:
             logger.log_err(f"CombatEngine initialization failed: {err}")
             self.last_error = str(err)
@@ -271,7 +272,8 @@ class CombatRoundManager:
         combat_id = self._next_id
         self._next_id += 1
 
-        inst = CombatInstance(combat_id, engine, set(fighters), round_time or self.tick_delay)
+        inst_round_time = self.tick_delay if round_time is None else round_time
+        inst = CombatInstance(combat_id, engine, set(fighters), inst_round_time)
         self.combats[combat_id] = inst
         for fighter in fighters:
             self.combatant_to_combat[fighter] = combat_id

--- a/typeclasses/tests/test_round_manager.py
+++ b/typeclasses/tests/test_round_manager.py
@@ -265,3 +265,15 @@ class TestCombatRoundManager(EvenniaTest):
             self.manager._tick()
             mock_proc.assert_called()
 
+    def test_round_time_passed_to_engine(self):
+        """create_combat should pass round_time to CombatEngine."""
+        with (
+            patch("combat.round_manager.delay"),
+            patch.object(CombatEngine, "process_round")
+        ):
+            inst = self.manager.create_combat(
+                combatants=[self.char1, self.char2], round_time=5
+            )
+
+        self.assertEqual(inst.engine.round_time, 5)
+


### PR DESCRIPTION
## Summary
- pass round_time from CombatRoundManager.create_combat to CombatEngine
- default round_time to manager.tick_delay when none is specified
- test that create_combat forwards round_time to the CombatEngine

## Testing
- `pytest -q` *(fails: django.db errors)*

------
https://chatgpt.com/codex/tasks/task_e_684f29f5f230832c827cd2ba0d0dbcc0