### PR TITLE
Update unarmed damage handling

### DIFF
--- a/combat/actions/utils.py
+++ b/combat/actions/utils.py
@@ -67,7 +67,7 @@ def calculate_damage(attacker, weapon, target) -> Tuple[int, object]:
                             if i == 0:
                                 dtype = dt
                     else:
-                        dice = getattr(db, "damage_dice", None) or "1d2"
+                        dice = getattr(db, "damage_dice", None) or "2d6"
                         try:
                             dmg = roll_dice_string(str(dice))
                         except Exception:

--- a/typeclasses/gear.py
+++ b/typeclasses/gear.py
@@ -15,7 +15,8 @@ class BareHand:
     A dummy "object" class that provides basic combat functionality for unarmed combat
     """
 
-    damage = 1
+    damage = None
+    damage_dice = "2d6"
     stamina_cost = 3
     skill = "unarmed"
     name = "fists"
@@ -40,6 +41,12 @@ class BareHand:
                 wielder.msg("You can't attack that.")
             return
         damage = self.damage
+        if damage is None:
+            try:
+                damage = roll_dice_string(str(self.damage_dice))
+            except Exception:
+                logger.log_err(f"Invalid damage_dice '{self.damage_dice}' on BareHand")
+                damage = 0
         hit_bonus = 0.0
         dmg_bonus = 0.0
         from world.skills.unarmed_passive import Unarmed

--- a/typeclasses/tests/test_combat_flow.py
+++ b/typeclasses/tests/test_combat_flow.py
@@ -328,7 +328,7 @@ def test_npc_damage_dice_with_bonus():
     assert defender.hp == 4
 
 
-def test_npc_damage_dice_fallback_to_1d2():
+def test_npc_damage_dice_fallback_to_2d6():
     attacker = Dummy()
     defender = Dummy()
     attacker.location = defender.location
@@ -352,5 +352,5 @@ def test_npc_damage_dice_fallback_to_1d2():
         engine.process_round()
 
     assert defender.hp == 8
-    mock_roll.assert_called_with("1d2")
+    mock_roll.assert_called_with("2d6")
 

--- a/typeclasses/tests/test_extended_stats.py
+++ b/typeclasses/tests/test_extended_stats.py
@@ -36,10 +36,10 @@ class TestExtendedStats(EvenniaTest):
         self.char2.traits.armor.base = 0
         with patch("combat.combat_utils.random.randint", return_value=100), patch(
             "world.system.stat_manager.check_hit", return_value=True
-        ):
+        ), patch("typeclasses.gear.roll_dice_string", return_value=2):
             before = self.char2.traits.health.current
             BareHand().at_attack(self.char1, self.char2)
-            self.assertLess(self.char2.traits.health.current, before - BareHand().damage)
+            self.assertLess(self.char2.traits.health.current, before - 2)
 
     def test_piercing_reduces_armor(self):
         self.char1.traits.piercing.base = 5

--- a/utils/tests/test_action_helpers.py
+++ b/utils/tests/test_action_helpers.py
@@ -100,7 +100,7 @@ class TestActionUtils(unittest.TestCase):
         self.assertEqual(dtype, DamageType.BLUDGEONING)
 
     def test_damage_default_dice_and_bonus(self):
-        """Missing damage_dice should fallback to '1d2' and include bonus."""
+        """Missing damage_dice should fallback to '2d6' and include bonus."""
         from combat.actions import utils
 
         weapon = MagicMock()
@@ -118,7 +118,7 @@ class TestActionUtils(unittest.TestCase):
              ):
             dmg, dtype = utils.calculate_damage(self.attacker, weapon, self.target)
 
-        mock_roll.assert_called_once_with("1d2")
+        mock_roll.assert_called_once_with("2d6")
         self.assertEqual(dmg, 3)
         self.assertEqual(dtype, DamageType.BLUDGEONING)
 

--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -405,6 +405,7 @@ SQUIRREL = {
     "react_as": "timid",
     "gender": "neutral",
     "drops": lambda: ["RAW_MEAT"] * randint(0, 1),
+    "damage_dice": "1d2",
     "can_attack": True,
 }
 
@@ -415,6 +416,7 @@ PHEASANT = {
     "react_as": "timid",
     "gender": "neutral",
     "drops": lambda: ["RAW_MEAT"] * randint(0, 1),
+    "damage_dice": "1d2",
     "can_attack": True,
 }
 
@@ -426,6 +428,7 @@ DOE_DEER = {
     "react_as": "timid",
     "armor": 10,
     "DEX": 15,
+    "damage_dice": "1d2",
     "can_attack": True,
     # randomly generate a list of drop prototype keys when the mob is spawned
     "drops": lambda: ["DEER_MEAT"] * randint(1, 3) + ["ANIMAL_HIDE"] * randint(0, 3),


### PR DESCRIPTION
## Summary
- tweak `BareHand` so unarmed damage comes from dice
- default dice strings use 2d6 instead of 1d2
- keep old weak damage for wildlife prototypes
- adjust tests for new dice values

## Testing
- `pytest -q` *(fails: django.db.utils.OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684f80ff540c832ca2d9233b6d30a846