### PR TITLE
Implement rlist command

### DIFF
--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -909,6 +909,31 @@ class TestRoomRegCommand(EvenniaTest):
         self.assertEqual(target.db.room_id, 4)
 
 
+class TestRListCommand(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.char1.msg = MagicMock()
+        self.char1.execute_cmd("amake zone 1-3")
+        self.char1.msg.reset_mock()
+        self.char1.execute_cmd("rmake zone 2")
+
+    def test_rlist_current_area(self):
+        self.char1.execute_cmd("rlist")
+        out = self.char1.msg.call_args[0][0]
+        self.assertIn("Rooms in zone", out)
+        self.assertIn("1:", out)
+        self.assertIn("2:", out)
+
+    def test_rlist_by_name(self):
+        self.char1.location.db.area = None
+        self.char1.msg.reset_mock()
+        self.char1.execute_cmd("rlist zone")
+        out = self.char1.msg.call_args[0][0]
+        self.assertIn("Rooms in zone", out)
+        self.assertIn("1:", out)
+        self.assertIn("2:", out)
+
+
 class TestAdminCommands(EvenniaTest):
     def setUp(self):
         super().setUp()

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -377,6 +377,34 @@ Related:
 """,
     },
     {
+        "key": "rlist",
+        "category": "Building",
+        "text": """"
+Help for rlist
+
+List rooms in an area showing VNUM and name.
+
+Usage:
+    rlist [<area>]
+
+Switches:
+    None
+
+Arguments:
+    None
+
+Examples:
+    rlist
+    rlist town
+
+Notes:
+    - Without an argument the command uses your current area's name.
+
+Related:
+    help ansi
+""",
+    },
+    {
         "key": "ocreate",
         "category": "Building",
         "text": """


### PR DESCRIPTION
## Summary
- add `CmdRList` to list area rooms
- register the command in AreaCmdSet
- document rlist command in help entries
- test rlist in current area or specified area

## Testing
- `pytest -q` *(fails: OperationalError no such table)*

------
https://chatgpt.com/codex/tasks/task_e_68506216dedc832ca339772d2d743168