### PR TITLE
Add cooldown helper function

### DIFF
--- a/commands/abilities.py
+++ b/commands/abilities.py
@@ -42,11 +42,12 @@ class CmdKick(Command):
                 return
         else:
             from utils import auto_search
+
             target = auto_search(self.caller, self.args.strip())
             if not target:
                 return
         skill = Kick()
-        if not self.caller.cooldowns.ready(skill.name):
+        if state_manager.is_on_cooldown(self.caller, skill.name):
             self.msg("You are still recovering.")
             return
         if self.caller.traits.stamina.current < skill.stamina_cost:

--- a/typeclasses/tests/test_state_manager.py
+++ b/typeclasses/tests/test_state_manager.py
@@ -9,17 +9,11 @@ class TestStateManager(EvenniaTest):
         char = self.char1
         state_manager.add_temp_stat_bonus(char, "STR", 5, 2)
         base = char.traits.STR.value
-        self.assertEqual(
-            state_manager.get_effective_stat(char, "STR"), base + 5
-        )
+        self.assertEqual(state_manager.get_effective_stat(char, "STR"), base + 5)
         state_manager.tick_all()
-        self.assertEqual(
-            state_manager.get_effective_stat(char, "STR"), base + 5
-        )
+        self.assertEqual(state_manager.get_effective_stat(char, "STR"), base + 5)
         state_manager.tick_all()
-        self.assertEqual(
-            state_manager.get_effective_stat(char, "STR"), base
-        )
+        self.assertEqual(state_manager.get_effective_stat(char, "STR"), base)
 
     def test_status_effects(self):
         char = self.char1
@@ -122,6 +116,20 @@ class TestStateManager(EvenniaTest):
             trait = char.traits.get(key)
             self.assertEqual(trait.current, trait.max // 2 + regen)
 
+    def test_independent_skill_cooldowns(self):
+        char = self.char1
+        state_manager.add_cooldown(char, "kick", 5)
+        self.assertTrue(state_manager.is_on_cooldown(char, "kick"))
+        self.assertFalse(state_manager.is_on_cooldown(char, "cleave"))
+
+        state_manager.add_cooldown(char, "cleave", 5)
+        self.assertTrue(state_manager.is_on_cooldown(char, "kick"))
+        self.assertTrue(state_manager.is_on_cooldown(char, "cleave"))
+
+        state_manager.remove_cooldown(char, "kick")
+        self.assertFalse(state_manager.is_on_cooldown(char, "kick"))
+        self.assertTrue(state_manager.is_on_cooldown(char, "cleave"))
+
     def test_apply_regen_scales_with_status(self):
         char = self.char1
         for key in ("health", "mana", "stamina"):
@@ -162,4 +170,3 @@ class TestStateManager(EvenniaTest):
         for key, regen in expected.items():
             trait = char.traits.get(key)
             self.assertEqual(trait.current, trait.max // 2 + regen)
-

--- a/world/system/state_manager.py
+++ b/world/system/state_manager.py
@@ -115,6 +115,12 @@ def has_status(chara, status: str) -> bool:
     return status in statuses
 
 
+def is_on_cooldown(chara, key: str) -> bool:
+    """Return True if ``key`` cooldown is active on ``chara``."""
+
+    return not chara.cooldowns.ready(key)
+
+
 def add_cooldown(chara, key: str, duration: int):
     """Wrapper to add a cooldown to ``chara``."""
     reduction = get_effective_stat(chara, "cooldown_reduction")
@@ -385,4 +391,3 @@ def gain_xp(chara, amount: int) -> None:
             chara.db.tnl -= excess
         else:
             chara.db.tnl = settings.XP_TO_LEVEL(int(chara.db.level or 1))
-


### PR DESCRIPTION
## Summary
- add `state_manager.is_on_cooldown` helper
- use the helper in `CmdKick`
- test cooldown independence across skills

## Testing
- `pytest typeclasses/tests/test_state_manager.py::TestStateManager::test_independent_skill_cooldowns -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_685050d24da4832c82c6981055fc3247