### PR TITLE
Implement random proficiency gains

### DIFF
--- a/world/skills/skill.py
+++ b/world/skills/skill.py
@@ -1,3 +1,6 @@
+from random import random
+
+
 class Skill:
     """Base skill providing proficiency tracking."""
 
@@ -6,17 +9,26 @@ class Skill:
     stamina_cost = 0
 
     def improve(self, user) -> None:
-        """Increase proficiency by 1% every 25 uses."""
+        """Increase proficiency by 1% every 25 uses and randomly."""
         uses = user.db.skill_uses or {}
         count = uses.get(self.name, 0) + 1
         uses[self.name] = count
         user.db.skill_uses = uses
         profs = user.db.proficiencies or {}
-        if count % 25 == 0:
-            prof = profs.get(self.name, 0)
-            if prof < 100:
-                profs[self.name] = min(100, prof + 1)
-                user.db.proficiencies = profs
+        prof = profs.get(self.name, 0)
+
+        improved = False
+        if prof < 100 and random() <= 0.15:
+            prof += 1
+            improved = True
+
+        if count % 25 == 0 and prof < 100:
+            prof += 1
+            improved = True
+
+        if improved:
+            profs[self.name] = min(100, prof)
+            user.db.proficiencies = profs
 
     def resolve(self, user, target):
         """Override in subclasses to produce a CombatResult."""


### PR DESCRIPTION
## Summary
- add optional random chance to increase skill proficiency in `Skill.improve`

## Testing
- `bash scripts/setup_test_env.sh` *(fails: could not install dependencies)*
- `pytest -q` *(fails: environment missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684f53e38cfc832c8e36e490ba2cdd83