### PR TITLE
Update spawn manager initial spawn logic

### DIFF
--- a/scripts/spawn_manager.py
+++ b/scripts/spawn_manager.py
@@ -218,12 +218,15 @@ class SpawnManager(Script):
             room = self._get_room(entry)
             if not room:
                 continue
-            for _ in range(entry.get("initial_count", 0)):
-                if self._live_count(entry.get("prototype"), room) < entry.get("max_count", 0):
-                    self._spawn(entry.get("prototype"), room)
+            proto = entry.get("prototype")
+            existing = self._live_count(proto, room)
+            to_spawn = max(0, entry.get("initial_count", 0) - existing)
+            for _ in range(to_spawn):
+                if self._live_count(proto, room) < entry.get("max_count", 0):
+                    self._spawn(proto, room)
                     entry["last_spawn"] = time.time()
                     logger.log_info(
-                        f"SpawnManager: spawned {entry.get('prototype')} in room {room.dbref}"
+                        f"SpawnManager: spawned {proto} in room {room.dbref}"
                     )
 
     def at_repeat(self):

--- a/typeclasses/tests/test_spawn_manager.py
+++ b/typeclasses/tests/test_spawn_manager.py
@@ -39,6 +39,18 @@ class TestSpawnManager(EvenniaTest):
         npcs = [o for o in self.room1.contents if o.key == "goblin"]
         self.assertEqual(len(npcs), 2)
 
+    def test_at_start_only_spawns_missing(self):
+        with patch("evennia.prototypes.spawner.spawn", side_effect=self._fake_spawn), patch(
+            "evennia.utils.delay", lambda t, func, *a, **kw: None
+        ):
+            self.script.register_room_spawn(self.room_proto)
+            npc = create_object(BaseNPC, key="goblin", location=self.room1)
+            npc.db.prototype_key = "goblin"
+            npc.db.spawn_room = self.room1
+            self.script.at_start()
+        npcs = [o for o in self.room1.contents if o.key == "goblin"]
+        self.assertEqual(len(npcs), 2)
+
     def test_respawn_after_removal(self):
         with patch("evennia.prototypes.spawner.spawn", side_effect=self._fake_spawn), patch(
             "evennia.utils.delay", lambda t, func, *a, **kw: None


### PR DESCRIPTION
## Summary
- spawn only the difference between initial count and existing mobs on start
- test that at_start only spawns missing mobs

## Testing
- `pytest typeclasses/tests/test_spawn_manager.py -q` *(fails: django.db.utils.OperationalError: no such table: accounts_accountdb)*


------
https://chatgpt.com/codex/tasks/task_e_685106403078832cbf2f08452e601dff