### PR TITLE
Fix natural weapon damage fields

### DIFF
--- a/typeclasses/tests/test_combat_flow.py
+++ b/typeclasses/tests/test_combat_flow.py
@@ -175,7 +175,11 @@ def test_npc_attack_uses_natural_weapon(self):
     defender = Dummy()
     attacker.wielding = []
     attacker.location = defender.location
-    attacker.db.natural_weapon = {"damage": 5, "damage_type": DamageType.PIERCING}
+    attacker.db.natural_weapon = {
+        "damage_dice": "1d1",
+        "damage_bonus": 4,
+        "damage_type": DamageType.PIERCING,
+    }
 
     engine = CombatEngine([attacker, defender], round_time=0)
     engine.queue_action(attacker, AttackAction(attacker, defender))
@@ -245,7 +249,10 @@ def test_auto_attack_uses_combat_target():
     attacker = Dummy()
     defender = Dummy(hp=2)
     attacker.location = defender.location
-    attacker.db.natural_weapon = {"damage": 1, "damage_type": DamageType.BLUDGEONING}
+    attacker.db.natural_weapon = {
+        "damage_dice": "1d1",
+        "damage_type": DamageType.BLUDGEONING,
+    }
     attacker.db.combat_target = defender
 
     engine = CombatEngine([attacker, defender], round_time=0)
@@ -267,7 +274,10 @@ def test_haste_grants_extra_attacks():
     attacker = Dummy()
     defender = Dummy()
     attacker.location = defender.location
-    attacker.db.natural_weapon = {"damage": 1, "damage_type": DamageType.BLUDGEONING}
+    attacker.db.natural_weapon = {
+        "damage_dice": "1d1",
+        "damage_type": DamageType.BLUDGEONING,
+    }
     attacker.db.combat_target = defender
 
     engine = CombatEngine([attacker, defender], round_time=0)

--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -362,7 +362,8 @@ ANGRY_BEAR = {
     "natural_weapon": {
         "name": "claws",
         "damage_type": "slash",
-        "damage": 10,
+        "damage_dice": "1d1",
+        "damage_bonus": 9,
         "speed": 8,
         "stamina_cost": 10,
     },
@@ -386,7 +387,8 @@ COUGAR = {
     "natural_weapon": {
         "name": "claws",
         "damage_type": "slash",
-        "damage": 10,
+        "damage_dice": "1d1",
+        "damage_bonus": 9,
         "speed": 8,
         "stamina_cost": 10,
     },
@@ -439,7 +441,8 @@ STAG_DEER = {
     "natural_weapon": {
         "name": "antlers",
         "damage_type": "pierce",
-        "damage": 10,
+        "damage_dice": "1d1",
+        "damage_bonus": 9,
         "speed": 10,
         "stamina_cost": 5,
     },

--- a/world/prototypes/npcs.json
+++ b/world/prototypes/npcs.json
@@ -69,6 +69,6 @@
         "npc_type": "base",
         "race": "human",
         "level": 1,
-        "damage": 1
+        "damage_dice": "1d2"
     }
 }


### PR DESCRIPTION
## Summary
- support `damage_dice` and `damage_bonus` for dict weapons
- update natural weapons to use dice/bonus instead of damage
- tweak test data for new damage fields

## Testing
- `scripts/setup_test_env.sh` *(fails: Could not install dependencies)*
- `pytest -q` *(fails: Django database errors, fixture issues)*

------
https://chatgpt.com/codex/tasks/task_e_684f72e261e0832c946a29ac29f2a4ef