### PR TITLE
Add Area tracking for mob prototypes

### DIFF
--- a/commands/mob_builder_commands.py
+++ b/commands/mob_builder_commands.py
@@ -12,6 +12,7 @@ from utils.prototype_manager import load_all_prototypes
 from .command import Command
 from . import npc_builder
 from world import prototypes, area_npcs
+from world.areas import get_areas
 from world.mob_constants import (
     NPC_RACES,
     NPC_CLASSES,
@@ -474,6 +475,7 @@ class CmdMList(Command):
         table = evtable.EvTable(
             "VNUM",
             "Key",
+            "Area",
             "Status",
             "Lvl",
             "Class",
@@ -501,9 +503,21 @@ class CmdMList(Command):
                 finalized = True
             status = "yes" if finalized else "no"
             primary = roles[0] if roles else "-"
+            area_val = proto.get("area")
+            if not area_val:
+                for ar in get_areas():
+                    if key in area_npcs.get_area_npc_list(ar.key):
+                        area_val = ar.key
+                        break
+            if not area_val and vnum is not None:
+                for ar in get_areas():
+                    if ar.start <= int(vnum) <= ar.end:
+                        area_val = ar.key
+                        break
             table.add_row(
                 str(vnum) if vnum is not None else "-",
                 key,
+                area_val or "-",
                 status,
                 str(proto.get("level", "-")),
                 proto.get("npc_type", "-"),

--- a/typeclasses/tests/test_mlist_command.py
+++ b/typeclasses/tests/test_mlist_command.py
@@ -94,6 +94,7 @@ class TestMListCommand(EvenniaTest):
         self.char1.execute_cmd("@mlist")
         out = self.char1.msg.call_args[0][0]
         assert "VNUM" in out
+        assert "Area" in out
         assert "5" in out
 
     def test_mlist_finalized_vnums_display(self):

--- a/utils/mob_proto.py
+++ b/utils/mob_proto.py
@@ -57,6 +57,8 @@ def register_prototype(
                 raise ValueError("VNUM outside area range")
         if validate_vnum(vnum, "npc"):
             register_vnum(vnum)
+    if area:
+        data["area"] = area
     mob_db.add_proto(vnum, data)
 
     key = data.get("key")


### PR DESCRIPTION
## Summary
- store area on prototypes when registering
- list prototype area in `@mlist`
- expect Area column in `@mlist` tests

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68505f2d5810832cbc37f53c0a39124f