### PR TITLE
Improve rlist area missing message

### DIFF
--- a/commands/areas.py
+++ b/commands/areas.py
@@ -163,8 +163,11 @@ class CmdRList(Command):
         area_name = self.args.strip()
         if not area_name:
             location = self.caller.location
-            if not location or not location.db.area:
+            if not location:
                 self.msg("Usage: rlist <area>")
+                return
+            if not location.db.area:
+                self.msg("No area information found for this room.")
                 return
             area_name = location.db.area
 

--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -933,6 +933,14 @@ class TestRListCommand(EvenniaTest):
         self.assertIn("1:", out)
         self.assertIn("2:", out)
 
+    def test_rlist_no_area_info(self):
+        self.char1.location.db.area = None
+        self.char1.msg.reset_mock()
+        self.char1.execute_cmd("rlist")
+        self.char1.msg.assert_called_with(
+            "No area information found for this room."
+        )
+
 
 class TestAdminCommands(EvenniaTest):
     def setUp(self):


### PR DESCRIPTION
## Summary
- update `CmdRList` to report missing room area info
- add unit test for this case

## Testing
- `pytest -q` *(fails: sqlite3.OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68506d670c40832c80599b8b70fd6a0c