### PR TITLE
Add missing message for live room editing

### DIFF
--- a/commands/redit.py
+++ b/commands/redit.py
@@ -362,6 +362,7 @@ class CmdREdit(Command):
                 )
                 if room:
                     proto = proto_from_room(room)
+                    self.msg(f"Editing live room #{vnum} (no prototype found).")
                 else:
                     self.msg(
                         f"Room VNUM {vnum} not found. Use `redit create {vnum}` to make a new room."

--- a/typeclasses/tests/test_redit_command.py
+++ b/typeclasses/tests/test_redit_command.py
@@ -97,6 +97,30 @@ class TestREditCommand(EvenniaTest):
         assert room.tags.has("safe", category="room_flag")
         assert not room.tags.has("dark", category="room_flag")
 
+    def test_edit_live_room_message(self):
+        from evennia.utils import create
+        from typeclasses.rooms import Room
+
+        room = create.create_object(
+            Room,
+            key="Test Room",
+            location=self.char1.location,
+            home=self.char1.location,
+        )
+        room.db.room_id = 6
+
+        with (
+            patch("commands.redit.load_prototype", return_value=None),
+            patch("commands.redit.OLCEditor"),
+            patch("commands.redit.ObjectDB.objects.filter", return_value=[room]),
+        ):
+            self.char1.msg.reset_mock()
+            self.char1.execute_cmd("redit 6")
+
+        self.char1.msg.assert_called_with(
+            "Editing live room #6 (no prototype found)."
+        )
+
     def test_live_subcommand(self):
         from evennia.utils import create
         from typeclasses.rooms import Room


### PR DESCRIPTION
## Summary
- notify builder when editing a live room without a prototype
- unit test to ensure the message is sent

## Testing
- `pytest -q` *(fails: Django and Evennia not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6850d15887f8832ca2341f96d31b3357