### PR TITLE
Adjust damage scaling

### DIFF
--- a/combat/actions/utils.py
+++ b/combat/actions/utils.py
@@ -36,7 +36,7 @@ def calculate_damage(attacker, weapon, target) -> Tuple[int, object]:
 
         if isinstance(weapon, dict):
             dmg = weapon.get("damage")
-            dtype = weapon.get("damage_type", DamageType.BLUDGEONING)
+            dtype = weapon.get("damage_type") or DamageType.BLUDGEONING
             if dmg is None:
                 dice = weapon.get("damage_dice")
                 if dice:
@@ -50,7 +50,7 @@ def calculate_damage(attacker, weapon, target) -> Tuple[int, object]:
 
         else:
             dmg = getattr(weapon, "damage", None)
-            dtype = getattr(weapon, "damage_type", DamageType.BLUDGEONING)
+            dtype = getattr(weapon, "damage_type", None) or DamageType.BLUDGEONING
 
             if dmg is None:
                 db = getattr(weapon, "db", None)
@@ -84,7 +84,7 @@ def calculate_damage(attacker, weapon, target) -> Tuple[int, object]:
         # Scale with stats
         str_val = state_manager.get_effective_stat(attacker, "STR")
         dex_val = state_manager.get_effective_stat(attacker, "DEX")
-        dmg = int(round(dmg * (1 + str_val * 0.012 + dex_val * 0.004)))
+        dmg = int(round(dmg * (1 + str_val * 0.05 + dex_val * 0.02)))
 
     return dmg, dtype
 

--- a/utils/tests/test_action_helpers.py
+++ b/utils/tests/test_action_helpers.py
@@ -41,7 +41,7 @@ class TestActionUtils(unittest.TestCase):
             mock_get.side_effect = lambda obj, stat: 10 if stat == "STR" else 0
             dmg, dtype = utils.calculate_damage(self.attacker, weapon, self.target)
         self.assertEqual(dtype, DamageType.SLASHING)
-        self.assertEqual(dmg, int(round(4 * (1 + 10 * 0.012))))
+        self.assertEqual(dmg, int(round(4 * (1 + 10 * 0.05))))
 
     def test_damage_mapping_stable_order(self):
         """Weapon damage mapping should produce consistent results regardless of key order."""
@@ -95,7 +95,7 @@ class TestActionUtils(unittest.TestCase):
              ):
             dmg, dtype = utils.calculate_damage(self.attacker, weapon, self.target)
 
-        expected = int(round((2 + 5) * (1 + 10 * 0.012)))
+        expected = int(round((2 + 5) * (1 + 10 * 0.05)))
         self.assertEqual(dmg, expected)
         self.assertEqual(dtype, DamageType.BLUDGEONING)
 


### PR DESCRIPTION
## Summary
- update `calculate_damage` formula for str/dex scaling
- fix fallback of damage type for None values
- update tests for new multipliers

## Testing
- `pytest -q utils/tests/test_action_helpers.py`

------
https://chatgpt.com/codex/tasks/task_e_684f83b28990832c9cef9af40fc1d071