### PR TITLE
Add mpcall hook validation

### DIFF
--- a/world/tests/test_mpcommands.py
+++ b/world/tests/test_mpcommands.py
@@ -54,9 +54,18 @@ class TestMPCommands(EvenniaTest):
         module = MagicMock()
         module.cb = func
         with patch("world.mpcommands.import_module", return_value=module) as mod:
-            execute_mpcommand(self.mob, "mpcall mod.cb")
-            mod.assert_called_with("mod")
+            execute_mpcommand(self.mob, "mpcall scripts.mod.cb")
+            mod.assert_called_with("scripts.mod")
             func.assert_called_with(self.mob)
+
+    def test_mpcall_invalid_module(self):
+        func = MagicMock()
+        module = MagicMock()
+        module.cb = func
+        with patch("world.mpcommands.import_module", return_value=module) as mod:
+            execute_mpcommand(self.mob, "mpcall bad.mod.cb")
+            mod.assert_not_called()
+            func.assert_not_called()
 
     def test_conditionals(self):
         self.room1.msg_contents = MagicMock()


### PR DESCRIPTION
## Summary
- validate `mpcall` using allowed module list and registry
- update tests for new validation

## Testing
- `pytest -k mpcommands -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6850fe9a3278832c90528b10346c5a2d