### PR TITLE
Use ScriptDB in spawncontrol commands

### DIFF
--- a/commands/admin/spawncontrol.py
+++ b/commands/admin/spawncontrol.py
@@ -1,6 +1,6 @@
 from evennia import CmdSet
 from ..command import Command
-from world import spawn_manager
+from evennia.scripts.models import ScriptDB
 
 
 class CmdSpawnReload(Command):
@@ -11,7 +11,9 @@ class CmdSpawnReload(Command):
     help_category = "Admin"
 
     def func(self):
-        spawn_manager.SpawnManager.reload_spawns()
+        script = ScriptDB.objects.filter(db_key="spawn_manager").first()
+        if script:
+            script.reload_spawns()
         self.msg("Spawn entries reloaded from prototypes.")
 
 
@@ -28,7 +30,9 @@ class CmdForceRespawn(Command):
             self.msg("Usage: @forcerespawn <room_vnum>")
             return
         room_vnum = int(arg)
-        spawn_manager.SpawnManager.force_respawn(room_vnum)
+        script = ScriptDB.objects.filter(db_key="spawn_manager").first()
+        if script:
+            script.force_respawn(room_vnum)
         self.msg(f"Respawn check run for room {room_vnum}.")
 
 

--- a/world/tests/test_spawncontrol_commands.py
+++ b/world/tests/test_spawncontrol_commands.py
@@ -1,0 +1,28 @@
+from unittest import TestCase, mock
+from commands.admin.spawncontrol import CmdSpawnReload, CmdForceRespawn
+
+
+class TestSpawnControlCommands(TestCase):
+    def test_spawnreload_calls_script(self):
+        cmd = CmdSpawnReload()
+        cmd.caller = mock.Mock()
+        cmd.args = ""
+        cmd.msg = mock.Mock()
+        with mock.patch("commands.admin.spawncontrol.ScriptDB") as mock_sdb:
+            script = mock.Mock()
+            mock_sdb.objects.filter.return_value.first.return_value = script
+            cmd.func()
+            script.reload_spawns.assert_called_once()
+            cmd.msg.assert_called_with("Spawn entries reloaded from prototypes.")
+
+    def test_force_respawn_calls_script(self):
+        cmd = CmdForceRespawn()
+        cmd.caller = mock.Mock()
+        cmd.args = "5"
+        cmd.msg = mock.Mock()
+        with mock.patch("commands.admin.spawncontrol.ScriptDB") as mock_sdb:
+            script = mock.Mock()
+            mock_sdb.objects.filter.return_value.first.return_value = script
+            cmd.func()
+            script.force_respawn.assert_called_with(5)
+            cmd.msg.assert_called_with("Respawn check run for room 5.")


### PR DESCRIPTION
## Summary
- update spawn control commands to use ScriptDB lookup
- test that spawn control commands trigger script methods

## Testing
- `pytest -q world/tests/test_spawncontrol_commands.py`

------
https://chatgpt.com/codex/tasks/task_e_6850fa888adc832ca97076b900ea3cd7