### PR TITLE
Fix fleeing flag preventing combat

### DIFF
--- a/commands/combat.py
+++ b/commands/combat.py
@@ -77,6 +77,10 @@ class CmdAttack(Command):
             )
             return
 
+        # ensure the target is not marked as fleeing
+        if target.attributes.has("fleeing"):
+            del target.db.fleeing
+
         # if we were trying to flee, cancel that
         if self.caller.attributes.has("fleeing"):
             del self.caller.db.fleeing

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -1275,6 +1275,8 @@ class NPC(Character):
         """
         initiate combat against another character
         """
+        if self.attributes.has("fleeing"):
+            del self.db.fleeing
         if weapons := self.wielding:
             weapon = weapons[0]
         else:

--- a/typeclasses/tests/test_attack_command.py
+++ b/typeclasses/tests/test_attack_command.py
@@ -55,6 +55,15 @@ class TestAttackCommand(EvenniaTest):
         # fleeing flag should still be absent after attacking
         self.assertFalse(self.char1.attributes.has("fleeing"))
 
+    def test_attack_clears_target_fleeing(self):
+        """Attacking a fleeing mob should clear its fleeing flag."""
+        mob = create.create_object(BaseNPC, key="mob", location=self.room1)
+        mob.db.fleeing = True
+
+        self.char1.execute_cmd("attack mob")
+
+        self.assertFalse(mob.attributes.has("fleeing"))
+
     def test_joining_combat_queues_immediately(self):
         """Joining an ongoing fight should allow immediate actions."""
         from typeclasses.characters import PlayerCharacter


### PR DESCRIPTION
## Summary
- remove fleeing flag from target when attacking
- clear fleeing state when an NPC enters combat
- test that attacking clears target fleeing

## Testing
- `pytest typeclasses/tests/test_attack_command.py -k test_attack_clears_target_fleeing -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68502ba2aba8832c8fd478c41f1a41b1