### PR TITLE
Remove redundant stamina deduction in kick command

### DIFF
--- a/commands/abilities.py
+++ b/commands/abilities.py
@@ -45,7 +45,6 @@ class CmdKick(Command):
         if self.caller.traits.stamina.current < skill.stamina_cost:
             self.msg("You are too exhausted.")
             return
-        self.caller.traits.stamina.current -= skill.stamina_cost
         state_manager.add_cooldown(self.caller, skill.name, skill.cooldown)
         inst = maybe_start_combat(self.caller, target)
         inst.engine.queue_action(self.caller, SkillAction(self.caller, skill, target))


### PR DESCRIPTION
## Summary
- stop manually deducting stamina when kicking, since `SkillAction` handles it

## Testing
- `pytest -q` *(fails: OperationalError no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684f52519a88832c95461ddcda419928