### PR TITLE
Add admin update command

### DIFF
--- a/commands/admin.py
+++ b/commands/admin.py
@@ -5,6 +5,7 @@ import re
 from evennia.utils.ansi import strip_ansi
 from .command import Command
 from .info import CmdScan
+from .update import CmdUpdate
 from .building import (
     CmdSetDesc,
     CmdSetWeight,
@@ -1396,6 +1397,7 @@ class AdminCmdSet(CmdSet):
         self.add(CmdPurge)
         self.add(CmdPeace)
         self.add(CmdForceMobReport)
+        self.add(CmdUpdate)
         self.add(CmdScan)
 
 

--- a/commands/update.py
+++ b/commands/update.py
@@ -1,0 +1,44 @@
+from evennia import CmdSet
+from .command import Command
+from world.system.class_skills import get_class_skills
+from world.system import state_manager
+
+
+class CmdUpdate(Command):
+    """Update a character's skills based on their class and level."""
+
+    key = "update"
+    locks = "cmd:perm(Admin)"
+    help_category = "Admin"
+
+    def func(self):
+        caller = self.caller
+        if not self.args:
+            caller.msg("Usage: update <target>")
+            return
+        target = caller.search(self.args.strip(), global_search=True)
+        if not target:
+            return
+        charclass = target.db.charclass
+        level = target.db.level
+        if not charclass or level is None:
+            caller.msg(f"{target.key} lacks a class or level.")
+            return
+        existing = set(target.db.skills or [])
+        learned = []
+        for skill in get_class_skills(charclass, level):
+            if skill not in existing:
+                learned.append(skill)
+            state_manager.grant_ability(target, skill)
+        if learned:
+            caller.msg(f"{target.key} learns: {', '.join(learned)}")
+        else:
+            caller.msg(f"{target.key} already knows all appropriate skills.")
+
+
+class UpdateCmdSet(CmdSet):
+    key = "Update CmdSet"
+
+    def at_cmdset_creation(self):
+        super().at_cmdset_creation()
+        self.add(CmdUpdate)


### PR DESCRIPTION
## Summary
- add Update command for admins
- wire Update command into Admin command set

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684f61181fcc832c9c15c01391806065