### PR TITLE
Fix local variable shadowing settings

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -349,9 +349,9 @@ class Character(ObjectParent, ClothedCharacter):
         if self.traits.stamina:
             self.traits.stamina.current = max(self.traits.stamina.current - cost, 0)
 
-        # check if we have auto-prompt in settings
-        if self.account and (settings := self.account.db.settings):
-            if settings.get("auto prompt"):
+        # check if we have auto-prompt in account settings
+        if self.account and (acct_settings := self.account.db.settings):
+            if acct_settings.get("auto prompt"):
                 status = self.get_display_status(self)
                 self.msg(prompt=status)
 


### PR DESCRIPTION
## Summary
- rename local variable for account settings in `at_post_move`

## Testing
- `pytest -q` *(fails: django.db errors)*

------
https://chatgpt.com/codex/tasks/task_e_6850fe99123c832ca84dc2848de30cc5