### PR TITLE
Add @showspawns command

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,8 @@ Example:
 
 `@spawnreload` reloads all spawn entries from saved NPC prototypes.
 Use `@forcerespawn <room_vnum>` to immediately run the spawn
-logic for a specific room.
+logic for a specific room. Use `@showspawns [vnum]` to list
+entries for your current room or the given VNUM.
 
 ## Weapon Creation and Inspection
 

--- a/commands/admin/__init__.py
+++ b/commands/admin/__init__.py
@@ -61,7 +61,7 @@ from ..hedit import CmdHEdit
 from ..opedit import CmdOPEdit
 from ..rpedit import CmdRPEdit
 from .resetworld import CmdResetWorld
-from .spawncontrol import CmdSpawnReload, CmdForceRespawn
+from .spawncontrol import CmdSpawnReload, CmdForceRespawn, CmdShowSpawns
 
 
 def _safe_split(text):
@@ -1403,6 +1403,7 @@ class AdminCmdSet(CmdSet):
         self.add(CmdResetWorld)
         self.add(CmdSpawnReload)
         self.add(CmdForceRespawn)
+        self.add(CmdShowSpawns)
         self.add(CmdScan)
 
 
@@ -1469,3 +1470,4 @@ class BuilderCmdSet(CmdSet):
         self.add(CmdRPEdit)
         self.add(CmdSpawnReload)
         self.add(CmdForceRespawn)
+        self.add(CmdShowSpawns)

--- a/commands/admin/spawncontrol.py
+++ b/commands/admin/spawncontrol.py
@@ -1,4 +1,5 @@
 from evennia import CmdSet
+from evennia.scripts.models import ScriptDB
 from ..command import Command
 from world import spawn_manager
 
@@ -32,6 +33,56 @@ class CmdForceRespawn(Command):
         self.msg(f"Respawn check run for room {room_vnum}.")
 
 
+class CmdShowSpawns(Command):
+    """Display spawn entries for a room."""
+
+    key = "@showspawns"
+    locks = "cmd:perm(Builder)"
+    help_category = "Building"
+
+    def func(self):
+        arg = self.args.strip()
+        script = ScriptDB.objects.filter(db_key="spawn_manager").first()
+        if not script:
+            self.msg("Spawn manager not found.")
+            return
+
+        if arg:
+            if not arg.isdigit():
+                self.msg("Usage: @showspawns [room_vnum]")
+                return
+            target_vnum = int(arg)
+        else:
+            target_vnum = getattr(self.caller.location.db, "room_id", None)
+            if target_vnum is None:
+                self.msg("Current room has no VNUM.")
+                return
+
+        lines = []
+        for entry in script.db.entries:
+            room = entry.get("room")
+            if hasattr(room, "dbref"):
+                rid = getattr(room.db, "room_id", None)
+            elif isinstance(room, str) and room.isdigit():
+                rid = int(room)
+            elif isinstance(room, int):
+                rid = room
+            else:
+                rid = None
+            if rid != target_vnum:
+                continue
+            obj = script._get_room(entry)
+            live = script._live_count(entry.get("prototype"), obj) if obj else 0
+            lines.append(
+                f"{entry.get('prototype')} (max {entry.get('max_count')}, respawn {entry.get('respawn_rate')}s, live {live})"
+            )
+
+        if lines:
+            self.msg("Spawn entries:\n" + "\n".join(lines))
+        else:
+            self.msg("No spawn entries found.")
+
+
 class SpawnControlCmdSet(CmdSet):
     key = "SpawnControlCmdSet"
 
@@ -39,3 +90,4 @@ class SpawnControlCmdSet(CmdSet):
         super().at_cmdset_creation()
         self.add(CmdSpawnReload)
         self.add(CmdForceRespawn)
+        self.add(CmdShowSpawns)

--- a/world/tests/test_showspawns_command.py
+++ b/world/tests/test_showspawns_command.py
@@ -1,0 +1,34 @@
+from unittest import TestCase, mock
+from commands.admin.spawncontrol import CmdShowSpawns
+
+class TestShowSpawns(TestCase):
+    def test_entries_exist(self):
+        cmd = CmdShowSpawns()
+        cmd.caller = mock.Mock()
+        cmd.caller.location = mock.Mock()
+        cmd.caller.location.db.room_id = 1
+        cmd.args = ""
+        cmd.msg = mock.Mock()
+        script = mock.MagicMock()
+        script.db.entries = [{"room": 1, "prototype": "goblin", "max_count": 2, "respawn_rate": 30}]
+        script._get_room.return_value = cmd.caller.location
+        script._live_count.return_value = 1
+        with mock.patch("commands.admin.spawncontrol.ScriptDB") as mock_sdb:
+            mock_sdb.objects.filter.return_value.first.return_value = script
+            cmd.func()
+        cmd.msg.assert_called_with("Spawn entries:\n" +
+                                   "goblin (max 2, respawn 30s, live 1)")
+
+    def test_no_entries(self):
+        cmd = CmdShowSpawns()
+        cmd.caller = mock.Mock()
+        cmd.caller.location = mock.Mock()
+        cmd.caller.location.db.room_id = 1
+        cmd.args = ""
+        cmd.msg = mock.Mock()
+        script = mock.MagicMock()
+        script.db.entries = []
+        with mock.patch("commands.admin.spawncontrol.ScriptDB") as mock_sdb:
+            mock_sdb.objects.filter.return_value.first.return_value = script
+            cmd.func()
+        cmd.msg.assert_called_with("No spawn entries found.")


### PR DESCRIPTION
## Summary
- add `@showspawns` builder command for inspecting spawn data
- wire it into command sets
- document it in README
- test expected output for rooms with and without spawn entries

## Testing
- `pytest -q` *(fails: OperationalError - no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6850fa8a9740832cabf52e7dc8d330eb