### PR TITLE
Update rmake for prototypes and force flag

### DIFF
--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -331,7 +331,7 @@ Usage:
     rmake <area> <number>
 
 Switches:
-    None
+    --force
 
 Arguments:
     None
@@ -341,7 +341,9 @@ Examples:
 
 Notes:
     - The number must fall within the area's range.
+    - The room is spawned from a saved prototype.
     - The room is not automatically linked to any others.
+    - Use --force to replace an existing room at that VNUM.
 
 Related:
     help ansi


### PR DESCRIPTION
## Summary
- support `--force` when making rooms
- spawn rooms from prototypes and update area lists
- document prototype usage and `--force` in the help file

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6850ace1eac4832cbe3f190ff6c77f5e