### PR TITLE
Fix kick skill immediate damage

### DIFF
--- a/world/skills/kick.py
+++ b/world/skills/kick.py
@@ -14,18 +14,35 @@ class Kick(Skill):
     damage = (1, 4)
 
     def resolve(self, user, target):
+        """Resolve the kick immediately, applying damage to ``target``."""
+
         self.improve(user)
+
         if not stat_manager.check_hit(user, target):
-            return CombatResult(actor=user, target=target, message=f"{user.key}'s kick misses {target.key}.")
+            return CombatResult(
+                actor=user,
+                target=target,
+                message=f"{user.key}'s kick misses {target.key}.",
+            )
+
         if roll_evade(user, target):
-            return CombatResult(actor=user, target=target, message=f"{target.key} evades the kick!")
+            return CombatResult(
+                actor=user,
+                target=target,
+                message=f"{target.key} evades the kick!",
+            )
+
         dmg = roll_damage(self.damage)
         str_val = state_manager.get_effective_stat(user, "STR")
         dmg = int(dmg + str_val * 0.2)
+
+        if hasattr(target, "at_damage"):
+            target.at_damage(user, dmg, DamageType.BLUDGEONING)
+        elif hasattr(target, "hp"):
+            target.hp = max(target.hp - dmg, 0)
+
         return CombatResult(
             actor=user,
             target=target,
             message=f"{user.key} kicks {target.key}!",
-            damage=dmg,
-            damage_type=DamageType.BLUDGEONING,
         )


### PR DESCRIPTION
## Summary
- resolve `kick` skill instantly when used
- subtract stamina cost and call skill directly in `kick` command

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684f69c2ede0832c835a8e264f1f4eca