### PR TITLE
Improve skill tracking

### DIFF
--- a/combat/combat_skills.py
+++ b/combat/combat_skills.py
@@ -18,6 +18,7 @@ from .combat_actions import CombatResult
 from .combat_utils import roll_damage, roll_evade
 from .combat_states import CombatState
 from world.system import stat_manager
+from world.skills.kick import Kick
 
 
 @dataclass
@@ -97,4 +98,5 @@ class Cleave(Skill):
 SKILL_CLASSES: Dict[str, type[Skill]] = {
     "shield bash": ShieldBash,
     "cleave": Cleave,
+    "kick": Kick,
 }

--- a/typeclasses/tests/test_skill_granting.py
+++ b/typeclasses/tests/test_skill_granting.py
@@ -1,0 +1,35 @@
+from unittest.mock import patch
+from evennia.utils.test_resources import EvenniaTest
+from commands.abilities import AbilityCmdSet
+from world.skills.kick import Kick
+from world.system import state_manager
+
+class TestGrantAbility(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.char1.cmdset.add_default(AbilityCmdSet)
+        self.char1.msg = lambda *args, **kwargs: None
+        state_manager.grant_ability(self.char1, "kick")
+
+    def test_grant_persists(self):
+        self.assertIn("kick", self.char1.db.skills)
+        self.assertEqual(self.char1.db.proficiencies.get("kick"), 0)
+        self.assertEqual(self.char1.db.skill_uses.get("kick"), 0)
+
+    def test_use_tracks_progress(self):
+        class DummyEngine:
+            def queue_action(self, actor, action):
+                action.resolve()
+
+        class DummyCombat:
+            def __init__(self):
+                self.engine = DummyEngine()
+
+        self.char1.db.skill_uses["kick"] = 24
+        with patch("commands.abilities.maybe_start_combat", return_value=DummyCombat()), \
+             patch("world.skills.skill.random", return_value=1):
+            self.char1.execute_cmd(f"kick {self.char2.key}")
+
+        self.assertEqual(self.char1.db.skill_uses["kick"], 25)
+        self.assertEqual(self.char1.db.proficiencies["kick"], 1)
+

--- a/world/system/state_manager.py
+++ b/world/system/state_manager.py
@@ -38,9 +38,14 @@ def grant_ability(chara, key: str) -> None:
     if key not in skills:
         skills.append(key)
         chara.db.skills = skills
+
     profs = chara.db.proficiencies or {}
     profs.setdefault(key, 0)
     chara.db.proficiencies = profs
+
+    uses = chara.db.skill_uses or {}
+    uses.setdefault(key, 0)
+    chara.db.skill_uses = uses
 
 
 def add_temp_stat_bonus(


### PR DESCRIPTION
## Summary
- persist initial skill usage counts
- include Kick in combat skill registry
- test granting abilities and tracking usage

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684f59664200832cb80338aa4caf3a7a