### PR TITLE
Add vnum list to alist output

### DIFF
--- a/typeclasses/tests/test_alist_command.py
+++ b/typeclasses/tests/test_alist_command.py
@@ -22,11 +22,13 @@ class TestAListCommand(EvenniaTest):
         self.char1.execute_cmd("alist")
         out = self.char1.msg.call_args[0][0]
         self.assertIn("Rooms", out)
+        self.assertIn("Vnums", out)
         self.assertIn("Mobs", out)
         row = next(line for line in out.splitlines() if line.startswith("| zone"))
         cols = [c.strip() for c in row.split("|")[1:-1]]
         self.assertEqual(cols[2], "2")
-        self.assertEqual(cols[3], "2")
+        self.assertEqual(cols[3], "1, 2")
+        self.assertEqual(cols[4], "2")
 
     @patch("commands.aedit.load_all_prototypes")
     @patch("commands.aedit.get_areas")
@@ -50,7 +52,8 @@ class TestAListCommand(EvenniaTest):
         cols = [c.strip() for c in row.split("|")[1:-1]]
         self.assertEqual(cols[1], "1-4")
         self.assertEqual(cols[2], "4")
-        self.assertEqual(cols[3], "1")
+        self.assertEqual(cols[3], "1, 2, 3, 4")
+        self.assertEqual(cols[4], "1")
 
     def test_current(self):
         self.char1.location = self.room1

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -1410,8 +1410,8 @@ Related:
         "text": """
 Help for alist
 
-List defined areas including their vnum range, number of rooms, registered mob
-prototypes, builders, flags, current age and reset interval.
+List defined areas including their vnum range, list of room vnums, number of rooms,
+registered mob prototypes, builders, flags, current age and reset interval.
 
 Usage:
     alist
@@ -1427,7 +1427,7 @@ Examples:
     alist current
 
 Notes:
-    - None
+    - The Vnums column lists all room ids defined for the area.
 
 Related:
     help ansi


### PR DESCRIPTION
## Summary
- extend alist command to display Vnums column
- track area room ids when collecting data
- show comma separated vnums or '-' if none
- adjust tests for new column
- document the new Vnums column in help

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68507960fbac832c878c453f5c3a7d98