### PR TITLE
Refactor combat instance ticking

### DIFF
--- a/combat/round_manager.py
+++ b/combat/round_manager.py
@@ -52,7 +52,12 @@ class CombatInstance:
     # ------------------------------------------------------------------
     # ticking helpers
     # ------------------------------------------------------------------
-    def schedule_tick(self) -> None:
+
+    def start(self) -> None:
+        """Begin automatic round processing."""
+        self._schedule_tick()
+
+    def _schedule_tick(self) -> None:
         """Schedule the next combat round."""
         if self.combat_ended or self.tick_handle:
             return
@@ -156,7 +161,7 @@ class CombatInstance:
                 self.end_combat("No active fighters remaining")
                 return
 
-            self.schedule_tick()
+            self._schedule_tick()
 
         except Exception as err:
             log_trace(f"Error in combat round processing: {err}")
@@ -234,7 +239,6 @@ class CombatRoundManager:
     def __init__(self) -> None:
         self.combats: Dict[int, CombatInstance] = {}
         self.combatant_to_combat: Dict[object, int] = {}
-        self.tick_delay = 2.0
         self._next_id = 1
 
     @classmethod
@@ -266,12 +270,12 @@ class CombatRoundManager:
         combat_id = self._next_id
         self._next_id += 1
 
-        inst = CombatInstance(combat_id, engine, set(fighters), round_time or self.tick_delay)
+        inst = CombatInstance(combat_id, engine, set(fighters), round_time or 2.0)
         self.combats[combat_id] = inst
         for fighter in fighters:
             self.combatant_to_combat[fighter] = combat_id
 
-        inst.schedule_tick()
+        inst.start()
 
         return inst
 
@@ -299,7 +303,7 @@ class CombatRoundManager:
                     if c not in inst.combatants:
                         inst.add_combatant(c)
                         self.combatant_to_combat[c] = inst.combat_id
-                inst.schedule_tick()
+                inst.start()
                 return inst
         return self.create_combat(combatants)
 

--- a/typeclasses/tests/test_attack_command.py
+++ b/typeclasses/tests/test_attack_command.py
@@ -71,7 +71,7 @@ class TestAttackCommand(EvenniaTest):
         from combat.round_manager import CombatRoundManager
         from combat.combat_actions import AttackAction
 
-        with patch.object(CombatInstance, "schedule_tick"):
+        with patch.object(CombatInstance, "start"):
             self.char1.execute_cmd("attack char2")
 
         char3 = create.create_object(
@@ -83,7 +83,7 @@ class TestAttackCommand(EvenniaTest):
         char3.msg = MagicMock()
         char3.cmdset.add_default(CombatCmdSet)
 
-        with patch.object(CombatInstance, "schedule_tick"):
+        with patch.object(CombatInstance, "start"):
             char3.execute_cmd("attack char2")
 
         manager = CombatRoundManager.get()

--- a/typeclasses/tests/test_combat_full_fight.py
+++ b/typeclasses/tests/test_combat_full_fight.py
@@ -19,7 +19,7 @@ class DamageAction(Action):
 
 class TestCombatFullFight(EvenniaTest):
     def test_fight_runs_until_defeat(self):
-        with patch.object(CombatInstance, "schedule_tick"):
+        with patch.object(CombatInstance, "start"):
             manager = CombatRoundManager.get()
             instance = manager.start_combat([self.char1, self.char2])
             engine = instance.engine

--- a/typeclasses/tests/test_round_manager.py
+++ b/typeclasses/tests/test_round_manager.py
@@ -10,16 +10,16 @@ class TestCombatRoundManager(EvenniaTest):
         self.manager = CombatRoundManager.get()
         self.manager.combats.clear()
         self.manager.combatant_to_combat.clear()
-        with patch.object(CombatInstance, "schedule_tick"):
+        with patch.object(CombatInstance, "start"):
             self.instance = self.manager.create_combat(combatants=[self.char1, self.char2])
 
     def test_create_schedules_tick(self):
-        with patch.object(CombatInstance, "schedule_tick") as mock_sched:
+        with patch.object(CombatInstance, "start") as mock_sched:
             self.manager.create_combat(combatants=[self.char1, self.char2])
             mock_sched.assert_called_once_with()
 
     def test_tick_processes_and_reschedules(self):
-        with patch.object(CombatInstance, "schedule_tick") as mock_sched, patch.object(CombatEngine, "process_round") as mock_proc:
+        with patch.object(CombatInstance, "_schedule_tick") as mock_sched, patch.object(CombatEngine, "process_round") as mock_proc:
             inst = self.manager.create_combat(combatants=[self.char1, self.char2])
             mock_sched.reset_mock()
             inst._tick()
@@ -27,13 +27,13 @@ class TestCombatRoundManager(EvenniaTest):
             mock_sched.assert_called_once()
 
     def test_instances_schedule_independently(self):
-        with patch.object(CombatInstance, "schedule_tick") as mock_sched:
+        with patch.object(CombatInstance, "start") as mock_sched:
             self.manager.create_combat(combatants=[self.char1, self.char2])
             self.manager.create_combat(combatants=[self.char2, self.char1])
             self.assertEqual(mock_sched.call_count, 2)
 
     def test_start_combat_reuses_instance(self):
-        with patch.object(CombatInstance, "schedule_tick"):
+        with patch.object(CombatInstance, "start"):
             inst1 = self.manager.start_combat([self.char1, self.char2])
             inst2 = self.manager.start_combat([self.char1])
         self.assertIs(inst1, inst2)
@@ -44,7 +44,7 @@ class TestCombatRoundManager(EvenniaTest):
         self.assertEqual(len(self.manager.combats), 0)
 
     def test_force_end_all_combat(self):
-        with patch.object(CombatInstance, "schedule_tick"):
+        with patch.object(CombatInstance, "start"):
             inst = self.manager.create_combat(combatants=[self.char1])
         self.manager.force_end_all_combat()
         self.assertTrue(inst.combat_ended)


### PR DESCRIPTION
## Summary
- localize combat ticking logic to `CombatInstance` with a new `start()`
- update round manager to use new API when creating or joining combat
- adapt tests for updated interface

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68504818399c832c9e70746e55846df3