### PR TITLE
Fix teleport NameError and add test

### DIFF
--- a/commands/building.py
+++ b/commands/building.py
@@ -2,7 +2,7 @@ from evennia import create_object
 from evennia.objects.models import ObjectDB
 from .command import Command
 from typeclasses.rooms import Room
-from world.areas import find_area
+from world.areas import find_area, find_area_by_vnum
 from utils import VALID_SLOTS, normalize_slot
 
 

--- a/world/tests/test_teleport_command.py
+++ b/world/tests/test_teleport_command.py
@@ -1,0 +1,21 @@
+from unittest import mock, TestCase
+
+from commands.building import CmdTeleport
+
+
+class TestTeleportCommand(TestCase):
+    """Ensure teleport looks up area by vnum when given digits."""
+
+    def test_digits_use_find_area_by_vnum(self):
+        caller = mock.Mock()
+        caller.location = mock.Mock()
+
+        cmd = CmdTeleport()
+        cmd.caller = caller
+        cmd.args = "42"
+        cmd.msg = mock.Mock()
+
+        with mock.patch("commands.building.find_area_by_vnum") as mock_lookup, \
+             mock.patch("commands.building.ObjectDB.objects.filter", return_value=[]):
+            cmd.func()
+            mock_lookup.assert_called_with(42)


### PR DESCRIPTION
## Summary
- import `find_area_by_vnum` in `CmdTeleport`
- test teleport command looks up area by vnum

## Testing
- `pytest world/tests/test_teleport_command.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6850a5e5b810832cada8d57679a80263