### PR TITLE
Add minimap docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,22 @@ bank withdraw <amount [coin]>
 bank transfer <amount [coin]> <player>
 ```
 
+## Minimap
+
+Looking at a room shows a small 3×3 map above the description. Arrows mark
+available exits while `[X]` marks your location. Example:
+
+```
+  ^
+< [X] >
+  v
+```
+
+Rooms in grid-based areas must define `xyz` coordinates so they appear on the
+map. Set the `xyz` field in `redit` or on the room prototype using
+`(x, y, "area")`. See [docs/area_json.md](docs/area_json.md) for more on area
+files and room placement.
+
 
 ## Installation and Setup
 

--- a/docs/area_json.md
+++ b/docs/area_json.md
@@ -12,3 +12,8 @@ Example:
 aedit add town 2001
 asave changed
 ```
+
+Rooms intended for grid-based maps should also include an `xyz` coordinate.
+This triplet `(x, y, "area")` determines where the room appears on the 3×3
+minimap shown when players `look`. Set `xyz` on the prototype or through
+`redit` to ensure the room is placed correctly.


### PR DESCRIPTION
## Summary
- document minimap usage and assigning coordinates
- reference minimap coordinates in area json docs

## Testing
- `pytest -q` *(fails: django.db errors)*

------
https://chatgpt.com/codex/tasks/task_e_68518af60b50832cad5fa89051d36b70