### PR TITLE
Add modular skill system with kick ability

### DIFF
--- a/commands/abilities.py
+++ b/commands/abilities.py
@@ -1,0 +1,60 @@
+from evennia import CmdSet
+from evennia.utils.evtable import EvTable
+
+from .command import Command
+from world.skills.kick import Kick
+from world.skills.utils import maybe_start_combat
+from combat.combat_actions import SkillAction
+from world.system import state_manager
+
+
+class CmdSkills(Command):
+    """List known skills and proficiency."""
+
+    key = "skills"
+
+    def func(self):
+        known = self.caller.db.skills or []
+        if not known:
+            self.msg("You do not know any skills.")
+            return
+        table = EvTable("Skill", "Proficiency")
+        profs = self.caller.db.proficiencies or {}
+        for sk in known:
+            table.add_row(sk, f"{profs.get(sk, 0)}%")
+        self.msg(str(table))
+
+
+class CmdKick(Command):
+    """Kick an opponent to start combat."""
+
+    key = "kick"
+    help_category = "Combat"
+
+    def func(self):
+        if not self.args:
+            self.msg("Kick whom?")
+            return
+        target = self.caller.search(self.args.strip())
+        if not target:
+            return
+        skill = Kick()
+        if not self.caller.cooldowns.ready(skill.name):
+            self.msg("You are still recovering.")
+            return
+        if self.caller.traits.stamina.current < skill.stamina_cost:
+            self.msg("You are too exhausted.")
+            return
+        self.caller.traits.stamina.current -= skill.stamina_cost
+        state_manager.add_cooldown(self.caller, skill.name, skill.cooldown)
+        inst = maybe_start_combat(self.caller, target)
+        inst.engine.queue_action(self.caller, SkillAction(self.caller, skill, target))
+
+
+class AbilityCmdSet(CmdSet):
+    key = "Ability CmdSet"
+
+    def at_cmdset_creation(self):
+        super().at_cmdset_creation()
+        self.add(CmdSkills)
+        self.add(CmdKick)

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -45,6 +45,7 @@ from commands.admin import AdminCmdSet, BuilderCmdSet
 from commands.quests import QuestCmdSet
 from commands.achievements import AchievementCmdSet
 from commands.spells import SpellCmdSet
+from commands.abilities import AbilityCmdSet
 
 
 class CharacterCmdSet(default_cmds.CharacterCmdSet):
@@ -74,6 +75,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(XYZGridCmdSet)
         self.add(CmdCraft)
         self.add(CombatCmdSet)
+        self.add(AbilityCmdSet)
         self.add(SkillCmdSet)
         self.add(SpellCmdSet)
         self.add(InteractCmdSet)

--- a/world/skills/__init__.py
+++ b/world/skills/__init__.py
@@ -1,0 +1,4 @@
+from .skill import Skill
+from .kick import Kick
+
+__all__ = ["Skill", "Kick"]

--- a/world/skills/kick.py
+++ b/world/skills/kick.py
@@ -1,0 +1,31 @@
+from combat.combat_actions import CombatResult
+from combat.combat_utils import roll_damage, roll_evade
+from combat.damage_types import DamageType
+from world.system import stat_manager, state_manager
+from .skill import Skill
+
+
+class Kick(Skill):
+    """Basic unarmed kick attack."""
+
+    name = "kick"
+    cooldown = 4
+    stamina_cost = 5
+    damage = (1, 4)
+
+    def resolve(self, user, target):
+        self.improve(user)
+        if not stat_manager.check_hit(user, target):
+            return CombatResult(actor=user, target=target, message=f"{user.key}'s kick misses {target.key}.")
+        if roll_evade(user, target):
+            return CombatResult(actor=user, target=target, message=f"{target.key} evades the kick!")
+        dmg = roll_damage(self.damage)
+        str_val = state_manager.get_effective_stat(user, "STR")
+        dmg = int(dmg + str_val * 0.2)
+        return CombatResult(
+            actor=user,
+            target=target,
+            message=f"{user.key} kicks {target.key}!",
+            damage=dmg,
+            damage_type=DamageType.BLUDGEONING,
+        )

--- a/world/skills/skill.py
+++ b/world/skills/skill.py
@@ -1,0 +1,23 @@
+class Skill:
+    """Base skill providing proficiency tracking."""
+
+    name = "skill"
+    cooldown = 0
+    stamina_cost = 0
+
+    def improve(self, user) -> None:
+        """Increase proficiency by 1% every 25 uses."""
+        uses = user.db.skill_uses or {}
+        count = uses.get(self.name, 0) + 1
+        uses[self.name] = count
+        user.db.skill_uses = uses
+        profs = user.db.proficiencies or {}
+        if count % 25 == 0:
+            prof = profs.get(self.name, 0)
+            if prof < 100:
+                profs[self.name] = min(100, prof + 1)
+                user.db.proficiencies = profs
+
+    def resolve(self, user, target):
+        """Override in subclasses to produce a CombatResult."""
+        raise NotImplementedError

--- a/world/skills/utils.py
+++ b/world/skills/utils.py
@@ -1,0 +1,21 @@
+from combat.round_manager import CombatRoundManager
+
+
+def maybe_start_combat(attacker, target):
+    """Ensure ``attacker`` and ``target`` are in combat together."""
+    manager = CombatRoundManager.get()
+    inst = manager.get_combatant_combat(attacker)
+    if inst:
+        if target not in inst.combatants:
+            inst.add_combatant(target)
+    else:
+        inst = manager.get_combatant_combat(target)
+        if inst:
+            inst.add_combatant(attacker)
+        else:
+            inst = manager.start_combat([attacker, target])
+    if hasattr(attacker, "db"):
+        attacker.db.combat_target = target
+    if hasattr(target, "db"):
+        target.db.combat_target = attacker
+    return inst

--- a/world/system/state_manager.py
+++ b/world/system/state_manager.py
@@ -32,6 +32,17 @@ def _save_effect_dict(chara, data):
     chara.db.active_effects = data
 
 
+def grant_ability(chara, key: str) -> None:
+    """Add ``key`` to ``chara.db.skills`` if not already present."""
+    skills = chara.db.skills or []
+    if key not in skills:
+        skills.append(key)
+        chara.db.skills = skills
+    profs = chara.db.proficiencies or {}
+    profs.setdefault(key, 0)
+    chara.db.proficiencies = profs
+
+
 def add_temp_stat_bonus(
     chara, stat: str, amount: int, duration: int, effect_key: str | None = None
 ):


### PR DESCRIPTION
## Summary
- implement basic Skill base class and Kick skill
- provide helper to start combat safely
- expose CmdSkills and CmdKick via new AbilityCmdSet
- allow granting skills with `grant_ability`
- register ability commands in default cmdset

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684f4c5bd820832c96b6b33e948cdfaa