### PR TITLE
Add round timing check and unit test

### DIFF
--- a/combat/round_manager.py
+++ b/combat/round_manager.py
@@ -342,7 +342,9 @@ class CombatRoundManager:
                     remove.append(cid)
                     continue
 
-                inst.process_round()
+                elapsed = time.time() - inst.last_round_time
+                if elapsed >= inst.round_time:
+                    inst.process_round()
 
                 if inst.combat_ended:
                     remove.append(cid)

--- a/typeclasses/tests/test_round_manager.py
+++ b/typeclasses/tests/test_round_manager.py
@@ -265,3 +265,26 @@ class TestCombatRoundManager(EvenniaTest):
             self.manager._tick()
             mock_proc.assert_called()
 
+    def test_round_time_delay(self):
+        """A larger round_time should delay round processing."""
+        with (
+            patch("combat.round_manager.delay"),
+            patch.object(CombatEngine, "process_round") as mock_proc,
+            patch("combat.round_manager.time.time") as mock_time,
+        ):
+            mock_time.return_value = 0
+            inst = self.manager.create_combat(
+                combatants=[self.char1, self.char2], round_time=5.0
+            )
+            mock_proc.reset_mock()
+
+            # Not enough time has passed; round should not process
+            mock_time.return_value = 2
+            self.manager._tick()
+            mock_proc.assert_not_called()
+
+            # After sufficient time, round should process
+            mock_time.return_value = 6
+            self.manager._tick()
+            mock_proc.assert_called_once()
+


### PR DESCRIPTION
## Summary
- respect `round_time` interval when processing combats
- add unit test verifying long `round_time` delays combat rounds

## Testing
- `pytest typeclasses/tests/test_round_manager.py::TestCombatRoundManager::test_round_time_delay -q`

------
https://chatgpt.com/codex/tasks/task_e_684f42f2c854832cb960e33b9119c2da