### PR TITLE
Update rlist header with area range

### DIFF
--- a/commands/areas.py
+++ b/commands/areas.py
@@ -196,7 +196,7 @@ class CmdRList(Command):
             num = room.db.room_id if room.db.room_id is not None else room.id
             lines.append(f"{num}: {room.key}")
 
-        header = f"Rooms in {area_name}"
+        header = f"Rooms in {area.key} ({area.start}-{area.end})"
         self.msg("\n".join([header] + lines))
 
 

--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -921,6 +921,7 @@ class TestRListCommand(EvenniaTest):
         self.char1.execute_cmd("rlist")
         out = self.char1.msg.call_args[0][0]
         self.assertIn("Rooms in zone", out)
+        self.assertIn("(1-3)", out)
         self.assertIn("1:", out)
         self.assertIn("2:", out)
 
@@ -930,6 +931,7 @@ class TestRListCommand(EvenniaTest):
         self.char1.execute_cmd("rlist zone")
         out = self.char1.msg.call_args[0][0]
         self.assertIn("Rooms in zone", out)
+        self.assertIn("(1-3)", out)
         self.assertIn("1:", out)
         self.assertIn("2:", out)
 


### PR DESCRIPTION
## Summary
- display area range in rlist output
- check for area range in rlist tests

## Testing
- `pytest -q` *(fails: OperationalError no such table)*

------
https://chatgpt.com/codex/tasks/task_e_68508155c954832c86e80478f27ee9d8