### PR TITLE
Add direct VNUM editing to redit

### DIFF
--- a/commands/redit.py
+++ b/commands/redit.py
@@ -214,6 +214,30 @@ class CmdREdit(Command):
         parts = self.args.split()
         sub = parts[0].lower()
 
+        if len(parts) == 1 and parts[0].isdigit():
+            vnum = int(parts[0])
+            proto = load_prototype("room", vnum)
+            if proto is None:
+                self.msg(
+                    f"Room VNUM {vnum} not found. Use `redit create {vnum}` to make a new room."
+                )
+                return
+            self.caller.ndb.room_protos = {vnum: proto}
+            self.caller.ndb.current_vnum = vnum
+            state = OLCState(
+                data=self.caller.ndb.room_protos,
+                vnum=vnum,
+                original=dict(self.caller.ndb.room_protos),
+            )
+            OLCEditor(
+                self.caller,
+                "commands.redit",
+                startnode="menunode_main",
+                state=state,
+                validator=OLCValidator(),
+            ).start()
+            return
+
         if sub == "vnum" and len(parts) == 3:
             old_str, new_str = parts[1], parts[2]
             if not (old_str.isdigit() and new_str.isdigit()):

--- a/typeclasses/tests/test_redit_command.py
+++ b/typeclasses/tests/test_redit_command.py
@@ -1,0 +1,30 @@
+from unittest.mock import MagicMock, patch
+from evennia.utils.test_resources import EvenniaTest
+from commands.admin import BuilderCmdSet
+
+
+class TestREditCommand(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.char1.msg = MagicMock()
+        self.char1.cmdset.add_default(BuilderCmdSet)
+
+    def test_open_existing_proto(self):
+        with (
+            patch("commands.redit.load_prototype", return_value={"vnum": 5}) as mock_load,
+            patch("commands.redit.OLCEditor") as mock_editor,
+        ):
+            self.char1.execute_cmd("redit 5")
+        mock_load.assert_called_with("room", 5)
+        mock_editor.assert_called()
+        mock_editor.return_value.start.assert_called()
+        assert self.char1.ndb.room_protos[5]["vnum"] == 5
+        assert self.char1.ndb.current_vnum == 5
+
+    def test_not_found_message(self):
+        with patch("commands.redit.load_prototype", return_value=None):
+            self.char1.msg.reset_mock()
+            self.char1.execute_cmd("redit 99")
+        self.char1.msg.assert_called_with(
+            "Room VNUM 99 not found. Use `redit create 99` to make a new room."
+        )

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -412,6 +412,7 @@ Related:
 Edit room prototypes in a menu.
 
 Usage:
+    redit <vnum>
     redit create <vnum>
 
 Switches:


### PR DESCRIPTION
## Summary
- allow `redit <vnum>` to edit existing room prototypes
- mention the new usage in help entries
- test the new command behaviour

## Testing
- `scripts/setup_test_env.sh` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pytest -q` *(fails: 549 failed, 29 passed, 2 warnings, 1 error)*

------
https://chatgpt.com/codex/tasks/task_e_68508ed2e9ec832c9bc0492d23bbddea