### PR TITLE
Add help entry for aedit command

### DIFF
--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -1463,6 +1463,44 @@ Related:
 """,
     },
     {
+        "key": "aedit",
+        "category": "Building",
+        "text": """Help for aedit
+
+Edit or create area metadata.
+
+Usage:
+    aedit create <name> <start> <end>
+    aedit range <name> <start> <end>
+    aedit builders <name> <list>
+    aedit flags <name> <list>
+    aedit interval <name> <ticks>
+    aedit add <area|vnum> <room_vnum>
+
+Switches:
+    None
+
+Arguments:
+    None
+
+Examples:
+    aedit create dungeon 1 99
+    aedit range town 200 299
+    aedit builders town Alice,Bob
+    aedit flags dungeon dark,safe
+    aedit interval dungeon 60
+    aedit add dungeon 5
+
+Notes:
+    - Builders and flags are comma separated lists.
+    - The interval value is given in ticks.
+    - Adding by room VNUM updates the area's range if needed.
+
+Related:
+    help ansi
+""",
+    },
+    {
         "key": "amake",
         "category": "Building",
         "text": """


### PR DESCRIPTION
## Summary
- document usage of `aedit` in help entries

## Testing
- `pytest typeclasses/tests/test_help_index.py typeclasses/tests/test_admin_commands.py::TestAdminCommands::test_help_entries_exist typeclasses/tests/test_aedit_add.py -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68509b16ab90832cb662b413bb752086