### PR TITLE
Room-based mob spawning overhaul

### DIFF
--- a/commands/admin/spawncontrol.py
+++ b/commands/admin/spawncontrol.py
@@ -67,17 +67,7 @@ class CmdShowSpawns(Command):
 
         lines = []
         for entry in script.db.entries:
-            room = entry.get("room")
-            if hasattr(room, "dbref"):
-                rid = getattr(room.db, "room_id", None)
-            elif isinstance(room, str) and room.isdigit():
-                rid = int(room)
-            elif isinstance(room, int):
-                rid = room
-            else:
-                rid = None
-
-            if rid != target_vnum:
+            if script._normalize_room_id(entry.get("room")) != target_vnum:
                 continue
 
             obj = script._get_room(entry)

--- a/typeclasses/tests/test_redit_spawns.py
+++ b/typeclasses/tests/test_redit_spawns.py
@@ -30,10 +30,10 @@ class TestReditSpawns(EvenniaTest):
         proto = self.char1.ndb.room_protos[5]
         assert proto["exits"] == {"north": 6}
         proto.setdefault("spawns", []).append({
-            "proto": "goblin",
-            "initial_count": 1,
-            "max_count": 2,
-            "respawn_rate": 10,
+            "prototype": "goblin",
+            "max_spawns": 2,
+            "spawn_interval": 10,
+            "location": "#5",
         })
         self.char1.ndb.room_protos[5] = proto
 

--- a/typeclasses/tests/test_spawn_manager.py
+++ b/typeclasses/tests/test_spawn_manager.py
@@ -19,9 +19,9 @@ class TestSpawnManager(EvenniaTest):
             "spawns": [
                 {
                     "prototype": "goblin",
-                    "initial_count": 2,
-                    "max_count": 3,
-                    "respawn_rate": 5,
+                    "max_spawns": 3,
+                    "spawn_interval": 5,
+                    "location": f"#{self.room1.db.room_id}",
                 }
             ],
         }

--- a/world/prototypes/npcs.json
+++ b/world/prototypes/npcs.json
@@ -1,5 +1,6 @@
 {
     "basic_merchant": {
+        "prototype_key": "basic_merchant",
         "key": "merchant",
         "desc": "A traveling merchant ready to trade goods.",
         "npc_type": "merchant",
@@ -19,6 +20,7 @@
         ]
     },
     "basic_questgiver": {
+        "prototype_key": "basic_questgiver",
         "key": "quest giver",
         "desc": "A local seeking brave adventurers for help.",
         "npc_type": "questgiver",
@@ -36,6 +38,7 @@
         "resistances": []
     },
     "basic_guard": {
+        "prototype_key": "basic_guard",
         "key": "town guard",
         "desc": "A vigilant guard keeping watch over the streets.",
         "npc_type": "base",
@@ -57,6 +60,7 @@
         ]
     },
     "slime": {
+        "prototype_key": "slime",
         "key": "slime",
         "npc_type": "base",
         "race": "human",
@@ -64,6 +68,7 @@
         "damage_dice": "1d2"
     },
     "goblin_grunt": {
+        "prototype_key": "goblin_grunt",
         "key": "Goblin Grunt",
         "desc": "A small, angry goblin snarls at you.",
         "npc_type": "base",

--- a/world/prototypes/rooms/200001.json
+++ b/world/prototypes/rooms/200001.json
@@ -5,6 +5,11 @@
     "typeclass": "typeclasses.rooms.Room",
     "area": "townsburg",
     "spawns": [
-        {"proto": "goblin_grunt", "initial_count": 1, "max_count": 3, "respawn_rate": 60}
+        {
+            "prototype": "goblin_grunt",
+            "spawn_interval": 60,
+            "max_spawns": 3,
+            "location": "#200001"
+        }
     ]
 }

--- a/world/prototypes/rooms/200002.json
+++ b/world/prototypes/rooms/200002.json
@@ -5,7 +5,17 @@
     "typeclass": "typeclasses.rooms.Room",
     "area": "townsburg",
     "spawns": [
-        {"proto": "basic_guard", "initial_count": 1, "max_count": 2, "respawn_rate": 120},
-        {"proto": "basic_merchant", "initial_count": 1, "max_count": 1, "respawn_rate": 300}
+        {
+            "prototype": "basic_guard",
+            "spawn_interval": 120,
+            "max_spawns": 2,
+            "location": "#200002"
+        },
+        {
+            "prototype": "basic_merchant",
+            "spawn_interval": 300,
+            "max_spawns": 1,
+            "location": "#200002"
+        }
     ]
 }

--- a/world/tests/test_showspawns_command.py
+++ b/world/tests/test_showspawns_command.py
@@ -10,7 +10,7 @@ class TestShowSpawns(TestCase):
         cmd.args = ""
         cmd.msg = mock.Mock()
         script = mock.MagicMock()
-        script.db.entries = [{"room": 1, "prototype": "goblin", "max_count": 2, "respawn_rate": 30}]
+        script.db.entries = [{"room": "#1", "prototype": "goblin", "max_count": 2, "respawn_rate": 30}]
         script._get_room.return_value = cmd.caller.location
         script._live_count.return_value = 1
         with mock.patch("commands.admin.spawncontrol.ScriptDB") as mock_sdb:

--- a/world/tests/test_spawn_manager.py
+++ b/world/tests/test_spawn_manager.py
@@ -21,7 +21,6 @@ class TestSpawnManager(EvenniaTest):
                 "area": "testarea",
                 "prototype": "basic_merchant",
                 "room": 1,
-                "initial_count": 1,
                 "max_count": 2,
                 "respawn_rate": 5,
                 "last_spawn": 0,


### PR DESCRIPTION
## Summary
- update NPC prototypes with `prototype_key`
- rework room prototypes to use `spawn_interval` and `max_spawns`
- load new spawn data in `SpawnManager`
- adjust spawn commands and admin utilities
- rewrite spawn editing in `redit`
- adapt tests for new spawn format

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6851a4ac1560832ca9c9e0309b7e4494