### PR TITLE
Show room VNUM to builders

### DIFF
--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -106,6 +106,29 @@ class RoomParent(ObjectParent):
         """Return the room id inside its area."""
         return self.db.room_id
 
+    # -----------------------------------------------------------------
+    # display helpers
+
+    def get_display_name(self, looker, **kwargs):
+        """Return the room name with optional area and vnum."""
+
+        name = self.key
+        room_id = self.get_room_id()
+        if (
+            room_id is not None
+            and looker
+            and (
+                looker.check_permstring("Builder")
+                or looker.check_permstring("Admin")
+            )
+        ):
+            area = self.get_area()
+            if area:
+                name = f"{name} ({area}) - {room_id}"
+            else:
+                name = f"{name} - {room_id}"
+        return name
+
     def get_display_footer(self, looker, **kwargs):
         """
         Shows a list of commands available here to the viewer.
@@ -135,7 +158,7 @@ class RoomParent(ObjectParent):
         if not looker:
             return ""
 
-        text = f"|c{self.key}|n\n"
+        text = f"|c{self.get_display_name(looker)}|n\n"
         text += f"{self.db.desc}\n"
 
         exits = self.get_display_exits(looker)

--- a/typeclasses/tests/test_objects_basic.py
+++ b/typeclasses/tests/test_objects_basic.py
@@ -200,6 +200,27 @@ class TestRoomHeaders(EvenniaTest):
         self.assertIn("(2, 3, zone)", header)
 
 
+class TestRoomDisplayName(EvenniaTest):
+    def test_display_name_builder_shows_vnum(self):
+        from typeclasses.rooms import Room
+
+        room = create_object(Room, key="field")
+        room.set_area("verdant_overgrowth", 200004)
+        self.char1.permissions.add("Builder")
+
+        name = room.get_display_name(self.char1)
+        self.assertEqual(name, "field (verdant_overgrowth) - 200004")
+
+    def test_display_name_player_no_vnum(self):
+        from typeclasses.rooms import Room
+
+        room = create_object(Room, key="field")
+        room.set_area("verdant_overgrowth", 200004)
+
+        name = room.get_display_name(self.char1)
+        self.assertEqual(name, "field")
+
+
 class TestMeleeWeaponAtAttack(EvenniaTest):
     def test_damage_dice_only(self):
         weapon = create_object(


### PR DESCRIPTION
## Summary
- support area and VNUM in room titles
- show VNUM in the top line of room descriptions for builders and admins
- test room display name logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6850db6d8944832c8ac87048a7073023