### PR TITLE
Display area in redit summary

### DIFF
--- a/commands/redit.py
+++ b/commands/redit.py
@@ -81,6 +81,9 @@ def _summary(caller) -> str:
         return ""
     lines = [f"|wEditing room {data['vnum']}|n"]
     lines.append(f"Name: {data.get('key', '')}")
+    area = data.get("area")
+    if area:
+        lines.append(f"Area: {area}")
     desc = data.get("desc", "")
     if desc:
         lines.append(f"Desc: {desc}")

--- a/typeclasses/tests/test_redit_summary.py
+++ b/typeclasses/tests/test_redit_summary.py
@@ -1,0 +1,15 @@
+from evennia.utils.test_resources import EvenniaTest
+from commands import redit
+
+class TestReditSummary(EvenniaTest):
+    def test_summary_shows_area(self):
+        self.char1.ndb.room_protos = {5: {"vnum": 5, "key": "Room", "area": "zone"}}
+        self.char1.ndb.current_vnum = 5
+        out = redit._summary(self.char1)
+        assert "Area: zone" in out
+
+    def test_summary_omits_missing_area(self):
+        self.char1.ndb.room_protos = {5: {"vnum": 5, "key": "Room"}}
+        self.char1.ndb.current_vnum = 5
+        out = redit._summary(self.char1)
+        assert "Area:" not in out


### PR DESCRIPTION
## Summary
- show area name in `_summary`
- add tests for summary area display

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6850d158f76c832ca9cc4269b47476d6