### PR TITLE
Remove duplicate `alist` command

### DIFF
--- a/commands/areas.py
+++ b/commands/areas.py
@@ -9,32 +9,6 @@ from .aedit import CmdAEdit, CmdAList, CmdASave, CmdAreaReset, CmdAreaAge
 from typeclasses.rooms import Room
 
 
-class CmdAreas(Command):
-    """
-    List all registered areas and their number ranges.
-
-    Usage:
-        alist
-
-    See |whelp alist|n for details.
-    """
-
-    key = "alist"
-    aliases = ("areas",)
-    locks = "cmd:perm(Builder)"
-    help_category = "Building"
-
-    def func(self):
-        areas = get_areas()
-        if not areas:
-            self.msg("No areas registered.")
-            return
-        table = EvTable("Name", "Range", border="cells")
-        for area in areas:
-            table.add_row(area.key, f"{area.start}-{area.end}")
-        self.msg(str(table))
-
-
 class CmdAMake(Command):
     """
     Register a new area. Usage: amake <name> <start>-<end>

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -1382,7 +1382,8 @@ Related:
         "text": """
 Help for alist
 
-List all registered areas and their number ranges.
+List defined areas including their vnum range, builders, flags, current age and
+reset interval.
 
 Usage:
     alist


### PR DESCRIPTION
## Summary
- delete the old `CmdAreas` implementation
- keep `CmdAList` as the only `alist` command in `AreaCmdSet`
- update in-game help text for `alist`

## Testing
- `pytest -q` *(fails: django.db errors)*

------
https://chatgpt.com/codex/tasks/task_e_68505d8646e8832cb7d27bb5205e499d