### PR TITLE
Improve auto_search numbering handling

### DIFF
--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -52,8 +52,13 @@ def auto_search(caller, search, **kwargs):
     if len(results) == 1:
         return results[0]
     # ignore auto-selection when specifying a numbered alias
-    if re.match(r"^\d+-", search.strip()):
-        return results[0]
+    if re.search(r"(^\d+-|-\d+$)", search.strip()):
+        numbered = caller.search(search.strip(), quiet=True, **kwargs)
+        if not numbered:
+            return None
+        if isinstance(numbered, list):
+            return numbered[0]
+        return numbered
     visible = [obj for obj in results if getattr(caller, "can_see", lambda o: True)(obj)]
     living = [obj for obj in visible if not (hasattr(obj, "tags") and obj.tags.has("unconscious", category="status"))]
     matches = living or visible or results


### PR DESCRIPTION
## Summary
- update `auto_search` to properly handle numbered aliases
- test that `kick slime-2` selects the second slime

## Testing
- `pytest -q typeclasses/tests/test_new_skills.py::TestKickSkill::test_kick_numbered_target -q` *(fails: ImportError: cannot import name 'Kick')*

------
https://chatgpt.com/codex/tasks/task_e_6850460fd6bc832c942ee43483c6ba3f