### PR TITLE
Implement SpawnManager and area spawn resets

### DIFF
--- a/commands/areas.py
+++ b/commands/areas.py
@@ -14,6 +14,7 @@ from world.areas import (
     parse_area_identifier,
 )
 from .aedit import CmdAEdit, CmdAList, CmdASave, CmdAreaReset, CmdAreaAge
+from world import spawn_manager
 from typeclasses.rooms import Room
 from utils.prototype_manager import load_prototype, load_all_prototypes
 
@@ -527,6 +528,28 @@ class CmdRRegAll(Command):
         self.msg(f"Created {created} room{'s' if created != 1 else ''}.")
 
 
+class CmdAreasReset(Command):
+    """Repopulate spawn entries for an area."""
+
+    key = "areas.reset"
+    locks = "cmd:perm(Builder)"
+    help_category = "Building"
+
+    def func(self):
+        if not self.args:
+            self.msg("Usage: areas.reset <area>")
+            return
+        area_name = self.args.strip()
+        _, area = find_area(area_name)
+        if area is None:
+            self.msg(
+                f"Area '{area_name}' not found. Use 'alist' to view available areas."
+            )
+            return
+        spawn_manager.SpawnManager.reset_area(area.key)
+        self.msg(f"Spawn entries reset for {area.key}.")
+
+
 class AreaCmdSet(CmdSet):
     key = "Area CmdSet"
 
@@ -537,6 +560,7 @@ class AreaCmdSet(CmdSet):
         self.add(CmdAEdit)
         self.add(CmdAreaReset)
         self.add(CmdAreaAge)
+        self.add(CmdAreasReset)
         self.add(CmdAMake)
         self.add(CmdASet)
         self.add(CmdRooms)

--- a/world/area_reset.py
+++ b/world/area_reset.py
@@ -1,5 +1,6 @@
 from evennia.scripts.scripts import DefaultScript
 from world.areas import get_areas, update_area
+from world import spawn_manager
 
 class AreaReset(DefaultScript):
     """Global script that increments area ages and performs resets."""
@@ -16,4 +17,5 @@ class AreaReset(DefaultScript):
             area.age += 1
             if area.reset_interval and area.age >= area.reset_interval:
                 area.age = 0
+                spawn_manager.SpawnManager.reset_area(area.key)
             update_area(idx, area)

--- a/world/spawn_manager.py
+++ b/world/spawn_manager.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+"""Simple spawn management for area resets."""
+
+from dataclasses import dataclass, asdict
+from typing import List, Dict
+
+from evennia.server.models import ServerConfig
+from evennia.objects.models import ObjectDB
+from evennia.prototypes import spawner
+from evennia.utils import logger
+
+from world import prototypes
+from utils.mob_proto import spawn_from_vnum, apply_proto_items
+from commands.npc_builder import finalize_mob_prototype
+from typeclasses.npcs import BaseNPC
+
+
+@dataclass
+class SpawnEntry:
+    """Data container representing a spawn entry."""
+
+    area: str
+    proto: str
+    room: int
+    initial_count: int = 1
+    max_count: int = 1
+
+    @classmethod
+    def from_dict(cls, data: Dict) -> "SpawnEntry":
+        return cls(
+            area=data.get("area", "").lower(),
+            proto=str(data.get("proto", "")),
+            room=int(data.get("room", 0)),
+            initial_count=int(data.get("initial_count", 1)),
+            max_count=int(data.get("max_count", 1)),
+        )
+
+    def to_dict(self) -> Dict:
+        return asdict(self)
+
+
+_REGISTRY_KEY = "spawn_registry"
+
+
+class SpawnManager:
+    """Utility class for accessing spawn entries."""
+
+    @staticmethod
+    def _load_registry() -> List[Dict]:
+        return ServerConfig.objects.conf(_REGISTRY_KEY, default=list)
+
+    @staticmethod
+    def _save_registry(registry: List[Dict]):
+        ServerConfig.objects.conf(_REGISTRY_KEY, value=registry)
+
+    @staticmethod
+    def get_entries(area: str | None = None) -> List[SpawnEntry]:
+        entries = [SpawnEntry.from_dict(d) for d in SpawnManager._load_registry()]
+        if area:
+            area = area.lower()
+            entries = [e for e in entries if e.area.lower() == area]
+        return entries
+
+    @staticmethod
+    def reset_area(area_key: str) -> None:
+        """Repopulate all spawn entries for ``area_key``."""
+
+        area = area_key.lower()
+        entries = SpawnManager.get_entries(area)
+        if not entries:
+            return
+
+        for entry in entries:
+            room = None
+            objs = ObjectDB.objects.filter(
+                db_attributes__db_key="area",
+                db_attributes__db_strvalue__iexact=entry.area,
+            )
+            for obj in objs:
+                if obj.db.room_id == entry.room and obj.is_typeclass(
+                    "typeclasses.rooms.Room", exact=False
+                ):
+                    room = obj
+                    break
+            if not room:
+                continue
+
+            existing = [
+                obj
+                for obj in room.contents
+                if obj.is_typeclass(BaseNPC, exact=False)
+                and str(obj.db.prototype_key or obj.db.vnum or "") == entry.proto
+            ]
+            to_spawn = entry.initial_count - len(existing)
+            if to_spawn <= 0:
+                continue
+            to_spawn = min(to_spawn, entry.max_count - len(existing))
+            for _ in range(to_spawn):
+                npc = None
+                if entry.proto.isdigit():
+                    try:
+                        npc = spawn_from_vnum(int(entry.proto), location=room)
+                    except ValueError as err:
+                        logger.log_err(str(err))
+                        continue
+                else:
+                    proto = prototypes.get_npc_prototypes().get(entry.proto)
+                    if not proto:
+                        continue
+                    proto_data = dict(proto)
+                    base_cls = proto_data.get("typeclass", "typeclasses.npcs.BaseNPC")
+                    if isinstance(base_cls, str):
+                        module, clsname = base_cls.rsplit(".", 1)
+                        base_cls = getattr(__import__(module, fromlist=[clsname]), clsname)
+
+                    from typeclasses.characters import NPC as BaseChar
+
+                    if not issubclass(base_cls, BaseChar):
+                        logger.log_warn(
+                            f"Prototype {entry.proto}: {base_cls} is not a subclass of NPC; using BaseNPC."
+                        )
+                        from typeclasses.npcs import BaseNPC as DefaultNPC
+
+                        base_cls = DefaultNPC
+
+                    proto_data["typeclass"] = base_cls
+                    npc = spawner.spawn(proto_data)[0]
+                    npc.location = room
+                    npc.db.prototype_key = entry.proto
+                    apply_proto_items(npc, proto_data)
+                finalize_mob_prototype(npc, npc)
+                npc.db.area_tag = entry.area
+                npc.db.spawn_room = room

--- a/world/tests/test_area_reset.py
+++ b/world/tests/test_area_reset.py
@@ -8,7 +8,8 @@ class TestAreaReset(EvenniaTest):
         area = Area(key="town", start=1, end=10, reset_interval=2)
         areas = [area]
         with mock.patch("world.area_reset.get_areas", return_value=areas), \
-             mock.patch("world.area_reset.update_area") as mock_update:
+             mock.patch("world.area_reset.update_area") as mock_update, \
+             mock.patch("world.area_reset.spawn_manager.SpawnManager.reset_area") as mock_reset:
             script = AreaReset()
             script.at_script_creation()
             script.at_repeat()
@@ -16,4 +17,5 @@ class TestAreaReset(EvenniaTest):
             script.at_repeat()
             self.assertEqual(area.age, 0)
             self.assertTrue(mock_update.called)
+            mock_reset.assert_called_with("town")
 

--- a/world/tests/test_spawn_manager.py
+++ b/world/tests/test_spawn_manager.py
@@ -1,0 +1,24 @@
+from unittest import mock
+from evennia.utils.test_resources import EvenniaTest
+from evennia import create_object
+
+from typeclasses.rooms import Room
+from typeclasses.npcs import BaseNPC
+from world.spawn_manager import SpawnManager, SpawnEntry
+
+
+class TestSpawnManager(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.room = create_object(Room, key="room")
+        self.room.set_area("testarea", 1)
+        # clear registry
+        SpawnManager._save_registry([])
+
+    def test_reset_area_spawns_npc(self):
+        entry = SpawnEntry(area="testarea", proto="basic_merchant", room=1, initial_count=1, max_count=2)
+        SpawnManager._save_registry([entry.to_dict()])
+        SpawnManager.reset_area("testarea")
+        npcs = [obj for obj in self.room.contents if obj.is_typeclass(BaseNPC, exact=False)]
+        self.assertEqual(len(npcs), 1)
+        self.assertEqual(npcs[0].db.prototype_key, "basic_merchant")


### PR DESCRIPTION
## Summary
- reset area spawns when AreaReset hits reset interval
- implement `SpawnManager` to repopulate spawn entries
- add `areas.reset` command for manual testing
- test spawn manager and area reset logic

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6850df802b48832c8815d5777a86dd5e