### PR TITLE
Prevent global script pausing

### DIFF
--- a/scripts/sated_decay.py
+++ b/scripts/sated_decay.py
@@ -1,4 +1,5 @@
 from typeclasses.scripts import Script
+from evennia.utils import logger
 
 
 class SatedDecayScript(Script):
@@ -18,6 +19,9 @@ class SatedDecayScript(Script):
                       1: "You are starving!"}
 
         for char in Character.objects.all():
+            if char.locks.check("dummy:perm(Admin) or perm(Builder)"):
+                logger.log_debug(f"Skipping {char.key} (admin/builder) in sated_decay")
+                continue
             sated = getattr(char.db, "sated", None)
             if sated is None or sated <= 0:
                 continue

--- a/server/conf/at_server_startstop.py
+++ b/server/conf/at_server_startstop.py
@@ -125,6 +125,9 @@ def at_server_start():
             script.start()
         elif getattr(script.db, "_paused_time", None):
             script.unpause()
+    # ensure not manually paused
+    if hasattr(script, "pause"):
+        script.pause(False)
 
     script = ScriptDB.objects.filter(db_key="global_npc_ai").first()
     if not script or script.typeclass_path != "scripts.global_npc_ai.GlobalNPCAI":
@@ -138,6 +141,8 @@ def at_server_start():
             script.start()
         elif getattr(script.db, "_paused_time", None):
             script.unpause()
+    if hasattr(script, "pause"):
+        script.pause(False)
 
     script = ScriptDB.objects.filter(db_key="area_reset").first()
     if not script or script.typeclass_path != "world.area_reset.AreaReset":
@@ -149,6 +154,8 @@ def at_server_start():
             script.start()
         elif getattr(script.db, "_paused_time", None):
             script.unpause()
+    if hasattr(script, "pause"):
+        script.pause(False)
 
     script = ScriptDB.objects.filter(db_key="spawn_manager").first()
     if not script or script.typeclass_path != "scripts.spawn_manager.SpawnManager":
@@ -162,8 +169,25 @@ def at_server_start():
             script.start()
         elif getattr(script.db, "_paused_time", None):
             script.unpause()
+    if hasattr(script, "pause"):
+        script.pause(False)
     if hasattr(script, "reload_spawns"):
         script.reload_spawns()
+
+    script = ScriptDB.objects.filter(db_key="sated_decay").first()
+    if not script or script.typeclass_path != "scripts.sated_decay.SatedDecayScript":
+        if script:
+            script.delete()
+        script = create.create_script(
+            "scripts.sated_decay.SatedDecayScript", key="sated_decay"
+        )
+    else:
+        if not script.is_active:
+            script.start()
+        elif getattr(script.db, "_paused_time", None):
+            script.unpause()
+    if hasattr(script, "pause"):
+        script.pause(False)
 
     # Ensure mob database script exists
     get_mobdb()

--- a/world/scripts/mob_db.py
+++ b/world/scripts/mob_db.py
@@ -86,4 +86,6 @@ def get_mobdb():
     if script.typeclass_path != "world.scripts.mob_db.MobDB":
         script.delete()
         script = create.create_script("world.scripts.mob_db.MobDB", key="mob_db")
+    if hasattr(script, "pause"):
+        script.pause(False)
     return script


### PR DESCRIPTION
## Summary
- keep every global script active on server start
- skip admin/builder characters in the sated decay script
- unpause the MobDB script if needed

## Testing
- `pytest -q` *(fails: 104 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68518520ae58832cb1871f6d5eb35316