### PR TITLE
Fix spawn manager duplicate entries

### DIFF
--- a/scripts/spawn_manager.py
+++ b/scripts/spawn_manager.py
@@ -71,6 +71,16 @@ class SpawnManager(Script):
         room_id = proto.get("room_id") or proto.get("vnum")
         if room_id is None:
             return
+        rid = (
+            int(room_id)
+            if isinstance(room_id, str) and room_id.isdigit()
+            else room_id
+        )
+        self.db.entries = [
+            e
+            for e in self.db.entries
+            if self._normalize_room_id(e.get("room")) != rid
+        ]
         for entry in spawns:
             proto_key = (
                 entry.get("prototype")
@@ -122,6 +132,15 @@ class SpawnManager(Script):
     # ------------------------------------------------------------
     # internal helpers
     # ------------------------------------------------------------
+    def _normalize_room_id(self, room: Any) -> int | None:
+        if hasattr(room, "dbref"):
+            return getattr(room.db, "room_id", None)
+        if isinstance(room, int):
+            return room
+        if isinstance(room, str) and room.isdigit():
+            return int(room)
+        return None
+
     def _room_match(self, stored: Any, room: Any) -> bool:
         if hasattr(stored, "dbref"):
             return stored == room

--- a/typeclasses/tests/test_spawn_manager.py
+++ b/typeclasses/tests/test_spawn_manager.py
@@ -80,3 +80,8 @@ class TestSpawnManager(EvenniaTest):
             script.at_repeat()
         npcs = [o for o in self.room1.contents if o.key == "goblin"]
         self.assertEqual(len(npcs), 3)
+
+    def test_register_twice_keeps_single_entry(self):
+        self.script.register_room_spawn(self.room_proto)
+        self.script.register_room_spawn(self.room_proto)
+        self.assertEqual(len(self.script.db.entries), 1)


### PR DESCRIPTION
## Summary
- avoid duplicate spawn entries when saving rooms
- normalize room id values for comparisons
- test that duplicate room saves do not create extra spawn entries

## Testing
- `python -m py_compile scripts/spawn_manager.py typeclasses/tests/test_spawn_manager.py`
- `sh scripts/setup_test_env.sh` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6850fa872630832c9301bfd7a02b81c9