### PR TITLE
Fix rreg not updating area rooms

### DIFF
--- a/commands/areas.py
+++ b/commands/areas.py
@@ -175,7 +175,7 @@ class CmdRList(Command):
                 return
             area_name = location.db.area
 
-        _, area = find_area(area_name)
+        idx, area = find_area(area_name)
         if area is None:
             self.msg(
                 f"Area '{area_name}' not found. Use 'alist' to view available areas."
@@ -426,7 +426,7 @@ class CmdRReg(Command):
             return
         room_id = int(num_str)
 
-        _, area = find_area(area_name)
+        idx, area = find_area(area_name)
         if area is None:
             self.msg(
                 f"Area '{area_name}' not found. Use 'alist' to view available areas."
@@ -448,6 +448,9 @@ class CmdRReg(Command):
                 return
 
         room.set_area(area_name, room_id)
+        if room_id not in area.rooms:
+            area.rooms.append(room_id)
+            update_area(idx, area)
         name = room.key if room != self.caller.location else "Room"
         self.msg(f"{name} registered as {area_name} #{room_id}.")
 

--- a/typeclasses/tests/test_rreg_area_file.py
+++ b/typeclasses/tests/test_rreg_area_file.py
@@ -1,0 +1,33 @@
+import json
+from unittest.mock import patch, MagicMock
+from tempfile import TemporaryDirectory
+from pathlib import Path
+from django.test import override_settings
+from evennia.utils.test_resources import EvenniaTest
+
+
+@override_settings(DEFAULT_HOME=None)
+class TestRRegAreaFile(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.tmp = TemporaryDirectory()
+        # patch area storage path
+        patcher = patch('world.areas._BASE_PATH', Path(self.tmp.name))
+        self.addCleanup(self.tmp.cleanup)
+        self.addCleanup(patcher.stop)
+        patcher.start()
+        self.char1.msg = MagicMock()
+        self.char1.execute_cmd("amake zone 1-10")
+        self.area_file = Path(self.tmp.name) / "zone.json"
+        self.char1.msg.reset_mock()
+
+    def test_rreg_updates_rooms_list(self):
+        with self.area_file.open() as f:
+            data = json.load(f)
+        self.assertEqual(data.get("rooms"), [])
+        self.char1.execute_cmd("rreg zone 3")
+        with self.area_file.open() as f:
+            data = json.load(f)
+        self.assertIn(3, data.get("rooms", []))
+        self.assertEqual(len(data["rooms"]), 1)
+


### PR DESCRIPTION
## Summary
- ensure `rreg` updates `Area.rooms` and saves the area json
- regression test for rreg updating the area file

## Testing
- `pytest -q typeclasses/tests/test_rreg_area_file.py -s`
- `pytest -q` *(fails: ObjectDB.DoesNotExist and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6850b48a1f78832c81263b806b5cfa5d