### PR TITLE
Fix aedit add area data

### DIFF
--- a/commands/aedit.py
+++ b/commands/aedit.py
@@ -13,7 +13,11 @@ from world.areas import (
 )
 from world import area_npcs
 from olc.base import OLCValidator
-from utils.prototype_manager import load_all_prototypes, load_prototype
+from utils.prototype_manager import (
+    load_all_prototypes,
+    load_prototype,
+    save_prototype,
+)
 
 
 class AreaValidator(OLCValidator):
@@ -301,12 +305,24 @@ class CmdAEdit(Command):
             if not proto:
                 self.msg("Room prototype not found.")
                 return
+
+            proto["area"] = area.key
+            proto.setdefault("room_id", room_vnum)
+
             if room_vnum not in area.rooms:
                 area.rooms.append(room_vnum)
-            if not (area.start <= room_vnum <= area.end):
+            out_of_range = not (area.start <= room_vnum <= area.end)
+            if out_of_range:
                 self.msg(
                     f"Warning: room {room_vnum} outside {area.key} range {area.start}-{area.end}."
                 )
+                if room_vnum < area.start:
+                    area.start = room_vnum
+                if room_vnum > area.end:
+                    area.end = room_vnum
+
+            save_prototype("room", proto, vnum=room_vnum)
+
             update_area(idx, area)
             self.msg(f"Room {room_vnum} added to {area.key}.")
             return

--- a/typeclasses/tests/test_aedit_add.py
+++ b/typeclasses/tests/test_aedit_add.py
@@ -3,6 +3,7 @@ from django.test import override_settings
 from evennia.utils.test_resources import EvenniaTest
 from commands.admin import BuilderCmdSet
 from world.areas import Area
+from commands import aedit
 
 @override_settings(DEFAULT_HOME=None)
 class TestAEditAdd(EvenniaTest):
@@ -12,13 +13,53 @@ class TestAEditAdd(EvenniaTest):
         self.char1.cmdset.add_default(BuilderCmdSet)
 
     @patch("commands.aedit.update_area")
+    @patch("commands.aedit.save_prototype")
     @patch("commands.aedit.load_prototype")
     @patch("commands.aedit.find_area")
-    def test_add_room(self, mock_find_area, mock_load_proto, mock_update):
+    def test_add_room(self, mock_find_area, mock_load_proto, mock_save, mock_update):
         area = Area(key="zone", start=1, end=5)
         mock_find_area.return_value = (0, area)
         mock_load_proto.return_value = {"vnum": 3}
-        self.char1.execute_cmd("aedit add zone 3")
+        cmd = aedit.CmdAEdit()
+        cmd.caller = self.char1
+        cmd.session = self.char1.sessions.get()
+        cmd.args = "add zone 3"
+        cmd.func()
         self.assertIn(3, area.rooms)
+        proto = mock_save.call_args[0][1]
+        self.assertEqual(proto["area"], "zone")
+        mock_save.assert_called_with("room", proto, vnum=3)
+        mock_update.assert_called_with(0, area)
+
+    @patch("commands.aedit.update_area")
+    @patch("commands.aedit.save_prototype")
+    @patch("commands.aedit.load_prototype")
+    @patch("commands.aedit.find_area")
+    def test_range_updates_end(self, mock_find_area, mock_load_proto, mock_save, mock_update):
+        area = Area(key="zone", start=5, end=10)
+        mock_find_area.return_value = (0, area)
+        mock_load_proto.return_value = {"vnum": 12}
+        cmd = aedit.CmdAEdit()
+        cmd.caller = self.char1
+        cmd.session = self.char1.sessions.get()
+        cmd.args = "add zone 12"
+        cmd.func()
+        self.assertEqual(area.end, 12)
+        mock_update.assert_called_with(0, area)
+
+    @patch("commands.aedit.update_area")
+    @patch("commands.aedit.save_prototype")
+    @patch("commands.aedit.load_prototype")
+    @patch("commands.aedit.find_area")
+    def test_range_updates_start(self, mock_find_area, mock_load_proto, mock_save, mock_update):
+        area = Area(key="zone", start=5, end=10)
+        mock_find_area.return_value = (0, area)
+        mock_load_proto.return_value = {"vnum": 2}
+        cmd = aedit.CmdAEdit()
+        cmd.caller = self.char1
+        cmd.session = self.char1.sessions.get()
+        cmd.args = "add zone 2"
+        cmd.func()
+        self.assertEqual(area.start, 2)
         mock_update.assert_called_with(0, area)
 


### PR DESCRIPTION
## Summary
- ensure room prototypes store area information when aedit adds them
- expand area range when adding out-of-range VNUMs
- exercise the add path and range update logic in tests

## Testing
- `pytest typeclasses/tests/test_aedit_add.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685090900704832cbf3ee6ac9354519a