### PR TITLE
Fix cleanup of combat participants

### DIFF
--- a/combat/engine/damage_processor.py
+++ b/combat/engine/damage_processor.py
@@ -165,6 +165,10 @@ class DamageProcessor:
             )
             if should_remove:
                 self.turn_manager.remove_participant(actor)
+                from combat.round_manager import CombatRoundManager
+                inst = CombatRoundManager.get().get_combatant_combat(actor)
+                if inst:
+                    inst.remove_combatant(actor)
 
     # -------------------------------------------------------------
     # action / round execution

--- a/combat/round_manager.py
+++ b/combat/round_manager.py
@@ -43,6 +43,10 @@ class CombatInstance:
             return False
         self.engine.remove_participant(combatant)
         self.combatants.discard(combatant)
+        try:
+            CombatRoundManager.get().combatant_to_combat.pop(combatant, None)
+        except Exception:  # pragma: no cover - safety
+            pass
         return True
 
     def is_valid(self) -> bool:


### PR DESCRIPTION
## Summary
- maintain combat-to-combatant mapping when removing a fighter
- drop fighters from combat instances when they leave or clear their target

## Testing
- `pytest -q` *(fails: 88 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685029405798832c8b50b701ef8cbc13