### PR TITLE
Improve redit create

### DIFF
--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -427,7 +427,7 @@ Examples:
 Notes:
     - Valid VNUM range is 200000-299999.
     - Use @nextvnum R to obtain a free number.
-    - This edits prototypes, not live rooms.
+    - redit create immediately spawns a usable room and registers it to the area.
 
 Related:
     help vnums


### PR DESCRIPTION
## Summary
- create rooms directly when using `redit create`
- update help for `redit`

## Testing
- `pytest -q` *(fails: django.db...)*

------
https://chatgpt.com/codex/tasks/task_e_6850aac405b4832ca020601856157857