### PR TITLE
Fix effective stat duplication

### DIFF
--- a/typeclasses/tests/test_state_manager.py
+++ b/typeclasses/tests/test_state_manager.py
@@ -1,6 +1,10 @@
 from evennia.utils.test_resources import EvenniaTest
+from evennia.utils import create
 from django.test import override_settings
-from world.system import state_manager
+from unittest.mock import patch
+
+from world.system import state_manager, stat_manager
+from world.effects import Effect, EFFECTS
 
 
 @override_settings(DEFAULT_HOME=None)
@@ -162,4 +166,37 @@ class TestStateManager(EvenniaTest):
         for key, regen in expected.items():
             trait = char.traits.get(key)
             self.assertEqual(trait.current, trait.max // 2 + regen)
+
+    def test_hit_chance_item_bonus_applied_once(self):
+        char = self.char1
+        stat_manager.refresh_stats(char)
+        base = char.db.derived_stats.get("hit_chance")
+
+        item = create.create_object(
+            "typeclasses.objects.ClothingObject",
+            key="trinket",
+            location=char,
+        )
+        item.tags.add("equipment", category="flag")
+        item.tags.add("identified", category="flag")
+        item.db.stat_mods = {"hit_chance": 5}
+        item.wear(char, True)
+        stat_manager.refresh_stats(char)
+
+        derived = char.db.derived_stats.get("hit_chance")
+        self.assertEqual(derived, base + 5)
+        self.assertEqual(state_manager.get_effective_stat(char, "hit_chance"), derived)
+
+    def test_hit_chance_effect_bonus_applied_once(self):
+        char = self.char1
+        stat_manager.refresh_stats(char)
+        base = char.db.derived_stats.get("hit_chance")
+
+        eff = Effect(key="aim", name="Aim", desc="", type="buff", mods={"hit_chance": 7})
+        with patch.dict(EFFECTS, {"aim": eff}):
+            state_manager.add_effect(char, "aim", 1)
+            buffed = char.db.derived_stats.get("hit_chance")
+            self.assertEqual(buffed, base + 7)
+            self.assertEqual(state_manager.get_effective_stat(char, "hit_chance"), buffed)
+
 

--- a/world/system/state_manager.py
+++ b/world/system/state_manager.py
@@ -181,14 +181,20 @@ def get_temp_bonus(chara, stat: str) -> int:
 
 
 def get_effective_stat(chara, stat: str) -> int:
-    """Return ``stat`` value including temporary bonuses."""
+    """Return ``stat`` value including temporary bonuses.
+
+    Gear and persistent buff modifiers are incorporated by
+    :func:`stat_manager.refresh_stats`, so this helper only adds any
+    outstanding temporary bonuses on top of the cached trait value.
+    """
+
     if not hasattr(chara, "traits"):
         return 0
 
-    base = stats.sum_bonus(chara, stat)
+    trait = chara.traits.get(stat)
+    base = trait.value if trait else 0
     base += get_temp_bonus(chara, stat)
-    base += get_effect_mods(chara).get(stat, 0)
-    return base
+    return int(base)
 
 
 def apply_regen(chara):


### PR DESCRIPTION
## Summary
- avoid double-counting gear buffs in `get_effective_stat`
- test that hit chance buffs from gear and effects apply only once

## Testing
- `pytest -q` *(fails: django.db.utils.OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_684f97453048832cb5264fab438f9955