### PR TITLE
Fix room-based mob spawns

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,10 +358,16 @@ Example:
 
 ## Spawn Control
 
-`@spawnreload` reloads all spawn entries from saved NPC prototypes.
+`@spawnreload` reloads all spawn entries from room prototype files.
 Use `@forcerespawn <room_vnum>` to immediately run the spawn
 logic for a specific room. Use `@showspawns [vnum]` to list
 entries for your current room or the given VNUM.
+
+Room spawns are defined in JSON files under `world/prototypes/rooms/`.
+Each room file can include a `spawns` list describing which NPC
+prototypes should repopulate there. Edit a room with `redit <vnum>`
+and choose **Edit spawns** to modify this list. After saving, run
+`@spawnreload` so the SpawnManager picks up the changes.
 
 ## Weapon Creation and Inspection
 

--- a/world/prototypes/npcs.json
+++ b/world/prototypes/npcs.json
@@ -16,13 +16,7 @@
         "skills": {"appraise": 100},
         "resistances": [
             "cold"
-        ],
-        "spawn": {
-            "room_vnum": 200002,
-            "initial_count": 2,
-            "max_count": 5,
-            "respawn_rate": 300
-        }
+        ]
     },
     "basic_questgiver": {
         "key": "quest giver",
@@ -39,13 +33,7 @@
             "call_for_help"
         ],
         "spells": {"cure light": 100},
-        "resistances": [],
-        "spawn": {
-            "room_vnum": 200002,
-            "initial_count": 2,
-            "max_count": 5,
-            "respawn_rate": 300
-        }
+        "resistances": []
     },
     "basic_guard": {
         "key": "town guard",
@@ -66,25 +54,21 @@
         "spells": {"heal": 100},
         "resistances": [
             "fire"
-        ],
-        "spawn": {
-            "room_vnum": 200002,
-            "initial_count": 2,
-            "max_count": 5,
-            "respawn_rate": 300
-        }
+        ]
     },
     "slime": {
         "key": "slime",
         "npc_type": "base",
         "race": "human",
         "level": 1,
-        "damage_dice": "1d2",
-        "spawn": {
-            "room_vnum": 200002,
-            "initial_count": 2,
-            "max_count": 5,
-            "respawn_rate": 300
-        }
+        "damage_dice": "1d2"
+    },
+    "goblin_grunt": {
+        "key": "Goblin Grunt",
+        "desc": "A small, angry goblin snarls at you.",
+        "npc_type": "base",
+        "typeclass": "typeclasses.npcs.CombatNPC",
+        "level": 1,
+        "damage_dice": "1d4"
     }
 }

--- a/world/prototypes/rooms/200001.json
+++ b/world/prototypes/rooms/200001.json
@@ -1,0 +1,10 @@
+{
+    "vnum": 200001,
+    "key": "Verdant Field",
+    "desc": "Tall grasses whisper in the breeze.",
+    "typeclass": "typeclasses.rooms.Room",
+    "area": "townsburg",
+    "spawns": [
+        {"proto": "goblin_grunt", "initial_count": 1, "max_count": 3, "respawn_rate": 60}
+    ]
+}

--- a/world/prototypes/rooms/200002.json
+++ b/world/prototypes/rooms/200002.json
@@ -1,0 +1,11 @@
+{
+    "vnum": 200002,
+    "key": "Training Grounds",
+    "desc": "A dusty clearing used for sparring.",
+    "typeclass": "typeclasses.rooms.Room",
+    "area": "townsburg",
+    "spawns": [
+        {"proto": "basic_guard", "initial_count": 1, "max_count": 2, "respawn_rate": 120},
+        {"proto": "basic_merchant", "initial_count": 1, "max_count": 1, "respawn_rate": 300}
+    ]
+}


### PR DESCRIPTION
## Summary
- add room prototypes with spawn lists
- move spawn data out of npc prototypes and add goblin example
- document how room spawns work in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68519a3ef0b0832cac6e34df693eff95