### PR TITLE
Add class skills mapping

### DIFF
--- a/world/system/__init__.py
+++ b/world/system/__init__.py
@@ -3,5 +3,6 @@
 from . import state_manager
 from . import stat_manager
 from . import constants
+from . import class_skills
 
-__all__ = ["state_manager", "stat_manager", "constants"]
+__all__ = ["state_manager", "stat_manager", "constants", "class_skills"]

--- a/world/system/class_skills.py
+++ b/world/system/class_skills.py
@@ -1,0 +1,36 @@
+"""Class skill progression definitions."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+# Mapping of class names to level->skills lists
+CLASS_SKILLS: Dict[str, Dict[int, List[str]]] = {
+    "Warrior": {
+        1: ["kick"],
+        2: ["cleave"],
+        3: ["shield bash"],
+    },
+    "Mage": {
+        1: ["kick"],
+    },
+}
+
+
+def get_class_skills(charclass: str, level: int) -> List[str]:
+    """Return skills granted to ``charclass`` up to ``level``."""
+    if level <= 0:
+        return []
+    skills: List[str] = []
+    table = CLASS_SKILLS.get(charclass)
+    if not table:
+        return skills
+    for lvl in sorted(table):
+        if lvl > level:
+            break
+        skills.extend(table[lvl])
+    return list(dict.fromkeys(skills))
+
+
+__all__ = ["CLASS_SKILLS", "get_class_skills"]
+


### PR DESCRIPTION
## Summary
- provide `world/system/class_skills.py` with sample skill progression
- expose the module in `world.system`

## Testing
- `pytest -q` *(fails: OperationalError no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684f5f6b8958832cb895c8871fd6f8cb