### PR TITLE
Use state_manager.tick_character in SatedDecayScript

### DIFF
--- a/scripts/sated_decay.py
+++ b/scripts/sated_decay.py
@@ -1,4 +1,5 @@
 from typeclasses.scripts import Script
+from world.system import state_manager
 
 
 class SatedDecayScript(Script):
@@ -13,21 +14,5 @@ class SatedDecayScript(Script):
     def at_repeat(self):
         from typeclasses.characters import Character
 
-        thresholds = {50: "You feel a bit peckish.",
-                      20: "You are getting hungry.",
-                      1: "You are starving!"}
-
         for char in Character.objects.all():
-            sated = getattr(char.db, "sated", None)
-            if sated is None or sated <= 0:
-                continue
-            old = sated
-            char.db.sated = max(sated - 1, 0)
-            new_val = char.db.sated
-            for threshold, msg in thresholds.items():
-                if old >= threshold > new_val:
-                    if hasattr(char, "msg"):
-                        char.msg(msg)
-                    break
-            # end inner for
-        # end outer for
+            state_manager.tick_character(char)

--- a/typeclasses/tests/test_sated_decay_script.py
+++ b/typeclasses/tests/test_sated_decay_script.py
@@ -1,0 +1,24 @@
+from django.test import override_settings
+from evennia.utils.test_resources import EvenniaTest
+from scripts.sated_decay import SatedDecayScript
+
+
+@override_settings(DEFAULT_HOME=None)
+class TestSatedDecayScript(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.script = SatedDecayScript()
+        self.script.at_script_creation()
+
+    def test_hunger_tick_reduces_sated(self):
+        char = self.char1
+        char.db.sated = 2
+        self.script.at_repeat()
+        self.assertEqual(char.db.sated, 1)
+
+    def test_hungry_effect_applied_at_zero(self):
+        char = self.char1
+        char.db.sated = 1
+        self.script.at_repeat()
+        self.assertEqual(char.db.sated, 0)
+        self.assertTrue(char.tags.has("hungry_thirsty", category="status"))


### PR DESCRIPTION
## Summary
- simplify hunger decay logic by using `state_manager.tick_character`
- add a regression test for the `SatedDecayScript`

## Testing
- `pytest -q` *(fails: django.db errors)*

------
https://chatgpt.com/codex/tasks/task_e_685187e1dda0832c842a9f4d3a43161d