### PR TITLE
Refactor AttackAction weapon helper

### DIFF
--- a/combat/combat_actions.py
+++ b/combat/combat_actions.py
@@ -7,9 +7,6 @@ from typing import Optional, Iterable
 import logging
 
 from .engine.combat_math import CombatMath
-from world.system import stat_manager
-
-from evennia.utils import utils
 from world.system import state_manager
 
 logger = logging.getLogger(__name__)
@@ -113,22 +110,19 @@ class AttackAction(Action):
         return super().validate()
 
     def resolve(self) -> CombatResult:
-        """Carry out a basic weapon attack."""
+        """Carry out a basic weapon attack.
+
+        Returns
+        -------
+        CombatResult
+            Outcome of the attack execution.
+        """
         target = self.target
         if not target:
             return CombatResult(self.actor, self.actor, "No target.")
 
-        weapon = self.actor
-        if utils.inherits_from(self.actor, "typeclasses.characters.Character"):
-            if self.actor.wielding:
-                weapon = self.actor.wielding[0]
-            elif getattr(self.actor.db, "natural_weapon", None):
-                # Use natural weapon stats when unarmed
-                weapon = self.actor.db.natural_weapon
-            else:
-                from typeclasses.gear import BareHand
-                # Default to bare hands if no natural weapon is defined
-                weapon = BareHand()
+        weapon_getter = getattr(self.actor, "get_attack_weapon", None)
+        weapon = weapon_getter() if callable(weapon_getter) else self.actor
 
         logger.debug("AttackAction weapon=%s", getattr(weapon, "key", weapon))
 

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -820,6 +820,22 @@ class Character(ObjectParent, ClothedCharacter):
         if self.sessions.count():
             self.msg(prompt=self.get_resource_prompt())
 
+    def get_attack_weapon(self):
+        """Return the weapon to use for an attack.
+
+        Returns
+        -------
+        object
+            A wielded weapon, a natural weapon mapping, or a
+            :class:`~typeclasses.gear.BareHand` instance if unarmed.
+        """
+        if self.wielding:
+            return self.wielding[0]
+        if getattr(self.db, "natural_weapon", None):
+            return self.db.natural_weapon
+        from typeclasses.gear import BareHand
+        return BareHand()
+
     def attack(self, target, weapon, **kwargs):
         """Execute an attack using ``weapon`` against ``target``."""
         if not self.in_combat or self.db.fleeing or self.tags.has("unconscious"):

--- a/typeclasses/tests/test_attack_parry_block_crit.py
+++ b/typeclasses/tests/test_attack_parry_block_crit.py
@@ -36,6 +36,14 @@ class Dummy:
         self.cast_spell = MagicMock()
         self.use_skill = MagicMock()
 
+    def get_attack_weapon(self):
+        if self.wielding:
+            return self.wielding[0]
+        if getattr(self.db, "natural_weapon", None):
+            return self.db.natural_weapon
+        from typeclasses.gear import BareHand
+        return BareHand()
+
 
 class TestAttackReactions(unittest.TestCase):
     def setUp(self):
@@ -55,8 +63,7 @@ class TestAttackReactions(unittest.TestCase):
         engine.process_round()
 
     def test_attack_parried(self):
-        with patch("combat.combat_actions.utils.inherits_from", return_value=True), \
-             patch("world.system.state_manager.apply_regen"), \
+        with patch("world.system.state_manager.apply_regen"), \
              patch("world.system.state_manager.get_effective_stat", return_value=0), \
              patch("world.system.stat_manager.check_hit", return_value=True), \
              patch("combat.combat_utils.roll_evade", return_value=False), \
@@ -70,8 +77,7 @@ class TestAttackReactions(unittest.TestCase):
         mock_parry.assert_called()
 
     def test_attack_blocked(self):
-        with patch("combat.combat_actions.utils.inherits_from", return_value=True), \
-             patch("world.system.state_manager.apply_regen"), \
+        with patch("world.system.state_manager.apply_regen"), \
              patch("world.system.state_manager.get_effective_stat", return_value=0), \
              patch("world.system.stat_manager.check_hit", return_value=True), \
              patch("combat.combat_utils.roll_evade", return_value=False), \
@@ -86,8 +92,7 @@ class TestAttackReactions(unittest.TestCase):
         mb.assert_called()
 
     def test_attack_critical(self):
-        with patch("combat.combat_actions.utils.inherits_from", return_value=True), \
-             patch("world.system.state_manager.apply_regen"), \
+        with patch("world.system.state_manager.apply_regen"), \
              patch("world.system.state_manager.get_effective_stat", return_value=0), \
              patch("world.system.stat_manager.check_hit", return_value=True), \
              patch("combat.combat_utils.roll_evade", return_value=False), \

--- a/typeclasses/tests/test_combat_actions.py
+++ b/typeclasses/tests/test_combat_actions.py
@@ -2,7 +2,7 @@ import unittest
 from unittest.mock import MagicMock, patch, call
 
 from combat.engine import CombatEngine
-from combat.combat_actions import DefendAction, CombatResult, Action
+from combat.combat_actions import DefendAction, CombatResult, Action, AttackAction
 
 
 class KillAction(Action):
@@ -41,3 +41,23 @@ class TestDefendAction(unittest.TestCase):
         a.tags.add.assert_any_call("defending", category="status")
 
 
+
+class TestAttackActionHelper(unittest.TestCase):
+    def test_helper_used_for_weapon_selection(self):
+        attacker = Dummy()
+        defender = Dummy()
+        weapon = MagicMock()
+        attacker.location = defender.location
+        attacker.get_attack_weapon = MagicMock(return_value=weapon)
+
+        engine = CombatEngine([attacker, defender], round_time=0)
+        engine.queue_action(attacker, AttackAction(attacker, defender))
+        with patch("world.system.state_manager.apply_regen"), \
+             patch("combat.combat_actions.CombatMath.check_hit", return_value=(True, "")), \
+             patch("combat.combat_actions.CombatMath.calculate_damage", return_value=(5, None)) as mock_calc, \
+             patch("combat.combat_actions.CombatMath.apply_critical", return_value=(5, False)), \
+             patch("random.randint", return_value=0):
+            engine.start_round()
+            engine.process_round()
+
+        mock_calc.assert_called_with(attacker, weapon, defender)

--- a/typeclasses/tests/test_combat_engine.py
+++ b/typeclasses/tests/test_combat_engine.py
@@ -180,7 +180,6 @@ class TestCombatEngine(unittest.TestCase):
         b = Dummy()
         with patch('world.system.state_manager.apply_regen'), \
              patch('world.system.state_manager.get_effective_stat', return_value=0), \
-             patch('combat.combat_actions.utils.inherits_from', return_value=False), \
              patch('combat.engine.damage_processor.delay') as mock_delay, \
              patch('random.randint', return_value=0):
             engine = CombatEngine([a, b], round_time=0)
@@ -454,7 +453,6 @@ class TestCombatNPCTurn(EvenniaTest):
 
         with patch('world.system.state_manager.apply_regen'), \
              patch('world.system.state_manager.get_effective_stat', return_value=0), \
-             patch('combat.combat_actions.utils.inherits_from', return_value=True), \
              patch('random.randint', return_value=0), \
              patch('combat.engine.damage_processor.delay'), \
              patch.object(engine, 'queue_action', wraps=engine.queue_action) as mock_queue:
@@ -551,7 +549,6 @@ class TestUnsavedPrototypeCombat(unittest.TestCase):
         with patch("world.system.state_manager.apply_regen"), \
              patch("world.system.state_manager.check_level_up"), \
              patch("world.system.state_manager.get_effective_stat", return_value=0), \
-             patch("combat.combat_actions.utils.inherits_from", return_value=False), \
              patch("random.randint", return_value=0), \
              patch("combat.engine.damage_processor.delay"):
             engine.start_round()

--- a/typeclasses/tests/test_combat_flow.py
+++ b/typeclasses/tests/test_combat_flow.py
@@ -45,6 +45,14 @@ class Dummy:
         self.cast_spell = MagicMock()
         self.use_skill = MagicMock()
 
+    def get_attack_weapon(self):
+        if self.wielding:
+            return self.wielding[0]
+        if getattr(self.db, "natural_weapon", None):
+            return self.db.natural_weapon
+        from typeclasses.gear import BareHand
+        return BareHand()
+
 
 class KillAction(Action):
     def resolve(self):
@@ -65,8 +73,7 @@ class TestAttackAction(unittest.TestCase):
 
         engine = CombatEngine([attacker, defender], round_time=0)
         engine.queue_action(attacker, AttackAction(attacker, defender))
-        with patch("combat.combat_actions.utils.inherits_from", return_value=True), \
-             patch("world.system.state_manager.apply_regen"), \
+        with patch("world.system.state_manager.apply_regen"), \
              patch("random.randint", return_value=0):
             engine.start_round()
             engine.process_round()
@@ -86,8 +93,7 @@ class TestAttackAction(unittest.TestCase):
 
         engine = CombatEngine([attacker, defender], round_time=0)
         engine.queue_action(attacker, AttackAction(attacker, defender))
-        with patch("combat.combat_actions.utils.inherits_from", return_value=True), \
-             patch("world.system.state_manager.apply_regen"), \
+        with patch("world.system.state_manager.apply_regen"), \
              patch("random.randint", return_value=0), \
              patch("world.system.state_manager.get_effective_stat") as mock_get:
             def getter(obj, stat):
@@ -116,8 +122,7 @@ class TestAttackAction(unittest.TestCase):
 
         engine = CombatEngine([attacker, defender], round_time=0)
         engine.queue_action(attacker, AttackAction(attacker, defender))
-        with patch("combat.combat_actions.utils.inherits_from", return_value=True), \
-             patch("world.system.state_manager.apply_regen"), \
+        with patch("world.system.state_manager.apply_regen"), \
              patch("world.system.state_manager.get_effective_stat", return_value=0), \
              patch("combat.engine.combat_math.roll_dice_string", return_value=3) as mock_roll:
             engine.start_round()
@@ -139,8 +144,7 @@ class TestAttackAction(unittest.TestCase):
 
         engine = CombatEngine([attacker, defender], round_time=0)
         engine.queue_action(attacker, AttackAction(attacker, defender))
-        with patch("combat.combat_actions.utils.inherits_from", return_value=True), \
-             patch("world.system.state_manager.apply_regen"), \
+        with patch("world.system.state_manager.apply_regen"), \
              patch("world.system.state_manager.get_effective_stat", return_value=0), \
              patch("random.randint", return_value=0), \
              patch("combat.combat_actions.roll_dice_string", side_effect=[2, 3]) as mock_roll:
@@ -159,8 +163,7 @@ class TestAttackAction(unittest.TestCase):
 
         engine = CombatEngine([attacker, defender], round_time=0)
         engine.queue_action(attacker, AttackAction(attacker, defender))
-        with patch("combat.combat_actions.utils.inherits_from", return_value=True), \
-             patch("world.system.state_manager.apply_regen"), \
+        with patch("world.system.state_manager.apply_regen"), \
              patch("world.system.stat_manager.check_hit", return_value=False), \
              patch("random.randint", return_value=0):
             engine.start_round()
@@ -183,8 +186,7 @@ def test_npc_attack_uses_natural_weapon(self):
     engine = CombatEngine([attacker, defender], round_time=0)
     engine.queue_action(attacker, AttackAction(attacker, defender))
 
-    with patch("combat.combat_actions.utils.inherits_from", return_value=True), \
-         patch("world.system.state_manager.apply_regen"), \
+    with patch("world.system.state_manager.apply_regen"), \
          patch("world.system.state_manager.get_effective_stat", return_value=0), \
          patch("random.randint", return_value=0):
         engine.start_round()
@@ -256,8 +258,7 @@ def test_auto_attack_uses_combat_target():
 
     engine = CombatEngine([attacker, defender], round_time=0)
 
-    with patch("combat.combat_actions.utils.inherits_from", return_value=True), \
-         patch("world.system.state_manager.apply_regen"), \
+    with patch("world.system.state_manager.apply_regen"), \
          patch("world.system.state_manager.get_effective_stat", return_value=0), \
          patch("evennia.utils.delay"), \
          patch("random.randint", return_value=0):
@@ -281,8 +282,7 @@ def test_haste_grants_extra_attacks():
 
     engine = CombatEngine([attacker, defender], round_time=0)
 
-    with patch("combat.combat_actions.utils.inherits_from", return_value=True), \
-         patch("world.system.state_manager.apply_regen"), \
+    with patch("world.system.state_manager.apply_regen"), \
          patch("world.system.state_manager.get_effective_stat") as mock_get, \
          patch("evennia.utils.delay"), \
          patch("combat.combat_utils.roll_evade", return_value=False), \
@@ -312,8 +312,7 @@ def test_npc_damage_dice_with_bonus():
     engine = CombatEngine([attacker, defender], round_time=0)
     engine.queue_action(attacker, AttackAction(attacker, defender))
 
-    with patch("evennia.utils.utils.inherits_from", return_value=False), \
-         patch("world.system.state_manager.apply_regen"), \
+    with patch("world.system.state_manager.apply_regen"), \
          patch("world.system.state_manager.get_effective_stat", return_value=0), \
          patch("world.system.stat_manager.check_hit", return_value=True), \
          patch("world.system.stat_manager.roll_crit", return_value=False), \
@@ -338,8 +337,7 @@ def test_npc_damage_dice_fallback_to_2d6():
     engine = CombatEngine([attacker, defender], round_time=0)
     engine.queue_action(attacker, AttackAction(attacker, defender))
 
-    with patch("evennia.utils.utils.inherits_from", return_value=False), \
-         patch("world.system.state_manager.apply_regen"), \
+    with patch("world.system.state_manager.apply_regen"), \
          patch("world.system.state_manager.get_effective_stat", return_value=0), \
          patch("world.system.stat_manager.check_hit", return_value=True), \
          patch("world.system.stat_manager.roll_crit", return_value=False), \

--- a/typeclasses/tests/test_unarmed_damage_bonus.py
+++ b/typeclasses/tests/test_unarmed_damage_bonus.py
@@ -39,6 +39,14 @@ class Dummy:
         self.cast_spell = MagicMock()
         self.use_skill = MagicMock()
 
+    def get_attack_weapon(self):
+        if self.wielding:
+            return self.wielding[0]
+        if getattr(self.db, "natural_weapon", None):
+            return self.db.natural_weapon
+        from typeclasses.gear import BareHand
+        return BareHand()
+
 
 class TestUnarmedAutoAttack(unittest.TestCase):
     def test_unarmed_auto_attack_bonus_damage(self):
@@ -53,8 +61,7 @@ class TestUnarmedAutoAttack(unittest.TestCase):
 
         engine = CombatEngine([attacker, defender], round_time=0)
 
-        with patch("combat.combat_actions.utils.inherits_from", return_value=True), \
-             patch("world.system.state_manager.apply_regen"), \
+        with patch("world.system.state_manager.apply_regen"), \
              patch("world.system.state_manager.get_effective_stat", return_value=0), \
              patch("world.system.stat_manager.check_hit", return_value=True), \
              patch("combat.engine.combat_math.roll_evade", return_value=False), \
@@ -78,8 +85,7 @@ class TestUnarmedAutoAttack(unittest.TestCase):
         engine = CombatEngine([attacker, defender], round_time=0)
         engine.queue_action(attacker, AttackAction(attacker, defender))
 
-        with patch("combat.combat_actions.utils.inherits_from", return_value=True), \
-             patch("world.system.state_manager.apply_regen"), \
+        with patch("world.system.state_manager.apply_regen"), \
              patch("combat.engine.combat_math.CombatMath.check_hit", return_value=(True, "")) as mock_hit, \
              patch("combat.engine.combat_math.CombatMath.apply_critical", side_effect=lambda a, t, d: (d, False)), \
              patch("combat.engine.combat_math.roll_evade", return_value=False), \
@@ -105,8 +111,7 @@ class TestUnarmedAutoAttack(unittest.TestCase):
         engine = CombatEngine([attacker, defender], round_time=0)
         engine.queue_action(attacker, AttackAction(attacker, defender))
 
-        with patch("combat.combat_actions.utils.inherits_from", return_value=True), \
-             patch("world.system.state_manager.apply_regen"), \
+        with patch("world.system.state_manager.apply_regen"), \
              patch("combat.engine.combat_math.CombatMath.check_hit", return_value=(True, "")) as mock_hit, \
              patch("combat.engine.combat_math.CombatMath.apply_critical", side_effect=lambda a, t, d: (d, False)), \
              patch("combat.engine.combat_math.roll_evade", return_value=False), \


### PR DESCRIPTION
## Summary
- add `get_attack_weapon` on characters
- simplify weapon selection inside `AttackAction`
- update combat tests for new helper

## Testing
- `pytest -q` *(fails: no such table accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_685035b8e43c832c844dcb564e551785