### PR TITLE
Add dynamic minimap for rooms

### DIFF
--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -223,6 +223,45 @@ class RoomParent(ObjectParent):
 class Room(RoomParent, DefaultRoom):
     """Basic indoor room with simple area metadata."""
 
+    def generate_map(self, looker):
+        """Return a small ASCII map centered on the caller.
+
+        The map shows the available exits north, south, east and west
+        relative to this room. The current room is marked with ``[X]``.
+
+        Args:
+            looker (Object): The object viewing the room.
+
+        Returns:
+            str: The generated ASCII map.
+        """
+
+        exits = self.db.exits or {}
+        north = "^" if "north" in exits else " "
+        south = "v" if "south" in exits else " "
+        west = "<" if "west" in exits else " "
+        east = ">" if "east" in exits else " "
+
+        map_lines = [
+            f"  {north}  ",
+            f"{west} [X] {east}",
+            f"  {south}  ",
+        ]
+
+        return "\n".join(map_lines)
+
+    def return_appearance(self, looker):
+        """Prefix the normal room appearance with a minimap."""
+
+        appearance = super().return_appearance(looker)
+        if not looker:
+            return appearance
+
+        minimap = self.generate_map(looker)
+        if minimap:
+            return f"{minimap}\n{appearance}"
+        return appearance
+
     def get_display_header(self, looker, **kwargs):
         """Show the area name/room id if available."""
         area = self.get_area()

--- a/typeclasses/tests/test_room_minimap.py
+++ b/typeclasses/tests/test_room_minimap.py
@@ -1,0 +1,26 @@
+from evennia.utils import create
+from evennia.utils.test_resources import EvenniaTest
+from typeclasses.rooms import Room
+
+
+class TestRoomMinimap(EvenniaTest):
+    def test_generate_map_marks_exits(self):
+        room = self.room1
+        north = create.create_object(Room, key="north", location=None)
+        south = create.create_object(Room, key="south", location=None)
+        east = create.create_object(Room, key="east", location=None)
+        west = create.create_object(Room, key="west", location=None)
+        room.db.exits = {"north": north, "south": south, "east": east, "west": west}
+
+        map_out = room.generate_map(self.char1)
+        self.assertIn("^", map_out)
+        self.assertIn("v", map_out)
+        self.assertIn("<", map_out)
+        self.assertIn(">", map_out)
+        self.assertIn("[X]", map_out)
+
+    def test_map_in_return_appearance(self):
+        room = self.room1
+        room.db.exits = {"north": self.room2}
+        out = room.return_appearance(self.char1)
+        self.assertIn("[X]", out.splitlines()[0])


### PR DESCRIPTION
## Summary
- render an ASCII minimap above room descriptions
- include minimap via `Room.generate_map` and override `return_appearance`
- test minimap generation and display

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6851013186f4832c8e3882835a4fda21