### PR TITLE
Handle list-form skills in mob editor summary

### DIFF
--- a/commands/rom_mob_editor.py
+++ b/commands/rom_mob_editor.py
@@ -14,6 +14,7 @@ from utils.mob_proto import register_prototype, get_prototype
 from utils.vnum_registry import validate_vnum, register_vnum
 from world.templates.mob_templates import get_template
 from .command import Command
+import re
 
 VALID_STATS = {"STR", "CON", "DEX", "INT", "WIS", "LUCK"}
 
@@ -33,6 +34,16 @@ def _summary(caller) -> str:
     if race := proto.get("race"):
         lines.append(f"Race: {race}")
     skills = proto.get("skills") or {}
+    if isinstance(skills, list):
+        new_skills: dict[str, int] = {}
+        for item in skills:
+            match = re.match(r"^([^()]+)(?:\((\d+)%\))?$", str(item).strip())
+            if match:
+                name = match.group(1).strip()
+                chance = int(match.group(2)) if match.group(2) else 100
+                new_skills[name] = chance
+        proto["skills"] = new_skills
+        skills = new_skills
     if skills:
         parts = ", ".join(f"{k}({v}%)" for k, v in skills.items())
         lines.append(f"Skills: {parts}")

--- a/typeclasses/tests/test_rom_mob_editor_summary.py
+++ b/typeclasses/tests/test_rom_mob_editor_summary.py
@@ -1,0 +1,10 @@
+from evennia.utils.test_resources import EvenniaTest
+from commands import rom_mob_editor
+
+class TestRomMobEditorSummary(EvenniaTest):
+    def test_summary_handles_list_skills(self):
+        self.char1.ndb.mob_proto = {"skills": ["slash(100%)"]}
+        self.char1.ndb.mob_vnum = 1
+        out = rom_mob_editor._summary(self.char1)
+        assert "slash(100%)" in out
+


### PR DESCRIPTION
## Summary
- fix `rom_mob_editor._summary` to parse list-form skills like `"slash(100%)"`
- test that list-form skills display correctly

## Testing
- `pytest -q` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685057baf0cc832cb84531a147080729