### PR TITLE
Implement boxed minimap with dynamic exit arrows

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,18 @@ bank transfer <amount [coin]> <player>
 
 ## Minimap
 
-Looking at a room shows a small 3×3 map above the description. Arrows mark
-available exits while `[X]` marks your location. Example:
+Looking at a room displays a small minimap above the description. The current
+room appears as `[X]` inside a box with exit arrows and compass directions
+around it.
 
 ```
-  ^
-< [X] >
-  v
+     N
+  __^__
+ |     |
+W<| [X] |>E
+ |____|
+     v
+     S
 ```
 
 Rooms in grid-based areas must define `xyz` coordinates so they appear on the

--- a/docs/area_json.md
+++ b/docs/area_json.md
@@ -14,6 +14,6 @@ asave changed
 ```
 
 Rooms intended for grid-based maps should also include an `xyz` coordinate.
-This triplet `(x, y, "area")` determines where the room appears on the 3×3
+This triplet `(x, y, "area")` determines where the room appears on the
 minimap shown when players `look`. Set `xyz` on the prototype or through
 `redit` to ensure the room is placed correctly.

--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -242,8 +242,9 @@ class Room(RoomParent, DefaultRoom):
     def generate_map(self, looker):
         """Return a small ASCII map centered on the caller.
 
-        The map shows the available exits north, south, east and west
-        relative to this room. The current room is marked with ``[X]``.
+        The map shows a framed box with ``[X]`` marking the current room.
+        Arrows and compass directions are added for exits in each of the
+        cardinal directions.
 
         Args:
             looker (Object): The object viewing the room.
@@ -256,31 +257,36 @@ class Room(RoomParent, DefaultRoom):
         if not coord:
             return "[X] (no map)"
 
-        x, y = coord
-        room_map = {}
-        for dx in range(-1, 2):
-            for dy in range(-1, 2):
-                check_coord = (x + dx, y + dy)
-                for obj in (self.location.contents if self.location else self.__class__.objects.all()):
-                    if obj.db.coord == check_coord:
-                        room_map[(dx, dy)] = obj
-                        break
-                else:
-                    room_map[(dx, dy)] = None
+        exits = self.db.exits or {}
 
-        lines = []
-        for dy in reversed(range(-1, 2)):
-            row = []
-            for dx in range(-1, 2):
-                if dx == 0 and dy == 0:
-                    row.append("[X]")
-                elif room_map.get((dx, dy)):
-                    row.append("[ ]")
-                else:
-                    row.append("   ")
-            lines.append("".join(row))
+        north = "north" in exits
+        south = "south" in exits
+        east = "east" in exits
+        west = "west" in exits
 
-        return "\n".join(lines)
+        map_lines = []
+
+        # north label/arrow
+        if north:
+            map_lines.append("     N")
+            map_lines.append("  __^__")
+
+        map_lines.append(" |     |")
+
+        center = "[X]"
+        mid = ""
+        mid += "W<| " if west else "   | "
+        mid += center
+        mid += " |>E" if east else " |  "
+        map_lines.append(mid.rstrip())
+
+        map_lines.append(" |____|")
+
+        if south:
+            map_lines.append("     v")
+            map_lines.append("     S")
+
+        return "\n".join(map_lines)
 
     def return_appearance(self, looker):
         """Prefix the normal room appearance with a minimap."""

--- a/typeclasses/tests/test_room_minimap.py
+++ b/typeclasses/tests/test_room_minimap.py
@@ -35,9 +35,13 @@ class TestRoomMinimap(EvenniaTest):
         map_output = room.generate_map(self.char1)
 
         expected = [
-            "   [ ]   ",
-            "[ ][X][ ]",
-            "   [ ]   "
+            "     N",
+            "  __^__",
+            " |     |",
+            "W<| [X] |>E",
+            " |____|",
+            "     v",
+            "     S",
         ]
 
         self.assertEqual(map_output.splitlines(), expected)
@@ -78,11 +82,15 @@ class TestRoomMinimap(EvenniaTest):
         east.db.exits = {"west": center}
         west.db.exits = {"east": center}
 
-        # Expected 3x3 grid
+        # Expected boxed map with exits
         expected_map = "\n".join([
-            "   [ ]   ",
-            "[ ][X][ ]",
-            "   [ ]   "
+            "     N",
+            "  __^__",
+            " |     |",
+            "W<| [X] |>E",
+            " |____|",
+            "     v",
+            "     S",
         ])
 
         generated_map = center.generate_map(self.char1)


### PR DESCRIPTION
## Summary
- generate dynamic minimap with boxed room and exit arrows
- update README and area docs to show new map format
- adjust tests to expect boxed minimap output

## Testing
- `pytest -q typeclasses/tests/test_room_minimap.py::TestRoomMinimap::test_generate_map_marks_exits` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685199335a7c832c8d47ce4a84cf7396