### PR TITLE
Fix closing indent for script modules

### DIFF
--- a/scripts/area_spawner.py
+++ b/scripts/area_spawner.py
@@ -75,3 +75,5 @@ class AreaSpawner(Script):
         finalize_mob_prototype(npc, npc)
         npc.db.area_tag = area
         npc.db.spawn_room = room
+
+

--- a/scripts/example_ai.py
+++ b/scripts/example_ai.py
@@ -11,3 +11,4 @@ def patrol_ai(npc):
     if exits:
         exit_obj = choice(exits)
         exit_obj.at_traverse(npc, exit_obj.destination)
+# end patrol_ai

--- a/scripts/global_npc_ai.py
+++ b/scripts/global_npc_ai.py
@@ -23,3 +23,4 @@ class GlobalNPCAI(Script):
                 process_mob_ai(npc)
             except Exception as err:  # pragma: no cover - log errors
                 logger.log_err(f"GlobalNPCAI error on {npc}: {err}")
+        # end npc loop

--- a/scripts/sated_decay.py
+++ b/scripts/sated_decay.py
@@ -29,5 +29,5 @@ class SatedDecayScript(Script):
                     if hasattr(char, "msg"):
                         char.msg(msg)
                     break
-
-
+            # end inner for
+        # end outer for


### PR DESCRIPTION
## Summary
- add closing comments and blank lines to script modules
- ensure sated decay loop closes cleanly

## Testing
- `python -m py_compile scripts/area_spawner.py scripts/sated_decay.py scripts/global_npc_ai.py scripts/example_ai.py`

------
https://chatgpt.com/codex/tasks/task_e_68518133aff8832cb50c5da904946be0