### PR TITLE
Add link command with autodig improvements

### DIFF
--- a/commands/README.md
+++ b/commands/README.md
@@ -15,15 +15,28 @@ find your modules.
 
 ## Dig Command
 
-The `dig` command creates a new room in the given compass direction and
-links exits between the current location and the new room. Usage:
+The `@dig` command creates and links a new room by VNUM.
 
 ```
-dig <direction>
+@dig <direction> <vnum>
 ```
 
-For example, `dig north` will make a new room north of the current one
-and also create a south exit back.
+By default the reverse exit back to the origin is also created. Use
+`--noreverse` to skip that.
+
+Example: `@dig east 200005` creates room `200005` east of you and links
+its west exit back here.
+
+## Link Command
+
+The `@link` command connects two existing rooms.
+
+```
+@link <direction> <vnum>
+```
+
+This sets the exit in the chosen direction to the target room and, unless
+`--noreverse` is given, also links the reverse direction back.
 
 ## Room Editing Commands
 

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -38,7 +38,7 @@ from commands.guilds import GuildCmdSet
 from commands.rest import RestCmdSet
 from commands.loot import LootCmdSet
 from commands.who import CmdWho
-from commands.building import CmdDig, CmdTeleport, CmdDelRoom
+from commands.building import CmdDig, CmdTeleport, CmdDelRoom, CmdLink
 from commands.areas import AreaCmdSet
 from commands.room_flags import RoomFlagCmdSet
 from commands.admin import AdminCmdSet, BuilderCmdSet
@@ -85,6 +85,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(GuildCmdSet)
         self.add(EquipmentCmdSet)
         self.add(CmdDig)
+        self.add(CmdLink)
         self.add(CmdTeleport)
         self.add(CmdDelRoom)
         self.add(RoomFlagCmdSet)

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -1618,25 +1618,53 @@ Related:
     {
         "key": "dig",
         "category": "Building",
-        "text": """
-Help for dig
+        "text": """Help for dig
 
-Create a new room in a direction. Usage: dig <direction> [<area>:<number>]
+Create and link a new room.
 
 Usage:
-    dig <direction> [<area>:<number>]
+    @dig <direction> <vnum>
+    dig <direction> <vnum>
 
 Switches:
-    None
+    --noreverse - skip the reverse exit
 
 Arguments:
     None
 
 Examples:
-    None
+    @dig east 200005
 
 Notes:
-    - None
+    - The VNUM must belong to a registered area.
+
+Related:
+    help ansi
+""",
+    },
+    {
+        "key": "@link",
+        "aliases": ["link"],
+        "category": "Building",
+        "text": """Help for @link
+
+Link one room to another by VNUM.
+
+Usage:
+    @link <direction> <vnum>
+    link <direction> <vnum>
+
+Switches:
+    --noreverse - skip the reverse exit
+
+Arguments:
+    None
+
+Examples:
+    @link north 3002
+
+Notes:
+    - The target room must already exist.
 
 Related:
     help ansi


### PR DESCRIPTION
## Summary
- add `@link` command for connecting rooms by VNUM
- extend `@dig` to take direction and VNUM with optional reverse link
- document new builder commands and update help entries
- load new command in default command set

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6850ea93e350832cb7e4b8cdfc36903a