### PR TITLE
Improve minimap for adjacent rooms

### DIFF
--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -6,7 +6,7 @@ Rooms are simple containers that has no location of their own.
 """
 
 from evennia import create_object
-from evennia.utils import iter_to_str, logger, lazy_property
+from evennia.utils import iter_to_str, logger, lazy_property, search
 from evennia.objects.objects import DefaultRoom
 from evennia.contrib.grid.xyzgrid.xyzroom import XYZRoom
 from evennia.contrib.grid.wilderness.wilderness import WildernessRoom
@@ -237,18 +237,48 @@ class Room(RoomParent, DefaultRoom):
         """
 
         exits = self.db.exits or {}
-        north = "^" if "north" in exits else " "
-        south = "v" if "south" in exits else " "
-        west = "<" if "west" in exits else " "
-        east = ">" if "east" in exits else " "
+        coord = self.db.coord
+        if not coord:
+            north = "^" if "north" in exits else " "
+            south = "v" if "south" in exits else " "
+            west = "<" if "west" in exits else " "
+            east = ">" if "east" in exits else " "
 
-        map_lines = [
-            f"  {north}  ",
-            f"{west} [X] {east}",
-            f"  {south}  ",
-        ]
+            map_lines = [
+                f"  {north}  ",
+                f"{west} [X] {east}",
+                f"  {south}  ",
+            ]
+            return "\n".join(map_lines)
 
-        return "\n".join(map_lines)
+        x, y = coord
+        neighbors = {}
+        for dx in (-1, 0, 1):
+            for dy in (-1, 0, 1):
+                if dx == 0 and dy == 0:
+                    neighbors[(dx, dy)] = True
+                    continue
+                objs = search.search_object_attribute(key="coord", value=(x + dx, y + dy))
+                neighbors[(dx, dy)] = bool(objs)
+
+        def cell(dx, dy):
+            if dx == 0 and dy == 0:
+                return "[X]"
+            return "[ ]" if neighbors.get((dx, dy)) else "   "
+
+        lines = []
+        lines.append("".join(cell(dx, 1) for dx in (-1, 0, 1)))
+        lines.append("   {}   ".format("|" if "north" in exits and neighbors.get((0, 1)) else " "))
+        center = cell(-1, 0)
+        center += "-" if "west" in exits and neighbors.get((-1, 0)) else " "
+        center += cell(0, 0)
+        center += "-" if "east" in exits and neighbors.get((1, 0)) else " "
+        center += cell(1, 0)
+        lines.append(center)
+        lines.append("   {}   ".format("|" if "south" in exits and neighbors.get((0, -1)) else " "))
+        lines.append("".join(cell(dx, -1) for dx in (-1, 0, 1)))
+
+        return "\n".join(lines)
 
     def return_appearance(self, looker):
         """Prefix the normal room appearance with a minimap."""

--- a/typeclasses/tests/test_room_minimap.py
+++ b/typeclasses/tests/test_room_minimap.py
@@ -6,21 +6,27 @@ from typeclasses.rooms import Room
 class TestRoomMinimap(EvenniaTest):
     def test_generate_map_marks_exits(self):
         room = self.room1
+        room.db.coord = (0, 0)
         north = create.create_object(Room, key="north", location=None)
         south = create.create_object(Room, key="south", location=None)
         east = create.create_object(Room, key="east", location=None)
         west = create.create_object(Room, key="west", location=None)
+        north.db.coord = (0, 1)
+        south.db.coord = (0, -1)
+        east.db.coord = (1, 0)
+        west.db.coord = (-1, 0)
         room.db.exits = {"north": north, "south": south, "east": east, "west": west}
 
         map_out = room.generate_map(self.char1)
-        self.assertIn("^", map_out)
-        self.assertIn("v", map_out)
-        self.assertIn("<", map_out)
-        self.assertIn(">", map_out)
         self.assertIn("[X]", map_out)
+        self.assertIn("[ ]", map_out)
+        self.assertIn("-", map_out)
+        self.assertIn("|", map_out)
 
     def test_map_in_return_appearance(self):
         room = self.room1
+        room.db.coord = (0, 0)
+        self.room2.db.coord = (0, 1)
         room.db.exits = {"north": self.room2}
         out = room.return_appearance(self.char1)
         self.assertIn("[X]", out.splitlines()[0])


### PR DESCRIPTION
## Summary
- build a simple 3x3 minimap around Room.db.coord
- add search import for generate_map
- update minimap tests for new behaviour

## Testing
- `evennia migrate --noinput`
- `pytest typeclasses/tests/test_room_minimap.py -q` *(fails: OperationalError - no such table)*

------
https://chatgpt.com/codex/tasks/task_e_68518af47340832cbac17c8cf8f47b81