### PR TITLE
Implement unarmed skill damage

### DIFF
--- a/combat/actions/utils.py
+++ b/combat/actions/utils.py
@@ -30,6 +30,29 @@ def calculate_damage(attacker, weapon, target) -> Tuple[int, object]:
     dmg = 0
     dtype = DamageType.BLUDGEONING
 
+    if weapon is None:
+        # fallback to basic unarmed damage scaled by Unarmed skill
+        prof = 0
+        prof = (getattr(getattr(attacker, "db", None), "proficiencies", {}) or {}).get(
+            "Unarmed", 0
+        )
+        virtual_weapon = {
+            "damage_dice": "1d4",
+            "damage_type": DamageType.BLUDGEONING,
+            "damage_bonus": 0,
+        }
+        if prof >= 75:
+            virtual_weapon["damage_dice"] = "1d6"
+            virtual_weapon["damage_bonus"] = 2
+        elif prof >= 50:
+            virtual_weapon["damage_dice"] = "1d5"
+            virtual_weapon["damage_bonus"] = 1
+        elif prof >= 25:
+            virtual_weapon["damage_dice"] = "1d4"
+        else:
+            virtual_weapon["damage_dice"] = "1d3"
+        weapon = virtual_weapon
+
     hp_trait = getattr(getattr(target, "traits", None), "health", None)
     if hasattr(target, "hp") or hp_trait:
         dmg_bonus = 0
@@ -57,11 +80,15 @@ def calculate_damage(attacker, weapon, target) -> Tuple[int, object]:
                 if db:
                     dmg_map = getattr(db, "damage", None)
                     if dmg_map:
-                        for i, (dt, formula) in enumerate(sorted(dmg_map.items(), key=lambda kv: str(kv[0]))):
+                        for i, (dt, formula) in enumerate(
+                            sorted(dmg_map.items(), key=lambda kv: str(kv[0]))
+                        ):
                             try:
                                 roll = roll_dice_string(str(formula))
                             except Exception:
-                                logger.error("Invalid damage formula '%s' on %s", formula, weapon)
+                                logger.error(
+                                    "Invalid damage formula '%s' on %s", formula, weapon
+                                )
                                 roll = 0
                             dmg = dmg + roll if dmg else roll
                             if i == 0:

--- a/combat/combat_actions.py
+++ b/combat/combat_actions.py
@@ -84,7 +84,8 @@ class Action:
         if (
             self.range == 1
             and self.target
-            and getattr(actor, "location", None) is not getattr(self.target, "location", None)
+            and getattr(actor, "location", None)
+            is not getattr(self.target, "location", None)
         ):
             return False, "Target out of range."
         if self.requires_status and hasattr(actor, "tags"):
@@ -126,9 +127,8 @@ class AttackAction(Action):
                 # Use natural weapon stats when unarmed
                 weapon = self.actor.db.natural_weapon
             else:
-                from typeclasses.gear import BareHand
-                # Default to bare hands if no natural weapon is defined
-                weapon = BareHand()
+                # No weapon - rely on unarmed fallback in calculate_damage
+                weapon = None
 
         logger.debug("AttackAction weapon=%s", getattr(weapon, "key", weapon))
 
@@ -177,7 +177,6 @@ class AttackAction(Action):
         )
 
 
-
 class DefendAction(Action):
     """Assume a defensive stance to reduce incoming damage."""
 
@@ -220,7 +219,9 @@ class SkillAction(Action):
             self.actor.traits.stamina.current -= self.stamina_cost
         result = self.skill.resolve(self.actor, self.target)
         if getattr(result, "damage", 0):
-            result.damage, crit = apply_critical(self.actor, result.target, result.damage)
+            result.damage, crit = apply_critical(
+                self.actor, result.target, result.damage
+            )
             if crit:
                 result.message += "\nCritical hit!"
         return result
@@ -253,7 +254,9 @@ class SpellAction(Action):
     def resolve(self) -> CombatResult:
         """Invoke the stored spell and return its combat result."""
         if not self.spell:
-            return CombatResult(self.actor, self.target or self.actor, "Nothing happens.")
+            return CombatResult(
+                self.actor, self.target or self.actor, "Nothing happens."
+            )
         if self.mana_cost and hasattr(self.actor.traits, "mana"):
             self.actor.traits.mana.current -= self.mana_cost
         success = getattr(self.actor, "cast_spell", None)
@@ -265,7 +268,9 @@ class SpellAction(Action):
             message=f"{self.actor.key} casts {self.spell.key}!",
         )
         if getattr(result, "damage", 0):
-            result.damage, crit = apply_critical(self.actor, result.target, result.damage)
+            result.damage, crit = apply_critical(
+                self.actor, result.target, result.damage
+            )
             if crit:
                 result.message += "\nCritical hit!"
         return result

--- a/typeclasses/tests/test_unarmed_damage_bonus.py
+++ b/typeclasses/tests/test_unarmed_damage_bonus.py
@@ -53,17 +53,46 @@ class TestUnarmedAutoAttack(unittest.TestCase):
 
         engine = CombatEngine([attacker, defender], round_time=0)
 
-        with patch("combat.combat_actions.utils.inherits_from", return_value=True), \
-             patch("world.system.state_manager.apply_regen"), \
-             patch("world.system.state_manager.get_effective_stat", return_value=0), \
-             patch("world.system.stat_manager.check_hit", return_value=True), \
-             patch("combat.actions.utils.roll_evade", return_value=False), \
-             patch("combat.actions.utils.roll_parry", return_value=False), \
-             patch("combat.actions.utils.roll_block", return_value=False), \
-             patch("evennia.utils.delay"):
+        with (
+            patch("combat.combat_actions.utils.inherits_from", return_value=True),
+            patch("world.system.state_manager.apply_regen"),
+            patch("world.system.state_manager.get_effective_stat", return_value=0),
+            patch("world.system.stat_manager.check_hit", return_value=True),
+            patch("combat.actions.utils.roll_evade", return_value=False),
+            patch("combat.actions.utils.roll_parry", return_value=False),
+            patch("combat.actions.utils.roll_block", return_value=False),
+            patch("evennia.utils.delay"),
+        ):
             engine.start_round()
             engine.process_round()
 
         # Base damage of 4 should be increased by 25% from Unarmed proficiency
         # resulting in 5 damage dealt
         self.assertEqual(defender.hp, 5)
+
+    def test_unarmed_base_damage_from_skill(self):
+        attacker = Dummy()
+        defender = Dummy()
+        attacker.location = defender.location
+        attacker.db.combat_target = defender
+        attacker.db.natural_weapon = None
+        attacker.db.proficiencies["Unarmed"] = 75
+
+        engine = CombatEngine([attacker, defender], round_time=0)
+
+        with (
+            patch("combat.combat_actions.utils.inherits_from", return_value=True),
+            patch("world.system.state_manager.apply_regen"),
+            patch("world.system.state_manager.get_effective_stat", return_value=0),
+            patch("world.system.stat_manager.check_hit", return_value=True),
+            patch("combat.actions.utils.roll_evade", return_value=False),
+            patch("combat.actions.utils.roll_parry", return_value=False),
+            patch("combat.actions.utils.roll_block", return_value=False),
+            patch("combat.actions.utils.roll_dice_string", return_value=4) as mock_roll,
+            patch("evennia.utils.delay"),
+        ):
+            engine.start_round()
+            engine.process_round()
+
+        mock_roll.assert_called_with("1d6")
+        self.assertEqual(defender.hp, 2)

--- a/typeclasses/tests/test_vnum_mobs.py
+++ b/typeclasses/tests/test_vnum_mobs.py
@@ -285,7 +285,9 @@ class TestVnumMobs(EvenniaTest):
 
     def test_invalid_typeclass_raises(self):
         with self.assertRaises(ValueError):
-            register_prototype({"key": "bad", "typeclass": "typeclasses.objects.ObjectParent"}, vnum=65)
+            register_prototype(
+                {"key": "bad", "typeclass": "typeclasses.objects.ObjectParent"}, vnum=65
+            )
 
     def test_spawn_populates_stat_caches(self):
         """spawn_from_vnum should set primary and derived stat caches."""
@@ -308,3 +310,15 @@ class TestVnumMobs(EvenniaTest):
             npc.db.primary_stats.get("STR"),
         )
 
+    def test_spawn_grants_unarmed_skill(self):
+        proto = {
+            "key": "brawler",
+            "typeclass": "typeclasses.npcs.BaseNPC",
+            "level": 1,
+            "combat_class": "Warrior",
+        }
+        vnum = register_prototype(proto, vnum=101)
+        npc = spawn_from_vnum(vnum, location=self.char1.location)
+
+        self.assertIn("Unarmed", npc.db.skills)
+        self.assertGreaterEqual(npc.db.proficiencies.get("Unarmed", 0), 25)

--- a/utils/mob_proto.py
+++ b/utils/mob_proto.py
@@ -101,7 +101,14 @@ def apply_proto_items(npc, proto_data: dict) -> None:
         item.location = npc
         slot_norm = normalize_slot(slot) or slot
         try:
-            if slot_norm in {"mainhand", "offhand", "twohanded", "mainhand/offhand", "left", "right"}:
+            if slot_norm in {
+                "mainhand",
+                "offhand",
+                "twohanded",
+                "mainhand/offhand",
+                "left",
+                "right",
+            }:
                 hand = None
                 if slot_norm in {"mainhand", "right"}:
                     hand = "right"
@@ -179,6 +186,15 @@ def spawn_from_vnum(vnum: int, location=None):
     npc.db.mobprogs = mobprogs
 
     apply_proto_items(npc, proto_data)
+
+    # ensure NPCs have basic unarmed skill
+    from world.system import state_manager
+
+    state_manager.grant_ability(npc, "Unarmed")
+    profs = npc.db.proficiencies or {}
+    if profs.get("Unarmed", 0) < 25:
+        profs["Unarmed"] = 25
+    npc.db.proficiencies = profs
 
     from commands.npc_builder import finalize_mob_prototype
 


### PR DESCRIPTION
## Summary
- add virtual weapon logic in `calculate_damage` for barehanded attacks
- rely on new virtual weapon fallback from `AttackAction`
- grant Unarmed skill to NPC prototypes during spawn
- cover new behaviors in tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684f98723ac0832c8aa1286e8be2e728