### PR TITLE
Improve alist command room counts

### DIFF
--- a/commands/aedit.py
+++ b/commands/aedit.py
@@ -120,21 +120,27 @@ class CmdAList(Command):
                 mob_count = area._temp_mob_count
                 room_ids = getattr(area, "_temp_room_ids", [])
             else:
-                objs = ObjectDB.objects.filter(
-                    db_attributes__db_key="area",
-                    db_attributes__db_strvalue__iexact=area.key,
-                )
-                rooms = [obj for obj in objs if obj.is_typeclass(Room, exact=False)]
-                room_count = len(rooms)
-                room_ids = []
-                for room in rooms:
-                    rid = room.attributes.get("room_id")
-                    if rid is not None:
-                        try:
-                            room_ids.append(int(rid))
-                        except (TypeError, ValueError):
-                            pass
-                room_ids = sorted(set(room_ids))
+                if area.rooms:
+                    room_ids = sorted(set(area.rooms))
+                    room_count = len(room_ids)
+                else:
+                    objs = ObjectDB.objects.filter(
+                        db_attributes__db_key="area",
+                        db_attributes__db_strvalue__iexact=area.key,
+                    )
+                    rooms = [
+                        obj for obj in objs if obj.is_typeclass(Room, exact=False)
+                    ]
+                    room_count = len(rooms)
+                    room_ids = []
+                    for room in rooms:
+                        rid = room.attributes.get("room_id")
+                        if rid is not None:
+                            try:
+                                room_ids.append(int(rid))
+                            except (TypeError, ValueError):
+                                pass
+                    room_ids = sorted(set(room_ids))
                 mob_count = len(area_npcs.get_area_npc_list(area.key))
                 area._temp_room_ids = room_ids
 

--- a/typeclasses/tests/test_alist_command.py
+++ b/typeclasses/tests/test_alist_command.py
@@ -55,6 +55,21 @@ class TestAListCommand(EvenniaTest):
         self.assertEqual(cols[3], "1, 2, 3, 4")
         self.assertEqual(cols[4], "1")
 
+    @patch("commands.aedit.ObjectDB.objects.filter", return_value=[])
+    @patch("commands.aedit.get_areas")
+    @patch("commands.aedit.area_npcs.get_area_npc_list")
+    def test_counts_from_metadata(self, mock_npcs, mock_get_areas, mock_filter):
+        area = Area(key="zone", start=1, end=5, rooms=[1, 2, 3])
+        mock_get_areas.return_value = [area]
+        mock_npcs.return_value = ["orc"]
+        self.char1.execute_cmd("alist")
+        out = self.char1.msg.call_args[0][0]
+        row = next(line for line in out.splitlines() if line.startswith("| zone"))
+        cols = [c.strip() for c in row.split("|")[1:-1]]
+        self.assertEqual(cols[2], "3")
+        self.assertEqual(cols[3], "1, 2, 3")
+        self.assertEqual(cols[4], "1")
+
     def test_current(self):
         self.char1.location = self.room1
         self.char1.execute_cmd("alist current")


### PR DESCRIPTION
## Summary
- use `area.rooms` as the primary source when listing areas
- show VNUMs from the stored metadata
- add a test for metadata-only areas

## Testing
- `pytest -q typeclasses/tests/test_alist_command.py` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6850c59c39b4832cb664ec01dd9d380a