### PR TITLE
Add start_or_get_combat helper

### DIFF
--- a/combat/combat_utils.py
+++ b/combat/combat_utils.py
@@ -315,3 +315,29 @@ def maybe_start_combat(user, target):
 
     return instance
 
+
+def start_or_get_combat(caller, target):
+    """Return an existing combat or start a new one.
+
+    Parameters
+    ----------
+    caller
+        Character attempting to engage in combat.
+    target
+        The intended opponent.
+
+    Returns
+    -------
+    CombatInstance | None
+        An active combat instance involving ``caller`` and ``target`` or
+        ``None`` if combat could not be started.
+    """
+
+    from .round_manager import CombatRoundManager
+
+    manager = CombatRoundManager.get()
+    instance = manager.get_combatant_combat(caller)
+    if instance:
+        return instance
+    return maybe_start_combat(caller, target)
+

--- a/commands/combat.py
+++ b/commands/combat.py
@@ -4,7 +4,7 @@ from evennia import CmdSet
 from evennia.utils import iter_to_str
 from evennia.utils.evtable import EvTable
 from combat.engine import _current_hp
-from combat.combat_utils import maybe_start_combat
+from combat.combat_utils import start_or_get_combat
 
 from .command import Command
 from typeclasses.gear import BareHand
@@ -87,17 +87,8 @@ class CmdAttack(Command):
         # it's all good! let's get started!
         from combat.round_manager import CombatRoundManager
 
-        # Try to get existing combat instance first
         manager = CombatRoundManager.get()
-        instance = manager.get_combatant_combat(self.caller)
-
-        # If no instance exists, try to start combat and capture the result
-        if not instance:
-            try:
-                instance = maybe_start_combat(self.caller, target)
-            except Exception as e:
-                self.msg(f"Failed to initialize combat: {e}")
-                return
+        instance = start_or_get_combat(self.caller, target)
 
         # Final check - if combat still hasn't started, provide detailed error
         if not instance:

--- a/scripts/combat_ai.py
+++ b/scripts/combat_ai.py
@@ -1,8 +1,7 @@
 from random import choice
 from typeclasses.scripts import Script
 
-from combat.combat_utils import maybe_start_combat
-from combat.round_manager import CombatRoundManager
+from combat.combat_utils import start_or_get_combat
 from combat.combat_actions import AttackAction
 
 class BaseCombatAI(Script):
@@ -31,10 +30,7 @@ class BaseCombatAI(Script):
         if not npc or not target:
             return
         # Ensure combat has started and queue an attack action directly
-        instance = maybe_start_combat(npc, target)
-        if not instance:
-            manager = CombatRoundManager.get()
-            instance = manager.get_combatant_combat(npc)
+        instance = start_or_get_combat(npc, target)
         if instance:
             instance.engine.queue_action(npc, AttackAction(npc, target))
 

--- a/typeclasses/tests/test_attack_command.py
+++ b/typeclasses/tests/test_attack_command.py
@@ -170,11 +170,11 @@ class TestAttackCommand(AttackCommandTestBase):
 
     @patch("combat.round_manager.delay")
     def test_attack_uses_returned_instance(self, _):
-        """Attack command should use the instance returned by maybe_start_combat."""
+        """Attack command should use the instance returned by start_or_get_combat."""
         mock_engine = MagicMock()
         inst = MagicMock(engine=mock_engine, combatants={self.char1, self.char2})
         with patch(
-            "commands.combat.maybe_start_combat", return_value=inst
+            "commands.combat.start_or_get_combat", return_value=inst
         ) as mock_start, patch("commands.combat.CombatRoundManager.get") as mock_get, patch(
             "commands.combat.AttackAction"
         ):

--- a/typeclasses/tests/test_combat_ai.py
+++ b/typeclasses/tests/test_combat_ai.py
@@ -39,11 +39,11 @@ class TestBaseCombatAI(EvenniaTest):
             mock_move.assert_not_called()
 
     def test_attack_target_uses_instance(self):
-        """attack_target should queue using the instance returned by maybe_start_combat."""
+        """attack_target should queue using the instance returned by start_or_get_combat."""
         mock_engine = MagicMock()
         inst = MagicMock(engine=mock_engine)
         with patch(
-            "scripts.combat_ai.maybe_start_combat", return_value=inst
+            "scripts.combat_ai.start_or_get_combat", return_value=inst
         ) as mock_start, patch("scripts.combat_ai.AttackAction"):
             self.script.attack_target(self.char1)
             mock_start.assert_called_with(self.npc, self.char1)

--- a/typeclasses/tests/test_start_or_get_combat.py
+++ b/typeclasses/tests/test_start_or_get_combat.py
@@ -1,0 +1,36 @@
+from unittest.mock import patch, MagicMock
+from evennia.utils.test_resources import EvenniaTest
+
+
+class TestStartOrGetCombat(EvenniaTest):
+    def test_returns_existing_instance(self):
+        from combat.combat_utils import start_or_get_combat
+
+        with patch("combat.round_manager.CombatRoundManager.get") as mock_get, patch(
+            "combat.combat_utils.maybe_start_combat"
+        ) as mock_start:
+            manager = MagicMock()
+            inst = MagicMock()
+            mock_get.return_value = manager
+            manager.get_combatant_combat.return_value = inst
+
+            result = start_or_get_combat(self.char1, self.char2)
+
+            self.assertIs(result, inst)
+            mock_start.assert_not_called()
+
+    def test_starts_new_combat_when_none(self):
+        from combat.combat_utils import start_or_get_combat
+
+        with patch("combat.round_manager.CombatRoundManager.get") as mock_get, patch(
+            "combat.combat_utils.maybe_start_combat", return_value="inst"
+        ) as mock_start:
+            manager = MagicMock()
+            mock_get.return_value = manager
+            manager.get_combatant_combat.return_value = None
+
+            result = start_or_get_combat(self.char1, self.char2)
+
+            mock_start.assert_called_with(self.char1, self.char2)
+            self.assertEqual(result, "inst")
+


### PR DESCRIPTION
## Summary
- implement `start_or_get_combat` to retrieve or start combat
- refactor command modules and combat AI to use this helper
- add regression tests for `start_or_get_combat`
- update existing tests for new helper

## Testing
- `pytest typeclasses/tests/test_attack_command.py::TestAttackCommand::test_attack_when_not_fleeing -q` *(fails: OperationalError no such table)*

------
https://chatgpt.com/codex/tasks/task_e_684f2e85a1a8832c842a817f73e59d5e