### PR TITLE
Improve reset world help text

### DIFF
--- a/commands/admin/resetworld.py
+++ b/commands/admin/resetworld.py
@@ -3,10 +3,10 @@ from ..command import Command
 from evennia.scripts.models import ScriptDB
 
 class CmdResetWorld(Command):
-    """Reset all areas by despawning and respawning spawns."""
+    """Trigger respawn checks for all areas without despawning existing mobs."""
 
     key = "@resetworld"
-    aliases = ["@refreshworld"]
+    aliases = ["@refreshworld", "@respawnworld"]
     locks = "cmd:perm(Builder)"
     help_category = "Admin"
 


### PR DESCRIPTION
## Summary
- clarify `CmdResetWorld` docstring to explain behavior
- add `@respawnworld` alias to hint that spawns are refreshed

## Testing
- `pytest world/tests/test_spawncontrol_commands.py::TestSpawnControlCommands -q`

------
https://chatgpt.com/codex/tasks/task_e_6851ad31a004832cb33ca49f32a004f7