### PR TITLE
Add room coord support

### DIFF
--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -106,6 +106,17 @@ class RoomParent(ObjectParent):
         """Return the room id inside its area."""
         return self.db.room_id
 
+    def set_coord(self, x, y):
+        """Set this room's map coordinates."""
+        try:
+            self.db.coord = (int(x), int(y))
+        except (TypeError, ValueError):  # pragma: no cover - guard
+            self.db.coord = None
+
+    def get_coord(self):
+        """Return this room's map coordinates."""
+        return self.db.coord
+
     # -----------------------------------------------------------------
     # display helpers
 
@@ -223,6 +234,11 @@ class RoomParent(ObjectParent):
 class Room(RoomParent, DefaultRoom):
     """Basic indoor room with simple area metadata."""
 
+    def at_object_creation(self):
+        super().at_object_creation()
+        if self.db.coord is None:
+            self.db.coord = (0, 0)
+
     def generate_map(self, looker):
         """Return a small ASCII map centered on the caller.
 
@@ -297,6 +313,14 @@ class OverworldRoom(RoomParent, WildernessRoom):
 
 class XYGridRoom(RoomParent, XYZRoom):
     """Room used inside the XYZGrid system."""
+
+    def at_object_creation(self):
+        super().at_object_creation()
+        x, y, _ = self.xyz
+        try:
+            self.db.coord = (int(x), int(y))
+        except (TypeError, ValueError):  # pragma: no cover - guard
+            self.db.coord = None
 
     def get_display_header(self, looker, **kwargs):
         """Return the room's XYZ coordinates."""

--- a/world/maps/starter_town.py
+++ b/world/maps/starter_town.py
@@ -70,18 +70,21 @@ LEGEND = {
 
 PROTOTYPES = {
     (6, 3): {
+        "coord": (6, 3),
         "prototype_parent": "xyz_room",
         "tags": [("townsburg", "zone")],
         "key": "West half of a plaza",
         "desc": "The central plaza in Townsburg is wide-open, with at least as many livestock as people.",
     },
     (7, 3): {
+        "coord": (7, 3),
         "prototype_parent": "xyz_room",
         "tags": [("townsburg", "zone")],
         "key": "East half of a plaza",
         "desc": "The central plaza in Townsburg is wide-open, with at least as many livestock as people.",
     },
     (9, 4): {
+        "coord": (9, 4),
         "typeclass": "typeclasses.rooms.XYGridShop",
         "key": "A tavern",
         "desc": "A bustling tavern, with food and drink for sale.",
@@ -90,6 +93,7 @@ PROTOTYPES = {
         ],
     },
     (6, 4): {
+        "coord": (6, 4),
         "typeclass": "typeclasses.rooms.XYGridShop",
         "key": "General Store",
         "desc": "Stuff! and Things",
@@ -101,24 +105,28 @@ PROTOTYPES = {
         ],
     },
     (4, 4): {
+        "coord": (4, 4),
         "typeclass": "typeclasses.rooms.XYGridTrain",
         "key": "Boxing R Us",
         "desc": "It looks like the perfect place for learning how to punch things.",
         "skill_training": "unarmed",
     },
     (6, 2): {
+        "coord": (6, 2),
         "typeclass": "typeclasses.rooms.XYGridTrain",
         "key": "Rogue's Guild",
         "desc": "I dunno you can train daggers here.",
         "skill_training": "daggers",
     },
     (8, 2): {
+        "coord": (8, 2),
         "typeclass": "typeclasses.rooms.XYGridTrain",
         "key": "Fencing studio",
         "desc": "Fencing dummies and practice swords are plentiful.",
         "skill_training": "swords",
     },
     (9, 2): {
+        "coord": (9, 2),
         "prototype_parent": "xyz_room",
         "typeclass": "typeclasses.rooms.XYZShopNTrain",
         "tags": [("townsburg", "zone")],
@@ -132,6 +140,7 @@ PROTOTYPES = {
         ],
     },
     (10, 4): {
+        "coord": (10, 4),
         "prototype_parent": "xyz_room",
         "typeclass": "typeclasses.rooms.XYZShopNTrain",
         "tags": [("townsburg", "zone")],
@@ -144,6 +153,7 @@ PROTOTYPES = {
         ],
     },
     (11, 4): {
+        "coord": (11, 4),
         "prototype_parent": "xyz_room",
         "typeclass": "typeclasses.rooms.XYGridTrain",
         "tags": [("townsburg", "zone")],
@@ -152,6 +162,7 @@ PROTOTYPES = {
         "skill_training": "leatherwork",
     },
     (11, 2): {
+        "coord": (11, 2),
         "prototype_parent": "xyz_room",
         "typeclass": "typeclasses.rooms.XYGridTrain",
         "tags": [("townsburg", "zone")],


### PR DESCRIPTION
## Summary
- track coordinates for rooms
- expose set_coord/get_coord helpers
- store coords when creating XY grid rooms
- record coords in starter town map prototype

## Testing
- `pytest -q` *(fails: OperationalError no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68518f14416c832cb921ee7c7fe1c3a5