### PR TITLE
Implement spawn control commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,12 @@ Example:
 @mobproto spawn 1
 ```
 
+## Spawn Control
+
+`@spawnreload` reloads all spawn entries from saved NPC prototypes.
+Use `@forcerespawn <room_vnum>` to immediately run the spawn
+logic for a specific room.
+
 ## Weapon Creation and Inspection
 
 Builders can quickly create melee weapons with the `cweapon` command.

--- a/commands/admin/__init__.py
+++ b/commands/admin/__init__.py
@@ -61,6 +61,7 @@ from ..hedit import CmdHEdit
 from ..opedit import CmdOPEdit
 from ..rpedit import CmdRPEdit
 from .resetworld import CmdResetWorld
+from .spawncontrol import CmdSpawnReload, CmdForceRespawn
 
 
 def _safe_split(text):
@@ -1400,6 +1401,8 @@ class AdminCmdSet(CmdSet):
         self.add(CmdForceMobReport)
         self.add(CmdUpdate)
         self.add(CmdResetWorld)
+        self.add(CmdSpawnReload)
+        self.add(CmdForceRespawn)
         self.add(CmdScan)
 
 
@@ -1464,3 +1467,5 @@ class BuilderCmdSet(CmdSet):
         self.add(CmdHEdit)
         self.add(CmdOPEdit)
         self.add(CmdRPEdit)
+        self.add(CmdSpawnReload)
+        self.add(CmdForceRespawn)

--- a/commands/admin/spawncontrol.py
+++ b/commands/admin/spawncontrol.py
@@ -1,0 +1,41 @@
+from evennia import CmdSet
+from ..command import Command
+from world import spawn_manager
+
+
+class CmdSpawnReload(Command):
+    """Reload all spawn entries from NPC prototypes."""
+
+    key = "@spawnreload"
+    locks = "cmd:perm(Admin)"
+    help_category = "Admin"
+
+    def func(self):
+        spawn_manager.SpawnManager.reload_spawns()
+        self.msg("Spawn entries reloaded from prototypes.")
+
+
+class CmdForceRespawn(Command):
+    """Run spawn checks immediately for a room."""
+
+    key = "@forcerespawn"
+    locks = "cmd:perm(Admin)"
+    help_category = "Admin"
+
+    def func(self):
+        arg = self.args.strip()
+        if not arg.isdigit():
+            self.msg("Usage: @forcerespawn <room_vnum>")
+            return
+        room_vnum = int(arg)
+        spawn_manager.SpawnManager.force_respawn(room_vnum)
+        self.msg(f"Respawn check run for room {room_vnum}.")
+
+
+class SpawnControlCmdSet(CmdSet):
+    key = "SpawnControlCmdSet"
+
+    def at_cmdset_creation(self):
+        super().at_cmdset_creation()
+        self.add(CmdSpawnReload)
+        self.add(CmdForceRespawn)


### PR DESCRIPTION
## Summary
- add spawn reload and force respawn commands
- expose commands in admin/builder cmdsets
- reload spawns and force respawn helpers in `SpawnManager`
- document new commands

## Testing
- `pytest -q` *(fails: django.db.utils.OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6850f3bb14fc832cb0b9f3d303d86e0b