### PR TITLE
Apply damage dice fallback and bonus

### DIFF
--- a/combat/actions/utils.py
+++ b/combat/actions/utils.py
@@ -4,7 +4,7 @@ import logging
 from typing import Tuple
 
 from ..damage_types import DamageType
-from ..combat_utils import roll_damage, roll_evade, roll_parry, roll_block
+from ..combat_utils import roll_evade, roll_parry, roll_block
 from utils import roll_dice_string
 from world.system import state_manager, stat_manager
 
@@ -56,16 +56,14 @@ def calculate_damage(attacker, weapon, target) -> Tuple[int, object]:
                             dtype = dt
                 else:
                     dice = getattr(db, "damage_dice", None)
-                    if dice:
-                        try:
-                            num, sides = map(int, str(dice).lower().split("d"))
-                        except (TypeError, ValueError):
-                            logger.error("Invalid damage_dice '%s' on %s", dice, weapon)
-                            dmg = int(getattr(db, "dmg", 0))
-                        else:
-                            dmg = roll_damage((num, sides))
-                    else:
+                    dice = dice or "1d2"
+                    try:
+                        dmg = roll_dice_string(str(dice))
+                    except Exception:
+                        logger.error("Invalid damage_dice '%s' on %s", dice, weapon)
                         dmg = int(getattr(db, "dmg", 0))
+                    bonus = getattr(db, "damage_bonus", 0)
+                    dmg += int(bonus)
 
         if dmg is None:
             dmg = 0

--- a/typeclasses/tests/test_combat_flow.py
+++ b/typeclasses/tests/test_combat_flow.py
@@ -119,13 +119,12 @@ class TestAttackAction(unittest.TestCase):
         with patch("combat.combat_actions.utils.inherits_from", return_value=True), \
              patch("world.system.state_manager.apply_regen"), \
              patch("world.system.state_manager.get_effective_stat", return_value=0), \
-             patch("random.randint", return_value=0), \
-             patch("combat.combat_utils.roll_damage", return_value=3) as mock_roll:
+             patch("combat.actions.utils.roll_dice_string", return_value=3) as mock_roll:
             engine.start_round()
             engine.process_round()
 
         self.assertEqual(defender.hp, 3)
-        mock_roll.assert_called_with((1, 4))
+        mock_roll.assert_called_with("1d4")
 
     def test_attack_uses_db_damage_mapping(self):
         attacker = Dummy()

--- a/utils/tests/test_action_helpers.py
+++ b/utils/tests/test_action_helpers.py
@@ -76,6 +76,52 @@ class TestActionUtils(unittest.TestCase):
         self.assertEqual(dmg1, dmg2)
         self.assertEqual(dtype1, dtype2)
 
+    def test_damage_bonus_applied_and_scaled(self):
+        """Damage bonus should be added before stat scaling."""
+        from combat.actions import utils
+
+        weapon = MagicMock()
+        weapon.damage = None
+        weapon.damage_type = None
+        weapon.db = MagicMock()
+        weapon.db.damage = None
+        weapon.db.damage_dice = "1d4"
+        weapon.db.damage_bonus = 5
+
+        with patch("combat.actions.utils.roll_dice_string", return_value=2), \
+             patch(
+                 "combat.actions.utils.state_manager.get_effective_stat",
+                 side_effect=lambda obj, stat: 10 if stat == "STR" else 0,
+             ):
+            dmg, dtype = utils.calculate_damage(self.attacker, weapon, self.target)
+
+        expected = int(round((2 + 5) * (1 + 10 * 0.012)))
+        self.assertEqual(dmg, expected)
+        self.assertEqual(dtype, DamageType.BLUDGEONING)
+
+    def test_damage_default_dice_and_bonus(self):
+        """Missing damage_dice should fallback to '1d2' and include bonus."""
+        from combat.actions import utils
+
+        weapon = MagicMock()
+        weapon.damage = None
+        weapon.damage_type = None
+        weapon.db = MagicMock()
+        weapon.db.damage = None
+        weapon.db.damage_dice = None
+        weapon.db.damage_bonus = 1
+
+        with patch("combat.actions.utils.roll_dice_string", return_value=2) as mock_roll, \
+             patch(
+                 "combat.actions.utils.state_manager.get_effective_stat",
+                 side_effect=lambda obj, stat: 0,
+             ):
+            dmg, dtype = utils.calculate_damage(self.attacker, weapon, self.target)
+
+        mock_roll.assert_called_once_with("1d2")
+        self.assertEqual(dmg, 3)
+        self.assertEqual(dtype, DamageType.BLUDGEONING)
+
     def test_apply_critical(self):
         from combat.actions import utils
         with patch("combat.actions.utils.stat_manager.roll_crit", return_value=True), \


### PR DESCRIPTION
## Summary
- add dice fallback and damage bonus in damage calculation
- update combat flow tests to expect dice parsing
- ensure damage bonus scaling tested

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684f70f58dcc832c94fa3f7f879d6dc7