### PR TITLE
Handle malformed prototype files

### DIFF
--- a/commands/redit.py
+++ b/commands/redit.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from olc.base import OLCEditor, OLCState, OLCValidator
+import json
 from utils.prototype_manager import (
     save_prototype,
     load_prototype,
@@ -338,7 +339,14 @@ class CmdREdit(Command):
 
         if len(parts) == 1 and parts[0].isdigit():
             vnum = int(parts[0])
-            proto = load_prototype("room", vnum)
+            try:
+                proto = load_prototype("room", vnum)
+            except json.JSONDecodeError:
+                self.msg(
+                    f"Error loading prototype for room {vnum}. Try 'redit create {vnum}'."
+                )
+                _clear_state()
+                return
             if proto is None:
                 objs = ObjectDB.objects.filter(
                     db_attributes__db_key="room_id",

--- a/typeclasses/tests/test_redit_command.py
+++ b/typeclasses/tests/test_redit_command.py
@@ -34,6 +34,21 @@ class TestREditCommand(EvenniaTest):
             "Room VNUM 99 not found. Use `redit create 99` to make a new room."
         )
 
+    def test_malformed_proto_message(self):
+        import json
+
+        err = json.JSONDecodeError("bad", "", 0)
+        with (
+            patch("commands.redit.load_prototype", side_effect=err),
+            patch("commands.redit.OLCEditor") as mock_editor,
+        ):
+            self.char1.msg.reset_mock()
+            self.char1.execute_cmd("redit 200000")
+            mock_editor.assert_not_called()
+        self.char1.msg.assert_called_with(
+            "Error loading prototype for room 200000. Try 'redit create 200000'."
+        )
+
     def test_edit_live_room(self):
         from evennia.utils import create
         from typeclasses.rooms import Room

--- a/utils/prototype_manager.py
+++ b/utils/prototype_manager.py
@@ -54,8 +54,10 @@ def load_prototype(category: str, vnum: int) -> Optional[dict]:
             return json.load(f)
     except FileNotFoundError:
         return None
-    except json.JSONDecodeError:
-        return None
+    except json.JSONDecodeError as err:
+        # Propagate decode errors so callers can differentiate between an
+        # unreadable file and one that simply does not exist.
+        raise err
 
 
 def load_all_prototypes(category: str) -> Dict[int, dict]:


### PR DESCRIPTION
## Summary
- raise JSONDecodeError from `load_prototype`
- display decode errors in `redit`
- test malformed room prototype handling

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6850c1f87520832cb94f034d25090ad3