### PR TITLE
Consolidate spawn logic

### DIFF
--- a/commands/redit.py
+++ b/commands/redit.py
@@ -526,6 +526,14 @@ def menunode_done(caller, raw_string="", **kwargs):
                     if dest_obj and dest_obj.is_typeclass(Room, exact=False):
                         exits[dirkey] = dest_obj
                 room.db.exits = exits
+    from evennia.scripts.models import ScriptDB
+    script = ScriptDB.objects.filter(db_key="spawn_manager").first()
+    if script and hasattr(script, "register_room_spawn"):
+        script.register_room_spawn(proto)
+        for entry in proto.get("spawns", []):
+            if int(entry.get("initial_count", 0)) > 0 and hasattr(script, "force_respawn"):
+                script.force_respawn(vnum)
+                break
     caller.msg("Room prototype(s) saved.")
     caller.ndb.room_protos = None
     caller.ndb.current_vnum = None

--- a/server/conf/at_server_startstop.py
+++ b/server/conf/at_server_startstop.py
@@ -135,9 +135,8 @@ def at_server_start():
         if script:
             script.delete()
         script = create.create_script("scripts.spawn_manager.SpawnManager", key="spawn_manager")
-    from scripts.spawn_manager import SpawnManager  # type: ignore
-    if hasattr(script, "load_spawn_data"):
-        script.load_spawn_data()
+    if hasattr(script, "reload_spawns"):
+        script.reload_spawns()
 
     # Ensure mob database script exists
     get_mobdb()

--- a/typeclasses/tests/test_spawnnpc.py
+++ b/typeclasses/tests/test_spawnnpc.py
@@ -7,7 +7,6 @@ from django.conf import settings
 from unittest import mock
 from typeclasses.npcs import MerchantNPC, BaseNPC
 from evennia.contrib.rpg.traits import TraitHandler
-from scripts.area_spawner import AreaSpawner
 from world import area_npcs
 
 
@@ -48,19 +47,6 @@ class TestSpawnNPCPrototype(EvenniaTest):
         self.assertIsNotNone(npc)
         self.assertIsInstance(npc.traits, TraitHandler)
 
-    @patch("scripts.area_spawner.choice", return_value="basic_merchant")
-    @patch("scripts.area_spawner.randint", return_value=1)
-    def test_area_spawner_sets_attributes(self, mock_randint, mock_choice):
-        area_npcs.add_area_npc("testarea", "basic_merchant")
-        script = self.char1.location.scripts.add(
-            AreaSpawner, key="area_spawner", autostart=False
-        )
-        script.db.spawn_chance = 100
-        script.at_repeat()
-        npc = [o for o in self.char1.location.contents if o.is_typeclass(BaseNPC, exact=False)][0]
-        self.assertEqual(npc.db.prototype_key, "basic_merchant")
-        self.assertIs(npc.db.spawn_room, self.char1.location)
-        self.assertEqual(npc.db.area_tag, "testarea")
 
     def test_old_prototype_fallback(self):
         from world import prototypes
@@ -85,44 +71,3 @@ class TestSpawnNPCPrototype(EvenniaTest):
         self.assertIn("never finalized", out)
 
 
-class TestAreaSpawnerCombatStats(EvenniaTest):
-    def setUp(self):
-        super().setUp()
-        self.char1.msg = MagicMock()
-        self.char1.cmdset.add_default(BuilderCmdSet)
-        self.char1.location.db.area = "testarea"
-        self.tmp = TemporaryDirectory()
-        patcher = mock.patch.object(
-            settings, "PROTOTYPE_NPC_FILE", Path(self.tmp.name) / "npcs.json"
-        )
-        self.addCleanup(self.tmp.cleanup)
-        self.addCleanup(patcher.stop)
-        patcher.start()
-
-    def test_area_spawned_npc_has_combat_stats(self):
-        from world import prototypes
-
-        proto = {
-            "key": "warrior",
-            "npc_type": "base",
-            "level": 1,
-            "combat_class": "Warrior",
-        }
-        prototypes.register_npc_prototype("test_warrior", proto)
-        area_npcs.add_area_npc("testarea", "test_warrior")
-
-        script = self.char1.location.scripts.add(
-            AreaSpawner, key="area_spawner", autostart=False
-        )
-        script.db.spawn_chance = 100
-
-        with patch("scripts.area_spawner.choice", return_value="test_warrior"), patch(
-            "scripts.area_spawner.randint", return_value=1
-        ):
-            script.at_repeat()
-
-        npc = [o for o in self.char1.location.contents if o.is_typeclass(BaseNPC, exact=False)][0]
-        self.assertGreater(npc.db.hp, 0)
-        self.assertGreater(npc.db.mp, 0)
-        self.assertGreater(npc.db.sp, 0)
-        self.assertGreater(npc.db.armor, 0)

--- a/world/area_reset.py
+++ b/world/area_reset.py
@@ -1,6 +1,6 @@
 from evennia.scripts.scripts import DefaultScript
 from world.areas import get_areas, update_area
-from world import spawn_manager
+from evennia.scripts.models import ScriptDB
 
 class AreaReset(DefaultScript):
     """Global script that increments area ages and performs resets."""
@@ -17,5 +17,12 @@ class AreaReset(DefaultScript):
             area.age += 1
             if area.reset_interval and area.age >= area.reset_interval:
                 area.age = 0
-                spawn_manager.SpawnManager.reset_area(area.key)
+                script = ScriptDB.objects.filter(db_key="spawn_manager").first()
+                if script and hasattr(script, "force_respawn"):
+                    for entry in script.db.entries:
+                        if entry.get("area") == area.key.lower():
+                            rid = entry.get("room")
+                            if isinstance(rid, str) and rid.isdigit():
+                                rid = int(rid)
+                            script.force_respawn(rid)
             update_area(idx, area)

--- a/world/tests/test_area_reset.py
+++ b/world/tests/test_area_reset.py
@@ -9,7 +9,9 @@ class TestAreaReset(EvenniaTest):
         areas = [area]
         with mock.patch("world.area_reset.get_areas", return_value=areas), \
              mock.patch("world.area_reset.update_area") as mock_update, \
-             mock.patch("world.area_reset.spawn_manager.SpawnManager.reset_area") as mock_reset:
+             mock.patch("world.area_reset.ScriptDB") as mock_sdb:
+            mock_script = mock.MagicMock()
+            mock_sdb.objects.filter.return_value.first.return_value = mock_script
             script = AreaReset()
             script.at_script_creation()
             script.at_repeat()
@@ -17,5 +19,5 @@ class TestAreaReset(EvenniaTest):
             script.at_repeat()
             self.assertEqual(area.age, 0)
             self.assertTrue(mock_update.called)
-            mock_reset.assert_called_with("town")
+            self.assertTrue(mock_script.force_respawn.called)
 

--- a/world/tests/test_spawn_manager.py
+++ b/world/tests/test_spawn_manager.py
@@ -4,7 +4,7 @@ from evennia import create_object
 
 from typeclasses.rooms import Room
 from typeclasses.npcs import BaseNPC
-from world.spawn_manager import SpawnManager, SpawnEntry
+from scripts.spawn_manager import SpawnManager
 
 
 class TestSpawnManager(EvenniaTest):
@@ -12,13 +12,22 @@ class TestSpawnManager(EvenniaTest):
         super().setUp()
         self.room = create_object(Room, key="room")
         self.room.set_area("testarea", 1)
-        # clear registry
-        SpawnManager._save_registry([])
+        self.script = SpawnManager()
+        self.script.at_script_creation()
 
     def test_reset_area_spawns_npc(self):
-        entry = SpawnEntry(area="testarea", proto="basic_merchant", room=1, initial_count=1, max_count=2)
-        SpawnManager._save_registry([entry.to_dict()])
-        SpawnManager.reset_area("testarea")
+        self.script.db.entries = [
+            {
+                "area": "testarea",
+                "prototype": "basic_merchant",
+                "room": 1,
+                "initial_count": 1,
+                "max_count": 2,
+                "respawn_rate": 5,
+                "last_spawn": 0,
+            }
+        ]
+        self.script.force_respawn(1)
         npcs = [obj for obj in self.room.contents if obj.is_typeclass(BaseNPC, exact=False)]
         self.assertEqual(len(npcs), 1)
         self.assertEqual(npcs[0].db.prototype_key, "basic_merchant")


### PR DESCRIPTION
## Summary
- centralize respawning in scripts.spawn_manager.SpawnManager
- hook spawn manager in server start
- support spawn registration from redit
- reset areas using global spawn manager
- deprecate AreaSpawner commands

## Testing
- `pytest -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6850f2fbb678832c97f7c85368b77a93