### PR TITLE
Implement aedit add subcommand

### DIFF
--- a/typeclasses/tests/test_aedit_add.py
+++ b/typeclasses/tests/test_aedit_add.py
@@ -1,0 +1,24 @@
+from unittest.mock import MagicMock, patch
+from django.test import override_settings
+from evennia.utils.test_resources import EvenniaTest
+from commands.admin import BuilderCmdSet
+from world.areas import Area
+
+@override_settings(DEFAULT_HOME=None)
+class TestAEditAdd(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.char1.msg = MagicMock()
+        self.char1.cmdset.add_default(BuilderCmdSet)
+
+    @patch("commands.aedit.update_area")
+    @patch("commands.aedit.load_prototype")
+    @patch("commands.aedit.find_area")
+    def test_add_room(self, mock_find_area, mock_load_proto, mock_update):
+        area = Area(key="zone", start=1, end=5)
+        mock_find_area.return_value = (0, area)
+        mock_load_proto.return_value = {"vnum": 3}
+        self.char1.execute_cmd("aedit add zone 3")
+        self.assertIn(3, area.rooms)
+        mock_update.assert_called_with(0, area)
+

--- a/world/areas.py
+++ b/world/areas.py
@@ -18,6 +18,7 @@ class Area:
     reset_interval: int = 0
     flags: List[str] = field(default_factory=list)
     age: int = 0
+    rooms: List[int] = field(default_factory=list)
 
     @classmethod
     def from_dict(cls, data: Dict) -> "Area":
@@ -30,6 +31,7 @@ class Area:
             reset_interval=int(data.get("reset_interval", 0)),
             flags=data.get("flags", []),
             age=int(data.get("age", 0)),
+            rooms=[int(r) for r in data.get("rooms", [])],
         )
 
     def to_dict(self) -> Dict:


### PR DESCRIPTION
## Summary
- support adding rooms to area metadata
- store room lists in area dataclass
- test new `aedit add` feature

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_685085864770832c966b5957096c02a0