### PR TITLE
Add world reset command

### DIFF
--- a/commands/admin/__init__.py
+++ b/commands/admin/__init__.py
@@ -3,10 +3,10 @@ from evennia.objects.models import ObjectDB
 import shlex
 import re
 from evennia.utils.ansi import strip_ansi
-from .command import Command
-from .info import CmdScan
-from .update import CmdUpdate
-from .building import (
+from ..command import Command
+from ..info import CmdScan
+from ..update import CmdUpdate
+from ..building import (
     CmdSetDesc,
     CmdSetWeight,
     CmdSetSlot,
@@ -22,7 +22,7 @@ from world.system import stat_manager
 from world.system.constants import MAX_LEVEL
 from utils.stats_utils import get_display_scroll, normalize_stat_key
 from utils import VALID_SLOTS, normalize_slot
-from .npc_builder import (
+from ..npc_builder import (
     CmdCNPC,
     CmdEditNPC,
     CmdDeleteNPC,
@@ -31,7 +31,7 @@ from .npc_builder import (
     CmdListNPCs,
     CmdDupNPC,
 )
-from .mob_builder_commands import (
+from ..mob_builder_commands import (
     CmdMCreate,
     CmdMSet,
     CmdMakeShop,
@@ -44,7 +44,7 @@ from .mob_builder_commands import (
     CmdRepairStat,
     CmdMobValidate,
 )
-from .npc_builder import (
+from ..npc_builder import (
     CmdMSpawn,
     CmdMobPreview,
     CmdMStat,
@@ -52,14 +52,15 @@ from .npc_builder import (
     CmdMobTemplate,
     CmdQuickMob,
 )
-from .rom_mob_editor import CmdMEdit
-from .mob_builder_commands import CmdProtoEdit
-from .cmdmobbuilder import CmdMobProto
-from .nextvnum import CmdNextVnum
-from .builder_types import CmdBuilderTypes
-from .hedit import CmdHEdit
-from .opedit import CmdOPEdit
-from .rpedit import CmdRPEdit
+from ..rom_mob_editor import CmdMEdit
+from ..mob_builder_commands import CmdProtoEdit
+from ..cmdmobbuilder import CmdMobProto
+from ..nextvnum import CmdNextVnum
+from ..builder_types import CmdBuilderTypes
+from ..hedit import CmdHEdit
+from ..opedit import CmdOPEdit
+from ..rpedit import CmdRPEdit
+from .resetworld import CmdResetWorld
 
 
 def _safe_split(text):
@@ -1398,6 +1399,7 @@ class AdminCmdSet(CmdSet):
         self.add(CmdPeace)
         self.add(CmdForceMobReport)
         self.add(CmdUpdate)
+        self.add(CmdResetWorld)
         self.add(CmdScan)
 
 

--- a/commands/admin/resetworld.py
+++ b/commands/admin/resetworld.py
@@ -1,0 +1,27 @@
+from evennia import CmdSet
+from ..command import Command
+from world import spawn_manager
+
+class CmdResetWorld(Command):
+    """Reset all areas by despawning and respawning spawns."""
+
+    key = "@resetworld"
+    aliases = ["@refreshworld"]
+    locks = "cmd:perm(Builder)"
+    help_category = "Admin"
+
+    def func(self):
+        area_keys = spawn_manager.SpawnManager.get_area_keys()
+        if not area_keys:
+            self.msg("No areas found to reset.")
+            return
+        for key in area_keys:
+            spawn_manager.SpawnManager.reset_area(key)
+        self.msg(f"World reset complete. [{len(area_keys)}] areas repopulated.")
+
+class ResetWorldCmdSet(CmdSet):
+    key = "ResetWorldCmdSet"
+
+    def at_cmdset_creation(self):
+        super().at_cmdset_creation()
+        self.add(CmdResetWorld)

--- a/world/spawn_manager.py
+++ b/world/spawn_manager.py
@@ -174,3 +174,30 @@ class SpawnManager:
             _REGISTRY_KEY,
             value=[entry.to_dict() for entry in self.entries]
         )
+
+    # ------------------------------------------------------------------
+    # class helpers for persistent registry access
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def _load_registry(cls) -> List[Dict]:
+        """Return the stored spawn registry."""
+        return ServerConfig.objects.conf(_REGISTRY_KEY, default=list)
+
+    @classmethod
+    def _save_registry(cls, registry: List[Dict]) -> None:
+        """Persist ``registry`` to ServerConfig."""
+        ServerConfig.objects.conf(_REGISTRY_KEY, value=registry)
+
+    @classmethod
+    def reset_area(cls, area_key: str) -> None:
+        """Despawn and respawn all spawns for ``area_key``."""
+        manager = cls.get()
+        manager.entries = [SpawnEntry.from_dict(d) for d in cls._load_registry()]
+        manager.repopulate_area(area_key)
+
+    @classmethod
+    def get_area_keys(cls) -> List[str]:
+        """Return all unique area keys from registered spawns."""
+        registry = cls._load_registry()
+        return sorted({str(d.get("area", "")).lower() for d in registry if d.get("area")})


### PR DESCRIPTION
## Summary
- convert `commands.admin` to a package
- add new admin command `@resetworld` that respawns all areas
- expose the command via `AdminCmdSet`
- extend `SpawnManager` with persistent registry helpers and `get_area_keys`

## Testing
- `pytest -q` *(fails: 100 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6850efc2b164832ca9664d8039f784ee