### PR TITLE
Fix vnum sorting

### DIFF
--- a/commands/cmdmobbuilder.py
+++ b/commands/cmdmobbuilder.py
@@ -105,7 +105,8 @@ class CmdMobProto(Command):
             caller.msg("No mob prototypes registered.")
             return
         lines = ["|wVNUM|n |wName|n |wSpawns|n"]
-        for vnum, proto in sorted(mob_db.db.vnums.items()):
+        for vnum in sorted(str(v) for v in mob_db.db.vnums):
+            proto = mob_db.db.vnums[vnum]
             name = proto.get("key", "--")
             count = proto.get("spawn_count", 0)
             lines.append(f"{vnum:>5} {name} {count}")

--- a/commands/mob_builder_commands.py
+++ b/commands/mob_builder_commands.py
@@ -497,7 +497,7 @@ class CmdMList(Command):
                 or proto.get("vnum")
             )
             finalized = False
-            if vnum is not None and int(vnum) in mob_db.db.vnums:
+            if vnum is not None and str(vnum) in mob_db.db.vnums:
                 finalized = True
             elif key in finalized_lookup or proto.get("key") in finalized_lookup:
                 finalized = True
@@ -528,7 +528,7 @@ class CmdMList(Command):
 
         lines = [str(table)]
         if not (area or filter_by or rangestr or show_room or show_area):
-            finalized = sorted(mob_db.db.vnums)
+            finalized = sorted(str(v) for v in mob_db.db.vnums)
             lines.append("\n|wFinalized VNUMs|n")
             if finalized:
                 lines.append(", ".join(str(v) for v in finalized))

--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -944,7 +944,7 @@ class CmdEditNPC(Command):
         data = self.caller.ndb.buildnpc
         mob_db = get_mobdb()
         vnum = data.get("vnum") or npc.db.vnum
-        finalized = vnum is not None and int(vnum) in mob_db.db.vnums
+        finalized = vnum is not None and str(vnum) in mob_db.db.vnums
         status = "✅" if finalized else "🚫"
         roles = data.get("roles") or []
         if isinstance(roles, str):


### PR DESCRIPTION
## Summary
- standardize vnum lookups to use string keys
- avoid mixed type sorting in mob listing
- check membership using string keys

## Testing
- `pytest -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68506bc03d74832cb27f0d0aa824b540