### PR TITLE
Implement skills command

### DIFF
--- a/commands/abilities.py
+++ b/commands/abilities.py
@@ -9,20 +9,23 @@ from world.system import state_manager
 
 
 class CmdSkills(Command):
-    """List known skills and proficiency."""
+    """Display known skills and current proficiency."""
 
     key = "skills"
 
     def func(self):
-        known = self.caller.db.skills or []
+        caller = self.caller
+        known = caller.db.skills or []
         if not known:
-            self.msg("You do not know any skills.")
+            caller.msg("|rYou do not know any skills.|n")
             return
+
         table = EvTable("Skill", "Proficiency")
-        profs = self.caller.db.proficiencies or {}
-        for sk in known:
-            table.add_row(sk, f"{profs.get(sk, 0)}%")
-        self.msg(str(table))
+        profs = caller.db.proficiencies or {}
+        for skill in sorted(known):
+            table.add_row(skill, f"{profs.get(skill, 0)}%")
+
+        caller.msg(str(table))
 
 
 class CmdKick(Command):

--- a/commands/skills.py
+++ b/commands/skills.py
@@ -20,11 +20,11 @@ SKILL_DICT = {
 class CmdStatSheet(Command):
     """
     View your character's current stats and known skills.
-    (aliases: "sheet", "skills")
+    (alias: "sheet")
     """
 
     key = "stats"
-    aliases = ("sheet", "skills")
+    aliases = ("sheet",)
 
     def func(self):
         caller = self.caller


### PR DESCRIPTION
## Summary
- show learned skills and proficiency percentages via `skills`
- remove alias conflict in stat sheet command

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684f5780dbfc832ca142a31cdc5de53c