### PR TITLE
Improve maybe_start_combat validation

### DIFF
--- a/combat/combat_utils.py
+++ b/combat/combat_utils.py
@@ -279,12 +279,27 @@ def maybe_start_combat(user, target):
     from .round_manager import CombatRoundManager
 
     mgr = CombatRoundManager.get()
+    if not getattr(user, "location", None):
+        mgr.last_error = "User has no location"
+        return None
+    if not getattr(target, "location", None):
+        mgr.last_error = "Target has no location"
+        return None
+
     inst_user = mgr.get_combatant_combat(user)
     inst_target = mgr.get_combatant_combat(target)
     if inst_user and inst_user is inst_target:
         return inst_user
 
     instance = mgr.start_combat([user, target])
+
+    if instance is None:
+        return None
+
+    if hasattr(user, "db"):
+        user.db.in_combat = True
+    if hasattr(target, "db"):
+        target.db.in_combat = True
 
     udb = getattr(user, "db", None)
     tdb = getattr(target, "db", None)


### PR DESCRIPTION
## Summary
- improve combat initiation checks in `maybe_start_combat`
- ensure combatants get `in_combat` flag when combat starts
- extend unit tests for flag checks and error handling

## Testing
- `pytest -q` *(fails: ImportError/setup errors)*

------
https://chatgpt.com/codex/tasks/task_e_684f2b6f5070832cb4abf407a34107d4