### PR TITLE
Fix combat hit chance logic

### DIFF
--- a/typeclasses/tests/test_auto_attack_accuracy.py
+++ b/typeclasses/tests/test_auto_attack_accuracy.py
@@ -41,8 +41,8 @@ class TestAutoAttackAccuracy(unittest.TestCase):
                     hits += 1
 
         rate = hits / trials
-        self.assertGreaterEqual(rate, 0.70)
-        self.assertLessEqual(rate, 0.80)
+        self.assertGreaterEqual(rate, 0.85)
+        self.assertLessEqual(rate, 0.90)
 
 
 if __name__ == "__main__":

--- a/utils/tests/test_combat_utils.py
+++ b/utils/tests/test_combat_utils.py
@@ -6,16 +6,13 @@ from world.system import stat_manager
 
 @override_settings(DEFAULT_HOME=None)
 class TestCombatCalculations(EvenniaTest):
-    def test_check_hit_uses_hit_chance_and_dodge(self):
-        self.char1.db.stat_overrides = {"hit_chance": 100}
-        self.char2.db.stat_overrides = {"dodge": 0}
+    def test_check_hit_uses_hit_chance(self):
+        self.char1.db.stat_overrides = {"hit_chance": 75}
         stat_manager.refresh_stats(self.char1)
         stat_manager.refresh_stats(self.char2)
-        with patch("world.system.stat_manager.randint", return_value=100):
+        with patch("world.system.stat_manager.randint", return_value=76):
             self.assertFalse(stat_manager.check_hit(self.char1, self.char2))
-        self.char2.db.stat_overrides = {"dodge": 200}
-        stat_manager.refresh_stats(self.char2)
-        with patch("world.system.stat_manager.randint", return_value=1):
+        with patch("world.system.stat_manager.randint", return_value=50):
             self.assertTrue(stat_manager.check_hit(self.char1, self.char2))
 
     def test_roll_crit_respects_resist(self):

--- a/world/system/stat_manager.py
+++ b/world/system/stat_manager.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Dict
 import re
 from random import randint
+import logging
 
 from utils.stats_utils import normalize_stat_key
 
@@ -19,6 +20,8 @@ from .constants import (
     MAX_LUCK,
 )
 from world.scripts import races, classes
+
+logger = logging.getLogger(__name__)
 
 # Primary and secondary stat keys
 PRIMARY_STATS = stats.CORE_STAT_KEYS
@@ -534,11 +537,20 @@ def compute_hit_chance(obj) -> int:
 
 
 def check_hit(attacker, target, base: int = 0) -> bool:
-    """Return True if an attack hits based on hit chance vs dodge."""
-    acc = get_effective_stat(attacker, "hit_chance") + base
-    dodge = get_effective_stat(target, "dodge")
-    chance = max(5, min(95, acc - dodge))
-    return randint(1, 100) <= chance
+    """Return ``True`` if ``attacker`` lands a hit on ``target``."""
+
+    chance = get_effective_stat(attacker, "hit_chance") + base
+    chance = max(5, min(95, chance))
+    roll = randint(1, 100)
+    logger.debug(
+        "%s hit chance: %s, roll: %s, vs %s evasion: %s",
+        getattr(attacker, "key", attacker),
+        chance,
+        roll,
+        getattr(target, "key", target),
+        state_manager.get_effective_stat(target, "evasion"),
+    )
+    return roll <= chance
 
 
 def roll_crit(attacker, target) -> bool:


### PR DESCRIPTION
## Summary
- correct hit chance computation and logging
- update combat tests for new hit chance behavior

## Testing
- `python -m py_compile world/system/stat_manager.py utils/tests/test_combat_utils.py typeclasses/tests/test_auto_attack_accuracy.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684f920d7c84832ca84e7009b7bb8d32