### PR TITLE
Add area identifier helper

### DIFF
--- a/commands/aedit.py
+++ b/commands/aedit.py
@@ -9,7 +9,7 @@ from world.areas import (
     save_area,
     update_area,
     find_area,
-    find_area_by_vnum,
+    parse_area_identifier,
 )
 from world import area_npcs
 from olc.base import OLCValidator
@@ -288,14 +288,11 @@ class CmdAEdit(Command):
                 return
             area_arg, vnum_str = args
             room_vnum = int(vnum_str)
-            if area_arg.isdigit():
-                area = find_area_by_vnum(int(area_arg))
-                if area:
-                    idx, _ = find_area(area.key)
-                else:
-                    idx = -1
+            area = parse_area_identifier(area_arg)
+            if area:
+                idx, _ = find_area(area.key)
             else:
-                idx, area = find_area(area_arg)
+                idx = -1
             if area is None:
                 self.msg(
                     f"Area '{area_arg}' not found. Use 'alist' to view available areas."

--- a/commands/building.py
+++ b/commands/building.py
@@ -2,7 +2,7 @@ from evennia import create_object
 from evennia.objects.models import ObjectDB
 from .command import Command
 from typeclasses.rooms import Room
-from world.areas import find_area, find_area_by_vnum
+from world.areas import find_area, parse_area_identifier, find_area_by_vnum
 from utils import VALID_SLOTS, normalize_slot
 
 
@@ -186,7 +186,7 @@ class CmdTeleport(Command):
                 self.msg("Room number must be numeric.")
                 return
             room_id = int(num_part)
-            _, area = find_area(area_part)
+            area = parse_area_identifier(area_part)
             if area and not (area.start <= room_id <= area.end):
                 self.msg("Number outside area range.")
                 return

--- a/typeclasses/tests/test_aedit_add.py
+++ b/typeclasses/tests/test_aedit_add.py
@@ -15,10 +15,10 @@ class TestAEditAdd(EvenniaTest):
     @patch("commands.aedit.update_area")
     @patch("commands.aedit.save_prototype")
     @patch("commands.aedit.load_prototype")
-    @patch("commands.aedit.find_area")
-    def test_add_room(self, mock_find_area, mock_load_proto, mock_save, mock_update):
+    @patch("commands.aedit.parse_area_identifier")
+    def test_add_room(self, mock_parse, mock_load_proto, mock_save, mock_update):
         area = Area(key="zone", start=1, end=5)
-        mock_find_area.return_value = (0, area)
+        mock_parse.return_value = area
         mock_load_proto.return_value = {"vnum": 3}
         cmd = aedit.CmdAEdit()
         cmd.caller = self.char1
@@ -34,10 +34,10 @@ class TestAEditAdd(EvenniaTest):
     @patch("commands.aedit.update_area")
     @patch("commands.aedit.save_prototype")
     @patch("commands.aedit.load_prototype")
-    @patch("commands.aedit.find_area")
-    def test_range_updates_end(self, mock_find_area, mock_load_proto, mock_save, mock_update):
+    @patch("commands.aedit.parse_area_identifier")
+    def test_range_updates_end(self, mock_parse, mock_load_proto, mock_save, mock_update):
         area = Area(key="zone", start=5, end=10)
-        mock_find_area.return_value = (0, area)
+        mock_parse.return_value = area
         mock_load_proto.return_value = {"vnum": 12}
         cmd = aedit.CmdAEdit()
         cmd.caller = self.char1
@@ -50,10 +50,10 @@ class TestAEditAdd(EvenniaTest):
     @patch("commands.aedit.update_area")
     @patch("commands.aedit.save_prototype")
     @patch("commands.aedit.load_prototype")
-    @patch("commands.aedit.find_area")
-    def test_range_updates_start(self, mock_find_area, mock_load_proto, mock_save, mock_update):
+    @patch("commands.aedit.parse_area_identifier")
+    def test_range_updates_start(self, mock_parse, mock_load_proto, mock_save, mock_update):
         area = Area(key="zone", start=5, end=10)
-        mock_find_area.return_value = (0, area)
+        mock_parse.return_value = area
         mock_load_proto.return_value = {"vnum": 2}
         cmd = aedit.CmdAEdit()
         cmd.caller = self.char1

--- a/world/areas.py
+++ b/world/areas.py
@@ -206,3 +206,17 @@ def find_area_by_vnum(vnum: int) -> Area | None:
         return area
 
     return None
+
+
+def parse_area_identifier(identifier: str) -> Area | None:
+    """Return an area by name or numeric index."""
+
+    ident = identifier.strip()
+    if ident.isdigit():
+        index = int(ident) - 1
+        areas = get_areas()
+        if 0 <= index < len(areas):
+            return areas[index]
+        return None
+    _, area = find_area(ident)
+    return area

--- a/world/tests/test_area_lookup.py
+++ b/world/tests/test_area_lookup.py
@@ -1,6 +1,6 @@
 from unittest import mock
 from evennia.utils.test_resources import EvenniaTest
-from world.areas import Area, find_area_by_vnum
+from world.areas import Area, find_area_by_vnum, parse_area_identifier
 
 class TestFindAreaByVnum(EvenniaTest):
     def test_lookup(self):
@@ -9,3 +9,18 @@ class TestFindAreaByVnum(EvenniaTest):
             assert find_area_by_vnum(3).key == "zone"
             assert find_area_by_vnum(15).key == "dungeon"
             assert find_area_by_vnum(30) is None
+
+
+class TestParseAreaIdentifier(EvenniaTest):
+    def setUp(self):
+        self.areas = [Area(key="zone", start=1, end=5), Area(key="dungeon", start=10, end=20)]
+
+    def test_by_name(self):
+        with mock.patch("world.areas.get_areas", return_value=self.areas):
+            area = parse_area_identifier("dungeon")
+            assert area.key == "dungeon"
+
+    def test_by_index(self):
+        with mock.patch("world.areas.get_areas", return_value=self.areas):
+            area = parse_area_identifier("2")
+            assert area.key == "dungeon"


### PR DESCRIPTION
## Summary
- add `parse_area_identifier` to parse area names or indexes
- refactor area commands to use the new helper
- adjust tests for the new helper
- add unit tests for parsing by name and index

## Testing
- `pytest world/tests/test_area_lookup.py typeclasses/tests/test_aedit_add.py world/tests/test_teleport_command.py -q` *(fails: OperationalError)*

------
https://chatgpt.com/codex/tasks/task_e_6850b6e51e10832cbeacaeeae3cc106b