### PR TITLE
Fix setuptools package discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,5 +14,13 @@ dependencies = [
 [tool.setuptools]
 py-modules = []
 
+[tool.setuptools.packages.find]
+where = ["."]
+exclude = [
+    "build*",
+    "docs*",
+    "*.egg-info",
+]
+
 [project.urls]
 repository = "https://github.com/InspectorCaracal/evennia-minimud"


### PR DESCRIPTION
## Summary
- ensure `pip install -e .` installs packages such as `typeclasses` and `commands`
- discover packages in `pyproject.toml`

## Testing
- `python -m pip install -e . --no-build-isolation`
- `pytest -q` *(fails: 345 failed, 11 passed, 1 error)*

------
https://chatgpt.com/codex/tasks/task_e_6850fe8e1250832ca2af31859a9090a9