### PR TITLE
Switch accuracy stat to hit_chance

### DIFF
--- a/combat/combat_utils.py
+++ b/combat/combat_utils.py
@@ -82,7 +82,7 @@ def roll_evade(attacker, target, base: int = 50) -> bool:
     """Return ``True`` if ``target`` evades an attack from ``attacker``."""
 
     evade = state_manager.get_effective_stat(target, "evasion")
-    acc = state_manager.get_effective_stat(attacker, "accuracy")
+    acc = state_manager.get_effective_stat(attacker, "hit_chance")
     chance = max(5, min(95, base + evade - acc))
     roll = random.randint(1, 100)
     result = roll <= chance
@@ -99,7 +99,7 @@ def roll_block(attacker, target, base: int = 0) -> bool:
     """Return ``True`` if ``target`` blocks an attack from ``attacker``."""
 
     block = state_manager.get_effective_stat(target, "block_rate")
-    acc = state_manager.get_effective_stat(attacker, "accuracy")
+    acc = state_manager.get_effective_stat(attacker, "hit_chance")
     chance = max(0, min(95, base + block - acc))
     roll = random.randint(1, 100)
     result = roll <= chance
@@ -111,7 +111,7 @@ def roll_parry(attacker, target, base: int = 0) -> bool:
     """Return ``True`` if ``target`` parries an attack from ``attacker``."""
 
     parry = state_manager.get_effective_stat(target, "parry_rate")
-    acc = state_manager.get_effective_stat(attacker, "accuracy")
+    acc = state_manager.get_effective_stat(attacker, "hit_chance")
     chance = max(0, min(95, base + parry - acc))
     roll = random.randint(1, 100)
     result = roll <= chance

--- a/typeclasses/tests/test_admin_commands.py
+++ b/typeclasses/tests/test_admin_commands.py
@@ -197,7 +197,7 @@ class TestAdminCommands(EvenniaTest):
         """Weapon creation supports stat modifiers and description parsing."""
 
         self.char1.execute_cmd(
-            "cweapon longsword mainhand 3d10 5 STR+2, Attack Power+5, Accuracy+3 A vicious longsword."
+            "cweapon longsword mainhand 3d10 5 STR+2, Attack Power+5, Hit Chance+3 A vicious longsword."
         )
         weapon = next(
             (
@@ -211,7 +211,7 @@ class TestAdminCommands(EvenniaTest):
         self.assertEqual(weapon.db.weight, 5)
         self.assertEqual(
             weapon.db.stat_mods,
-            {"str": 2, "attack_power": 5, "accuracy": 3},
+            {"str": 2, "attack_power": 5, "hit_chance": 3},
         )
         self.assertEqual(weapon.db.desc, "A vicious longsword.")
 

--- a/typeclasses/tests/test_auto_attack_accuracy.py
+++ b/typeclasses/tests/test_auto_attack_accuracy.py
@@ -25,7 +25,7 @@ class TestAutoAttackAccuracy(unittest.TestCase):
             return next(evade_rng)
 
         def get_stat(obj, stat):
-            if obj is attacker and stat == "accuracy":
+            if obj is attacker and stat == "hit_chance":
                 return 12
             return 0
 

--- a/typeclasses/tests/test_characters.py
+++ b/typeclasses/tests/test_characters.py
@@ -355,7 +355,7 @@ class TestCombatResists(EvenniaTest):
 
     def test_status_resist_prevents_effect(self):
         from world.system import stat_manager
-        self.char1.db.stat_overrides = {"accuracy": 100}
+        self.char1.db.stat_overrides = {"hit_chance": 100}
         self.char2.db.stat_overrides = {"status_resist": 60}
         stat_manager.refresh_stats(self.char1)
         stat_manager.refresh_stats(self.char2)
@@ -372,7 +372,7 @@ class TestCombatResists(EvenniaTest):
     def test_crit_resist_reduces_crit_damage(self):
         from world.system import stat_manager
         self.char1.db.stat_overrides = {
-            "accuracy": 100,
+            "hit_chance": 100,
             "crit_chance": 50,
             "crit_bonus": 100,
         }

--- a/utils/stats_utils.py
+++ b/utils/stats_utils.py
@@ -13,7 +13,7 @@ ALIAS_MAP = {
     "stamina": "SP",
     "atk": "ATK",
     "def": "DEF",
-    "acc": "ACC",
+    "acc": "hit_chance",
     "eva": "EVA",
     "haste": "haste",
     "per": "perception",

--- a/utils/tests/test_combat_utils.py
+++ b/utils/tests/test_combat_utils.py
@@ -6,17 +6,17 @@ from world.system import stat_manager
 
 @override_settings(DEFAULT_HOME=None)
 class TestCombatCalculations(EvenniaTest):
-    def test_check_hit_uses_accuracy_and_dodge(self):
-        self.char1.db.stat_overrides = {"accuracy": 100}
+    def test_check_hit_uses_hit_chance_and_dodge(self):
+        self.char1.db.stat_overrides = {"hit_chance": 100}
         self.char2.db.stat_overrides = {"dodge": 0}
         stat_manager.refresh_stats(self.char1)
         stat_manager.refresh_stats(self.char2)
         with patch("world.system.stat_manager.randint", return_value=100):
-            self.assertFalse(stat_manager.check_hit(self.char1, self.char2, base=50))
+            self.assertFalse(stat_manager.check_hit(self.char1, self.char2))
         self.char2.db.stat_overrides = {"dodge": 200}
         stat_manager.refresh_stats(self.char2)
         with patch("world.system.stat_manager.randint", return_value=1):
-            self.assertTrue(stat_manager.check_hit(self.char1, self.char2, base=50))
+            self.assertTrue(stat_manager.check_hit(self.char1, self.char2))
 
     def test_roll_crit_respects_resist(self):
         self.char1.db.stat_overrides = {"crit_chance": 50}
@@ -67,7 +67,7 @@ class TestCombatUtils(EvenniaTest):
     def test_roll_evade(self):
         from combat import combat_utils
 
-        self.char1.db.stat_overrides = {"accuracy": 0}
+        self.char1.db.stat_overrides = {"hit_chance": 0}
         self.char2.db.stat_overrides = {"evasion": 40}
         stat_manager.refresh_stats(self.char1)
         stat_manager.refresh_stats(self.char2)

--- a/utils/tests/test_parse_stat_mods.py
+++ b/utils/tests/test_parse_stat_mods.py
@@ -19,5 +19,5 @@ class TestParseStatMods(EvenniaTest):
         self.assertEqual(mods, {"crit_chance": 2})
 
     def test_negative_modifier(self):
-        mods, _ = parse_stat_mods("accuracy-3")
-        self.assertEqual(mods, {"accuracy": -3})
+        mods, _ = parse_stat_mods("hit_chance-3")
+        self.assertEqual(mods, {"hit_chance": -3})

--- a/world/stats.py
+++ b/world/stats.py
@@ -51,7 +51,7 @@ OFFENSE_STATS: List[Stat] = [
     Stat("spell_power", "Spell Power", stat="INT"),
     Stat("crit_chance", "Critical Chance", stat="LUCK"),
     Stat("crit_bonus", "Critical Damage Bonus", stat="STR"),
-    Stat("accuracy", "Accuracy", stat="DEX"),
+    Stat("hit_chance", "Hit Chance"),
     Stat("piercing", "Armor Penetration", stat="STR"),
     Stat("spell_penetration", "Spell Penetration", stat="INT"),
 ]


### PR DESCRIPTION
## Summary
- rename Accuracy stat to Hit Chance
- compute hit chance from primary stats
- update combat utilities to use hit chance
- update stat parsing and tests

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684f8f525784832cbeddab4d2f1911cb