### PR TITLE
Apply unarmed bonus inside damage calc

### DIFF
--- a/combat/actions/utils.py
+++ b/combat/actions/utils.py
@@ -81,6 +81,22 @@ def calculate_damage(attacker, weapon, target) -> Tuple[int, object]:
 
         dmg += dmg_bonus
 
+        # Apply unarmed skill bonuses when no weapon is wielded
+        unarmed = not getattr(attacker, "wielding", [])
+        if unarmed:
+            from world.skills.unarmed_passive import Unarmed
+            from world.skills.hand_to_hand import HandToHand
+
+            dmg_bonus_pct = 0.0
+            skills = getattr(getattr(attacker, "db", None), "skills", []) or []
+            for cls in (Unarmed, HandToHand):
+                if cls.name in skills:
+                    skill = cls()
+                    dmg_bonus_pct += skill.damage_bonus(attacker)
+
+            if dmg_bonus_pct:
+                dmg = int(round(dmg * (1 + dmg_bonus_pct / 100)))
+
         # Scale with stats
         str_val = state_manager.get_effective_stat(attacker, "STR")
         dex_val = state_manager.get_effective_stat(attacker, "DEX")

--- a/combat/combat_actions.py
+++ b/combat/combat_actions.py
@@ -142,17 +142,15 @@ class AttackAction(Action):
 
         unarmed = not getattr(self.actor, "wielding", [])
         hit_bonus = 0.0
-        dmg_bonus = 0.0
         if unarmed:
             from world.skills.unarmed_passive import Unarmed
             from world.skills.hand_to_hand import HandToHand
 
             for cls in (Unarmed, HandToHand):
-                if cls.name in (self.actor.db.skills or []):
+                if cls.name in (getattr(self.actor.db, "skills", []) or []):
                     skill = cls()
                     skill.improve(self.actor)
                     hit_bonus += skill.hit_bonus(self.actor)
-                    dmg_bonus += skill.damage_bonus(self.actor)
 
         hit, outcome = check_hit(self.actor, target, bonus=hit_bonus)
         if not hit:
@@ -163,8 +161,6 @@ class AttackAction(Action):
             )
 
         dmg, dtype = calculate_damage(self.actor, weapon, target)
-        if unarmed and dmg_bonus:
-            dmg = int(round(dmg * (1 + dmg_bonus / 100)))
         dmg, crit = apply_critical(self.actor, target, dmg)
 
         msg = f"{attempt}\n{self.actor.key} hits {target.key}!\n"

--- a/typeclasses/tests/test_unarmed_damage_bonus.py
+++ b/typeclasses/tests/test_unarmed_damage_bonus.py
@@ -1,0 +1,69 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from combat.engine import CombatEngine
+from combat.combat_actions import AttackAction
+from combat.damage_types import DamageType
+
+
+class Dummy:
+    def __init__(self, hp=10):
+        self.hp = hp
+        self.key = "dummy"
+        self.location = MagicMock()
+        self.traits = MagicMock()
+        self.traits.get.return_value = MagicMock(value=0)
+        self.traits.health = MagicMock(value=hp, max=hp)
+        self.traits.mana = MagicMock(current=20)
+        self.traits.stamina = MagicMock(current=20)
+        self.cooldowns = MagicMock()
+        self.cooldowns.ready.return_value = True
+        self.tags = MagicMock()
+        self.wielding = []
+        self.db = type(
+            "DB",
+            (),
+            {
+                "temp_bonuses": {},
+                "status_effects": {},
+                "active_effects": {},
+                "get": lambda *a, **k: 0,
+                "skills": ["Unarmed"],
+                "proficiencies": {"Unarmed": 50},
+                "skill_uses": {},
+            },
+        )()
+        self.attack = MagicMock()
+        self.on_enter_combat = MagicMock()
+        self.on_exit_combat = MagicMock()
+        self.cast_spell = MagicMock()
+        self.use_skill = MagicMock()
+
+
+class TestUnarmedAutoAttack(unittest.TestCase):
+    def test_unarmed_auto_attack_bonus_damage(self):
+        attacker = Dummy()
+        defender = Dummy()
+        attacker.location = defender.location
+        attacker.db.combat_target = defender
+        attacker.db.natural_weapon = {
+            "damage": 4,
+            "damage_type": DamageType.BLUDGEONING,
+        }
+
+        engine = CombatEngine([attacker, defender], round_time=0)
+
+        with patch("combat.combat_actions.utils.inherits_from", return_value=True), \
+             patch("world.system.state_manager.apply_regen"), \
+             patch("world.system.state_manager.get_effective_stat", return_value=0), \
+             patch("world.system.stat_manager.check_hit", return_value=True), \
+             patch("combat.actions.utils.roll_evade", return_value=False), \
+             patch("combat.actions.utils.roll_parry", return_value=False), \
+             patch("combat.actions.utils.roll_block", return_value=False), \
+             patch("evennia.utils.delay"):
+            engine.start_round()
+            engine.process_round()
+
+        # Base damage of 4 should be increased by 25% from Unarmed proficiency
+        # resulting in 5 damage dealt
+        self.assertEqual(defender.hp, 5)


### PR DESCRIPTION
## Summary
- add unarmed skill logic directly in `calculate_damage`
- avoid doubling bonus in `AttackAction`
- test auto‑attack damage bonus with `Unarmed` skill

## Testing
- `pytest typeclasses/tests/test_unarmed_damage_bonus.py utils/tests/test_action_helpers.py::TestActionUtils::test_calculate_damage -q`

------
https://chatgpt.com/codex/tasks/task_e_684f890aa61c832cb1fbf507f6aa221c