### PR TITLE
Improve unarmed combat formulas

### DIFF
--- a/combat/combat_actions.py
+++ b/combat/combat_actions.py
@@ -137,17 +137,15 @@ class AttackAction(Action):
         unarmed = not getattr(self.actor, "wielding", [])
         hit_bonus = 0.0
         if unarmed:
-            from world.skills.unarmed_passive import Unarmed, HandToHand
+            from world.skills.unarmed_passive import Unarmed
+            from world.skills.hand_to_hand import HandToHand
 
             for cls in (Unarmed, HandToHand):
                 if cls.name in (getattr(self.actor.db, "skills", []) or []):
                     cls().improve(self.actor)
 
-            if "Hand-to-Hand" in (getattr(self.actor.db, "skills", []) or []):
-                prof = (getattr(self.actor.db, "proficiencies", {}) or {}).get(
-                    "Hand-to-Hand", 0
-                )
-                hit_bonus = prof * 0.2
+            chance = CombatMath.calculate_unarmed_hit(self.actor)
+            hit_bonus = chance - 85
 
         hit, outcome = CombatMath.check_hit(self.actor, target, bonus=hit_bonus)
         if not hit:

--- a/typeclasses/gear.py
+++ b/typeclasses/gear.py
@@ -57,7 +57,8 @@ class BareHand:
                 damage = 0
         hit_bonus = hth_prof * 0.2 if knows_hth else 0.0
 
-        from world.skills.unarmed_passive import Unarmed, HandToHand
+        from world.skills.unarmed_passive import Unarmed
+        from world.skills.hand_to_hand import HandToHand
         for cls in (Unarmed, HandToHand):
             if cls.name in (wielder.db.skills or []):
                 cls().improve(wielder)

--- a/typeclasses/tests/test_unarmed_damage_bonus.py
+++ b/typeclasses/tests/test_unarmed_damage_bonus.py
@@ -91,15 +91,16 @@ class TestUnarmedAutoAttack(unittest.TestCase):
              patch("combat.engine.combat_math.roll_evade", return_value=False), \
              patch("combat.engine.combat_math.roll_parry", return_value=False), \
              patch("combat.engine.combat_math.roll_block", return_value=False), \
-             patch("combat.engine.combat_math.roll_dice_string", return_value=2), \
+             patch("combat.engine.combat_math.roll_dice_string", return_value=4), \
              patch("world.system.state_manager.get_effective_stat", return_value=0), \
              patch("evennia.utils.delay"), \
              patch("random.randint", return_value=0):
             engine.start_round()
             engine.process_round()
 
-        self.assertEqual(defender.hp, 8)
-        mock_hit.assert_called_with(attacker, defender, bonus=0)
+        self.assertEqual(defender.hp, 6)
+        from unittest.mock import call
+        self.assertIn(call(attacker, defender, bonus=-35), mock_hit.call_args_list)
 
     def test_barehand_damage_hand_to_hand(self):
         attacker = Dummy()
@@ -125,4 +126,5 @@ class TestUnarmedAutoAttack(unittest.TestCase):
             engine.process_round()
 
         self.assertEqual(defender.hp, 0)
-        mock_hit.assert_called_with(attacker, defender, bonus=6.0)
+        from unittest.mock import call
+        self.assertIn(call(attacker, defender, bonus=2), mock_hit.call_args_list)


### PR DESCRIPTION
## Summary
- compute unarmed hit chance based on stats and proficiencies
- scale unarmed damage from 1d6 and proficiency bonus
- route unarmed attacks through the new hit logic
- update unarmed damage tests

## Testing
- `pytest typeclasses/tests/test_unarmed_damage_bonus.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68504cc5e9cc832c98edf902979bc8ea