### PR TITLE
Handle combat init failures and test message

### DIFF
--- a/commands/combat.py
+++ b/commands/combat.py
@@ -90,19 +90,13 @@ class CmdAttack(Command):
         manager = CombatRoundManager.get()
         instance = start_or_get_combat(self.caller, target)
 
-        # Final check - if combat still hasn't started, provide detailed error
+        # Final check - if combat still hasn't started, use manager error if available
         if not instance:
-            # Try to determine why combat isn't starting
-            if not hasattr(self.caller, "in_combat"):
-                self.msg("Error: Character lacks combat capabilities.")
-            elif not hasattr(target, "db") or not hasattr(target, "get_display_name"):
-                self.msg("Error: Invalid target for combat.")
+            err = getattr(manager, "last_error", "")
+            if err:
+                self.msg(f"Error: Combat system failed to initialize: {err}")
             else:
-                err = getattr(manager, "last_error", "")
-                if err:
-                    self.msg(f"Error: Combat system failed to initialize: {err}")
-                else:
-                    self.msg("Error: Combat system failed to initialize. Check combat configuration.")
+                self.msg("Error: Combat system failed to initialize.")
             return
 
         # Verify caller is actually in the combat instance

--- a/typeclasses/tests/test_attack_command.py
+++ b/typeclasses/tests/test_attack_command.py
@@ -187,3 +187,17 @@ class TestAttackCommand(AttackCommandTestBase):
             mock_start.assert_called_with(self.char1, self.char2)
             mock_engine.queue_action.assert_called()
 
+    @patch("combat.round_manager.delay")
+    def test_attack_reports_manager_error(self, _):
+        """If combat fails to start, the manager error should be displayed."""
+        with patch("commands.combat.start_or_get_combat", return_value=None) as mock_start, patch(
+            "commands.combat.CombatRoundManager.get"
+        ) as mock_get:
+            manager = MagicMock(last_error="engine failure")
+            mock_get.return_value = manager
+            self.char1.execute_cmd("attack char2")
+            mock_start.assert_called_with(self.char1, self.char2)
+            self.char1.msg.assert_any_call(
+                "Error: Combat system failed to initialize: engine failure"
+            )
+


### PR DESCRIPTION
## Summary
- show CombatRoundManager.last_error when combat cannot start
- test Attack command displays manager error when combat init fails

## Testing
- `pytest -q` *(fails: OperationalError - no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684f31ff02fc832ca6101d5f04160cad