### PR TITLE
Tune auto attack accuracy

### DIFF
--- a/combat/actions/utils.py
+++ b/combat/actions/utils.py
@@ -13,14 +13,14 @@ logger = logging.getLogger(__name__)
 
 def check_hit(attacker, target, bonus: float = 0.0) -> Tuple[bool, str]:
     """Return ``(True, '')`` on hit or ``(False, message)`` on failure."""
-    base = 75 + int(bonus)
+    base = 85 + int(bonus)
     if not stat_manager.check_hit(attacker, target, base=base):
         return False, f"{attacker.key} misses."
-    if roll_evade(attacker, target):
+    if roll_evade(attacker, target, base=20):
         return False, f"{target.key} evades the attack!"
-    if roll_parry(attacker, target):
+    if roll_parry(attacker, target, base=20):
         return False, f"{target.key} parries the attack!"
-    if roll_block(attacker, target):
+    if roll_block(attacker, target, base=20):
         return False, f"{target.key} blocks the attack!"
     return True, ""
 

--- a/typeclasses/tests/test_auto_attack_accuracy.py
+++ b/typeclasses/tests/test_auto_attack_accuracy.py
@@ -1,0 +1,49 @@
+import unittest
+from itertools import cycle
+from unittest.mock import patch
+
+from combat.actions.utils import check_hit
+
+
+class Dummy:
+    def __init__(self, key="dummy"):
+        self.key = key
+
+
+class TestAutoAttackAccuracy(unittest.TestCase):
+    def test_auto_attack_hit_rate(self):
+        attacker = Dummy("attacker")
+        defender = Dummy("defender")
+
+        hit_rng = cycle(range(1, 101))
+        evade_rng = cycle(range(1, 101))
+
+        def rand_hit(*args, **kwargs):
+            return next(hit_rng)
+
+        def rand_evade(*args, **kwargs):
+            return next(evade_rng)
+
+        def get_stat(obj, stat):
+            if obj is attacker and stat == "accuracy":
+                return 12
+            return 0
+
+        hits = 0
+        trials = 100
+        with patch("world.system.stat_manager.randint", side_effect=rand_hit), \
+             patch("combat.combat_utils.random.randint", side_effect=rand_evade), \
+             patch("world.system.stat_manager.get_effective_stat", side_effect=get_stat), \
+             patch("world.system.state_manager.get_effective_stat", side_effect=get_stat):
+            for _ in range(trials):
+                success, _ = check_hit(attacker, defender)
+                if success:
+                    hits += 1
+
+        rate = hits / trials
+        self.assertGreaterEqual(rate, 0.70)
+        self.assertLessEqual(rate, 0.80)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- bump base hit chance in auto attacks
- lower base chances for evade/parry/block
- test that autos hit most of the time

## Testing
- `pytest -q typeclasses/tests/test_auto_attack_accuracy.py`

------
https://chatgpt.com/codex/tasks/task_e_684f86df37c4832cb86db242594239a4