### PR TITLE
Add area rooms tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,3 +472,7 @@ After installing the dependencies, execute the tests with:
 pytest -q
 ```
 
+
+## Area JSON Files
+
+Area definitions under `world/prototypes/areas` now store a `rooms` list of VNUMs belonging to that area. Older JSON files missing this field still load correctly but will not track individual rooms until updated. See [docs/area_json.md](docs/area_json.md) for details.

--- a/docs/area_json.md
+++ b/docs/area_json.md
@@ -1,0 +1,7 @@
+# Area JSON Files
+
+Area definitions are stored under `world/prototypes/areas` as JSON. Each area file tracks the range of allowed room VNUMs and other metadata.
+
+As of the latest update, area data also includes a `rooms` list containing the VNUMs of rooms explicitly associated with the area. Older area files may not include this key. When loaded those entries will receive an empty list automatically and will continue to work.
+
+If you want to track which rooms belong to an area, use the `aedit add <area> <room_vnum>` command to populate the list and then save the area with `asave changed`.

--- a/world/areas.py
+++ b/world/areas.py
@@ -31,11 +31,13 @@ class Area:
             reset_interval=int(data.get("reset_interval", 0)),
             flags=data.get("flags", []),
             age=int(data.get("age", 0)),
-            rooms=[int(r) for r in data.get("rooms", [])],
+            rooms=sorted({int(r) for r in data.get("rooms", [])}),
         )
 
     def to_dict(self) -> Dict:
-        return asdict(self)
+        data = asdict(self)
+        data["rooms"] = sorted({int(r) for r in self.rooms})
+        return data
 
 
 _BASE_PATH = Path(settings.GAME_DIR) / "world" / "prototypes" / "areas"
@@ -113,5 +115,3 @@ def find_area_by_vnum(vnum: int) -> Area | None:
         if area.start <= vnum <= area.end:
             return area
     return None
-
-


### PR DESCRIPTION
## Summary
- ensure `Area` dataclass keeps a list of room vnums and preserve it when saving
- document the new `rooms` field in area JSON files

## Testing
- `pytest -q` *(fails: django.db connection errors)*

------
https://chatgpt.com/codex/tasks/task_e_685087750020832ca5b1990241859513