### PR TITLE
Increase SpawnManager interval

### DIFF
--- a/scripts/spawn_manager.py
+++ b/scripts/spawn_manager.py
@@ -18,7 +18,7 @@ class SpawnManager(Script):
     def at_script_creation(self):
         self.key = "spawn_manager"
         self.desc = "Handles mob respawning for rooms"
-        self.interval = 15
+        self.interval = 60
         self.persistent = True
         self.db.entries = self.db.entries or []
 


### PR DESCRIPTION
## Summary
- set SpawnManager.interval to 60 seconds

## Testing
- `pytest -q` *(fails: django.db.utils.OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68510640bc80832c8ff27f75e643cd1e