### PR TITLE
Automatically resume paused scripts on startup

### DIFF
--- a/server/conf/at_server_startstop.py
+++ b/server/conf/at_server_startstop.py
@@ -23,6 +23,7 @@ import time
 from evennia.utils import logger
 from evennia.server.models import ServerConfig
 from utils.prototype_manager import load_all_prototypes
+from utils.script_utils import resume_paused_scripts
 
 
 _PROTOTYPE_CACHE = {}
@@ -184,6 +185,7 @@ def at_server_start():
 
     _build_caches()
     _ensure_room_areas()
+    resume_paused_scripts()
     ServerConfig.objects.conf("server_start_time", time.time())
 
 

--- a/utils/script_utils.py
+++ b/utils/script_utils.py
@@ -1,0 +1,50 @@
+"""Utilities for working with Evennia scripts."""
+
+from typing import Iterable, List
+
+from evennia.utils import logger
+from evennia.scripts.models import ScriptDB
+
+
+def resume_paused_scripts(keys: Iterable[str] | None = None,
+                           paths: Iterable[str] | None = None,
+                           log: bool = True) -> List[ScriptDB]:
+    """Resume paused scripts.
+
+    Parameters
+    ----------
+    keys
+        Optional iterable of script keys to resume. If omitted, all
+        paused scripts are considered.
+    paths
+        Optional iterable of typeclass paths to resume. Scripts must
+        match either a key in ``keys`` or a path in ``paths`` when
+        these are supplied.
+    log
+        If ``True``, log each resumed script to the Evennia logger.
+
+    Returns
+    -------
+    list
+        The resumed ``ScriptDB`` instances.
+    """
+
+    keyset = set(keys or [])
+    pathset = set(paths or [])
+
+    resumed: List[ScriptDB] = []
+    for script in ScriptDB.objects.filter(db_is_active=True):
+        if not getattr(script.db, "_paused_time", None):
+            continue
+        if keyset or pathset:
+            if not ((script.key in keyset) or (script.typeclass_path in pathset)):
+                continue
+        if getattr(script.db, "manual_pause", False):
+            continue
+        script.unpause()
+        resumed.append(script)
+        if log:
+            obj_name = getattr(script.obj, "key", None)
+            logger.log_info(f"[Startup] Resuming paused script: {script.key} ({obj_name})")
+
+    return resumed


### PR DESCRIPTION
## Summary
- add helper `resume_paused_scripts` to revive scripts stuck in paused state
- call the helper from `at_server_start` so any paused scripts are resumed when the server boots

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685107b3bb24832c986c086f35e8ad5b