### PR TITLE
Improve redit validation and docs

### DIFF
--- a/commands/redit.py
+++ b/commands/redit.py
@@ -13,6 +13,7 @@ from utils.vnum_registry import (
     validate_vnum,
     register_vnum,
     unregister_vnum,
+    VNUM_RANGES,
 )
 from world.areas import find_area_by_vnum, get_areas, update_area
 from .building import DIR_FULL, OPPOSITE
@@ -264,7 +265,11 @@ class CmdREdit(Command):
             return
         vnum = int(parts[1])
         if not validate_vnum(vnum, "room"):
-            self.msg("Invalid or already used VNUM.")
+            start, end = VNUM_RANGES["room"]
+            self.msg(
+                f"Invalid or already used VNUM. Rooms use {start}-{end}. "
+                "Try @nextvnum R."
+            )
             return
         register_vnum(vnum)
         proto = {"vnum": vnum, "key": f"Room {vnum}", "desc": "", "flags": [], "exits": {}}

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -405,6 +405,34 @@ Related:
 """,
     },
     {
+        "key": "redit",
+        "category": "Building",
+        "text": """Help for redit
+
+Edit room prototypes in a menu.
+
+Usage:
+    redit create <vnum>
+
+Switches:
+    None
+
+Arguments:
+    None
+
+Examples:
+    None
+
+Notes:
+    - Valid VNUM range is 200000-299999.
+    - Use @nextvnum R to obtain a free number.
+    - This edits prototypes, not live rooms.
+
+Related:
+    help vnums
+""",
+    },
+    {
         "key": "ocreate",
         "category": "Building",
         "text": """


### PR DESCRIPTION
## Summary
- show allowed VNUM range when `redit` creates a room prototype
- add help entry for `redit`

## Testing
- `pytest -q` *(fails: django.db and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68508a0a6810832c8efea875fa688bd5