### PR TITLE
Add auto_search helper for combat commands

### DIFF
--- a/commands/abilities.py
+++ b/commands/abilities.py
@@ -41,7 +41,8 @@ class CmdKick(Command):
                 self.msg("Kick whom?")
                 return
         else:
-            target = self.caller.search(self.args.strip())
+            from utils import auto_search
+            target = auto_search(self.caller, self.args.strip())
             if not target:
                 return
         skill = Kick()

--- a/commands/combat.py
+++ b/commands/combat.py
@@ -51,8 +51,9 @@ class CmdAttack(Command):
             return
 
         # if we specified a weapon, find it first
+        from utils import auto_search
         if self.weapon:
-            weapon = self.caller.search(self.weapon)
+            weapon = auto_search(self.caller, self.weapon)
             if not weapon:
                 # no valid match
                 return
@@ -65,7 +66,7 @@ class CmdAttack(Command):
                 weapon = BareHand()
 
         # find our enemy!
-        target = self.caller.search(self.target)
+        target = auto_search(self.caller, self.target)
         if not target:
             # no valid match
             return
@@ -163,7 +164,8 @@ class CmdWield(Command):
         else:
             hand = None
 
-        weapon = caller.search(self.weapon, location=caller)
+        from utils import auto_search
+        weapon = auto_search(caller, self.weapon, location=caller)
         if not weapon:
             # no valid object found
             return
@@ -196,7 +198,8 @@ class CmdUnwield(Command):
     def func(self):
         caller = self.caller
 
-        weapon = caller.search(self.args, candidates=caller.wielding)
+        from utils import auto_search
+        weapon = auto_search(caller, self.args, candidates=caller.wielding)
         if not weapon:
             # no valid object found
             return
@@ -356,7 +359,8 @@ class CmdRevive(Command):
                     )
             return
 
-        target = caller.search(arg)
+        from utils import auto_search
+        target = auto_search(caller, arg)
         if not target:
             return
 
@@ -382,7 +386,8 @@ class CmdStatus(Command):
             target = self.caller
             display_auto_prompt(self.account, target, self.msg, force=True)
         else:
-            target = self.caller.search(self.args.strip())
+            from utils import auto_search
+            target = auto_search(self.caller, self.args.strip())
             if not target:
                 # no valid object found
                 return

--- a/typeclasses/tests/test_attack_command.py
+++ b/typeclasses/tests/test_attack_command.py
@@ -32,6 +32,16 @@ class TestAttackCommand(EvenniaTest):
         )
         self.assertTrue(queued)
 
+    def test_attack_ambiguous_names_auto_selects_first(self):
+        slime1 = create.create_object(BaseNPC, key="slime", location=self.room1)
+        slime2 = create.create_object(BaseNPC, key="slime", location=self.room1)
+
+        self.char1.execute_cmd("attack slime")
+        self.assertEqual(self.char1.db.combat_target, slime1)
+
+        self.char1.execute_cmd("attack slime-2")
+        self.assertEqual(self.char1.db.combat_target, slime2)
+
     def test_attack_when_not_fleeing(self):
         """Attacking without a fleeing flag should not raise errors."""
         mob = create.create_object(BaseNPC, key="mob", location=self.room1)

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -39,3 +39,23 @@ def display_auto_prompt(account, caller, msg_func, *, force=False):
         status = caller.get_display_status(caller)
         msg_func(prompt=status)
 
+
+import re
+
+def auto_search(caller, search, **kwargs):
+    """Search quietly and auto-select the first visible/living match."""
+    results = caller.search(search, quiet=True, **kwargs)
+    if not results:
+        return None
+    if not isinstance(results, list):
+        return results
+    if len(results) == 1:
+        return results[0]
+    # ignore auto-selection when specifying a numbered alias
+    if re.match(r"^\d+-", search.strip()):
+        return results[0]
+    visible = [obj for obj in results if getattr(caller, "can_see", lambda o: True)(obj)]
+    living = [obj for obj in visible if not (hasattr(obj, "tags") and obj.tags.has("unconscious", category="status"))]
+    matches = living or visible or results
+    matches.sort(key=lambda o: getattr(o, "id", 0))
+    return matches[0]


### PR DESCRIPTION
## Summary
- implement `auto_search` to quietly find and auto-select a target
- update combat commands to use the helper
- test that `attack slime` auto-targets the first matching mob

## Testing
- `pytest -k test_attack_command -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68501416fb90832c87e88627fe604a1a