### PR TITLE
Update armor to be percent based

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -370,10 +370,10 @@ class Character(ObjectParent, ClothedCharacter):
 
         # apply armor damage reduction with piercing
         reduction = self.defense(damage_type)
+        armor = max(0, reduction)
         if attacker:
-            reduction = max(0, reduction - state_manager.get_effective_stat(attacker, "piercing"))
-        damage -= reduction
-        damage = max(0, damage)
+            armor = max(0, armor - state_manager.get_effective_stat(attacker, "piercing"))
+        damage = int(max(0, round(damage * (1 - armor / 100))))
         if attacker:
             log = getattr(self.ndb, "damage_log", None) or {}
             log[attacker] = log.get(attacker, 0) + int(damage)

--- a/typeclasses/tests/test_characters.py
+++ b/typeclasses/tests/test_characters.py
@@ -406,10 +406,10 @@ class TestCombatResists(EvenniaTest):
         self.assertFalse(char.tags.has("unconscious", category="status"))
 
     def test_armor_reduces_damage(self):
-        self.char2.traits.armor.base = 5
+        self.char2.traits.armor.base = 10
         base = self.char2.traits.health.current
         self.char2.at_damage(self.char1, 10)
-        self.assertEqual(self.char2.traits.health.current, base - 5)
+        self.assertEqual(self.char2.traits.health.current, base - 9)
 
     def test_evasion_prevents_weapon_damage(self):
         self.char2.traits.evasion.base = 100

--- a/typeclasses/tests/test_extended_stats.py
+++ b/typeclasses/tests/test_extended_stats.py
@@ -45,7 +45,7 @@ class TestExtendedStats(EvenniaTest):
         self.char1.traits.piercing.base = 5
         self.char2.db.armor = 10
         dmg = self.char2.at_damage(self.char1, 20)
-        self.assertEqual(dmg, 15)
+        self.assertEqual(dmg, 19)
 
     def test_spell_pen_and_resist(self):
         self.char1.traits.spell_penetration.base = 5


### PR DESCRIPTION
## Summary
- compute armor as a percentage reduction in `Character.at_damage`
- adjust tests for new armor math

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68500806edb4832c98a3e394b5c90724