### PR TITLE
Implement immediate kick command

### DIFF
--- a/commands/abilities.py
+++ b/commands/abilities.py
@@ -35,11 +35,15 @@ class CmdKick(Command):
 
     def func(self):
         if not self.args:
-            self.msg("Kick whom?")
-            return
-        target = self.caller.search(self.args.strip())
-        if not target:
-            return
+            if self.caller.in_combat and self.caller.db.combat_target:
+                target = self.caller.db.combat_target
+            else:
+                self.msg("Kick whom?")
+                return
+        else:
+            target = self.caller.search(self.args.strip())
+            if not target:
+                return
         skill = Kick()
         if not self.caller.cooldowns.ready(skill.name):
             self.msg("You are still recovering.")


### PR DESCRIPTION
## Summary
- implement Kick ability with STR damage scaling
- auto-target current combat opponent in `kick` command
- add unit tests for auto-targeting and STR scaling

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684f6c331824832cbaee9cbeddd2a74e