### PR TITLE
Implement live room editing support

### DIFF
--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -441,9 +441,10 @@ Related:
 Edit room prototypes in a menu.
 
 Usage:
-    redit <vnum>
-    redit create <vnum>
-    redit here <vnum>
+    redit <vnum> – edit a prototype or fallback to the live room
+    redit create <vnum> – create a new prototype
+    redit vnum <old> <new> – change prototype VNUM
+    redit live <vnum> – force edit of an existing room object
 
 Switches:
     None


### PR DESCRIPTION
## Summary
- extend `redit` command with `live` subcommand to edit existing rooms
- document new usage in help entry
- test new `redit live` behavior

## Testing
- `pytest -q` *(fails: django.db errors)*

------
https://chatgpt.com/codex/tasks/task_e_6850c1ce271c832ca3432145e171f25c