### PR TITLE
Add area lookup helper and auto assignment

### DIFF
--- a/commands/cmdmobbuilder.py
+++ b/commands/cmdmobbuilder.py
@@ -13,6 +13,7 @@ from utils.mob_proto import (
     register_prototype,
     spawn_from_vnum,
 )
+from world.areas import find_area_by_vnum
 from world.scripts.mob_db import get_mobdb
 from typeclasses.npcs import BaseNPC
 from scripts import BuilderAutosave
@@ -67,7 +68,11 @@ class CmdMobProto(Command):
         if get_prototype(vnum):
             caller.msg("Prototype already exists.")
             return
-        register_prototype({"key": name}, vnum=vnum)
+        area = find_area_by_vnum(vnum)
+        proto = {"key": name}
+        if area:
+            proto["area"] = area.key
+        register_prototype(proto, vnum=vnum, area=area.key if area else None)
         caller.msg(f"Prototype {vnum} created.")
 
     def _sub_set(self, rest: str):

--- a/commands/mob_builder_commands.py
+++ b/commands/mob_builder_commands.py
@@ -13,6 +13,7 @@ from .command import Command
 from . import npc_builder
 from world import prototypes, area_npcs
 from world.areas import get_areas
+from world.areas import find_area_by_vnum
 from world.mob_constants import (
     NPC_RACES,
     NPC_CLASSES,
@@ -934,5 +935,8 @@ class CmdProtoEdit(Command):
 
         proto = dict(proto)
         proto[self.field] = val
-        register_prototype(proto, vnum=self.vnum)
+        area = find_area_by_vnum(self.vnum)
+        if area and "area" not in proto:
+            proto["area"] = area.key
+        register_prototype(proto, vnum=self.vnum, area=area.key if area else None)
         self.msg(f"{self.field} updated on {self.vnum}.")

--- a/commands/redit.py
+++ b/commands/redit.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from olc.base import OLCEditor, OLCState, OLCValidator
 from utils.prototype_manager import save_prototype
 from utils.vnum_registry import validate_vnum, register_vnum
+from world.areas import find_area_by_vnum
 from .building import DIR_FULL, OPPOSITE
 from .command import Command
 
@@ -211,7 +212,10 @@ class CmdREdit(Command):
             self.msg("Invalid or already used VNUM.")
             return
         register_vnum(vnum)
-        self.caller.ndb.room_protos = {vnum: {"vnum": vnum, "key": f"Room {vnum}", "desc": "", "flags": [], "exits": {}}}
+        proto = {"vnum": vnum, "key": f"Room {vnum}", "desc": "", "flags": [], "exits": {}}
+        if area := find_area_by_vnum(vnum):
+            proto["area"] = area.key
+        self.caller.ndb.room_protos = {vnum: proto}
         self.caller.ndb.current_vnum = vnum
         state = OLCState(data=self.caller.ndb.room_protos, vnum=vnum, original=dict(self.caller.ndb.room_protos))
         OLCEditor(

--- a/world/areas.py
+++ b/world/areas.py
@@ -105,3 +105,11 @@ def get_area_vnum_range(name: str) -> Optional[tuple[int, int]]:
     return None
 
 
+def find_area_by_vnum(vnum: int) -> Area | None:
+    """Return the area whose range includes ``vnum``."""
+    for area in get_areas():
+        if area.start <= vnum <= area.end:
+            return area
+    return None
+
+

--- a/world/menus/mob_builder_menu.py
+++ b/world/menus/mob_builder_menu.py
@@ -12,6 +12,7 @@ from utils.menu_utils import (
 )
 from utils import vnum_registry
 from utils.prototype_manager import load_prototype
+from world.areas import find_area_by_vnum
 from evennia.utils import dedent
 import re
 
@@ -282,6 +283,8 @@ def _set_vnum(caller, raw_string, **kwargs):
         vnum_registry.unregister_vnum(int(old), "npc")
 
     data["vnum"] = val
+    if area := find_area_by_vnum(val):
+        data.setdefault("area", area.key)
     caller.ndb.buildnpc = data
     return _next_node(caller, "menunode_creature_type")
 

--- a/world/tests/test_area_lookup.py
+++ b/world/tests/test_area_lookup.py
@@ -1,0 +1,11 @@
+from unittest import mock
+from evennia.utils.test_resources import EvenniaTest
+from world.areas import Area, find_area_by_vnum
+
+class TestFindAreaByVnum(EvenniaTest):
+    def test_lookup(self):
+        areas = [Area(key="zone", start=1, end=5), Area(key="dungeon", start=10, end=20)]
+        with mock.patch("world.areas.get_areas", return_value=areas):
+            assert find_area_by_vnum(3).key == "zone"
+            assert find_area_by_vnum(15).key == "dungeon"
+            assert find_area_by_vnum(30) is None


### PR DESCRIPTION
## Summary
- implement `find_area_by_vnum` helper in `world.areas`
- auto-assign area in `redit`, `medit`, mob builder menu and commands
- include unit test for area lookup

## Testing
- `pytest -q` *(fails: `sqlite3.OperationalError: no such table: accounts_accountdb`)*

------
https://chatgpt.com/codex/tasks/task_e_6850825c53d8832ca4148d18b4f4f883