### PR TITLE
Fix room exits and add rdel command

### DIFF
--- a/commands/aedit.py
+++ b/commands/aedit.py
@@ -178,8 +178,25 @@ class CmdASave(Command):
         if self.args.strip().lower() != "changed":
             self.msg("Usage: asave changed")
             return
-        # prototypes are written immediately on edit, so nothing to do
-        self.msg("All areas saved.")
+        from commands.redit import proto_from_room
+        from utils.prototype_manager import save_prototype
+        updated = 0
+        for idx, area in enumerate(get_areas()):
+            for room_vnum in area.rooms:
+                objs = ObjectDB.objects.filter(
+                    db_attributes__db_key="room_id",
+                    db_attributes__db_value=room_vnum,
+                )
+                room = next(
+                    (o for o in objs if o.is_typeclass(Room, exact=False)), None
+                )
+                if not room:
+                    continue
+                proto = proto_from_room(room)
+                save_prototype("room", proto, vnum=room_vnum)
+                updated += 1
+            update_area(idx, area)
+        self.msg(f"All areas saved. {updated} room prototypes updated.")
 
 
 class CmdAEdit(Command):

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -38,7 +38,7 @@ from commands.guilds import GuildCmdSet
 from commands.rest import RestCmdSet
 from commands.loot import LootCmdSet
 from commands.who import CmdWho
-from commands.building import CmdDig, CmdTeleport, CmdDelRoom, CmdLink
+from commands.building import CmdDig, CmdTeleport, CmdDelRoom, CmdRDel, CmdLink
 from commands.areas import AreaCmdSet
 from commands.room_flags import RoomFlagCmdSet
 from commands.admin import AdminCmdSet, BuilderCmdSet
@@ -88,6 +88,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(CmdLink)
         self.add(CmdTeleport)
         self.add(CmdDelRoom)
+        self.add(CmdRDel)
         self.add(RoomFlagCmdSet)
         self.add(AreaCmdSet)
         self.add(AdminCmdSet)

--- a/commands/redit.py
+++ b/commands/redit.py
@@ -458,18 +458,15 @@ def menunode_done(caller, raw_string="", **kwargs):
         existing_exits = existing.get("exits", {})
         base_exits = {**existing_exits, **current_exits}
 
-        proto_exits = proto.get("exits")
-        if proto_exits is not None:
-            if proto_exits == existing_exits:
-                final_exits = base_exits
-            else:
-                final_exits = base_exits.copy()
-                for dirkey in set(existing_exits) - set(proto_exits):
-                    final_exits.pop(dirkey, None)
-                final_exits.update(proto_exits)
-        else:
+    proto_exits = proto.get("exits")
+    if proto_exits is not None:
+        if proto_exits == existing_exits:
             final_exits = base_exits
-
+        else:
+            final_exits = base_exits.copy()
+            for dirkey in set(existing_exits) - set(proto_exits):
+                final_exits.pop(dirkey, None)
+            final_exits.update(proto_exits)
         proto["exits"] = final_exits
 
         data = dict(existing)

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -66,6 +66,33 @@ Related:
 """,
     },
     {
+        "key": "rdel",
+        "category": "Building",
+        "text": """Help for rdel
+
+Delete a room by its VNUM and remove the saved prototype.
+
+Usage:
+    rdel <vnum>
+
+Switches:
+    None
+
+Arguments:
+    vnum - room VNUM to delete
+
+Examples:
+    rdel 200001
+
+Notes:
+    - Removes any exits to or from the room.
+    - Deletes the prototype file if present.
+
+Related:
+    help delroom
+""",
+    },
+    {
         "key": "building",
         "category": "Building",
         "text": """
@@ -1195,6 +1222,22 @@ Arguments:
 Examples:
     @showspawns
     @showspawns 200001
+""",
+    },
+    {
+        "key": "mob spawn setup",
+        "aliases": ["mobspawns"],
+        "category": "Building",
+        "text": """Help for mob spawn setup
+
+This describes how to make NPCs automatically appear in a room.
+
+1. Create or edit a mob prototype using |wcnpc|n or |wmobbuilder|n.
+2. Save the prototype with a VNUM.
+3. Use |wredit <room_vnum>|n and choose |wEdit spawns|n to add the prototype,
+   max count and respawn interval.
+4. Save the room prototype and run |w@spawnreload|n or |wasave changed|n.
+5. Check spawns with |w@showspawns <room_vnum>|n.
 """,
     },
     {

--- a/world/tests/test_rdel_command.py
+++ b/world/tests/test_rdel_command.py
@@ -1,0 +1,48 @@
+from unittest.mock import MagicMock, patch
+from tempfile import TemporaryDirectory
+from pathlib import Path
+from evennia.utils.test_resources import EvenniaTest
+from evennia import create_object
+
+from typeclasses.rooms import Room
+from commands.building import CmdRDel
+from utils.prototype_manager import CATEGORY_DIRS
+
+
+class TestRDelCommand(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.tmp = TemporaryDirectory()
+        patcher = patch.dict('utils.prototype_manager.CATEGORY_DIRS', {'room': Path(self.tmp.name)})
+        self.addCleanup(self.tmp.cleanup)
+        self.addCleanup(patcher.stop)
+        patcher.start()
+        self.char1.msg = MagicMock()
+
+    def test_rdel_deletes_room_and_proto(self):
+        room = create_object(Room, key='R', location=self.room1)
+        room.set_area('zone', 5)
+        self.room1.db.exits = {'north': room}
+        room.db.exits = {'south': self.room1}
+        proto_path = CATEGORY_DIRS['room'] / '5.json'
+        proto_path.parent.mkdir(parents=True, exist_ok=True)
+        proto_path.write_text('{"vnum": 5}')
+
+        cmd = CmdRDel()
+        cmd.caller = self.char1
+        cmd.args = '5'
+        cmd.msg = MagicMock()
+        cmd.func()
+
+        cmd.msg.assert_called_with('Room 5 deleted.')
+        self.assertIsNone(room.pk)
+        self.assertNotIn('north', self.room1.db.exits)
+        self.assertFalse(proto_path.exists())
+
+    def test_usage(self):
+        cmd = CmdRDel()
+        cmd.caller = self.char1
+        cmd.args = 'abc'
+        cmd.msg = MagicMock()
+        cmd.func()
+        cmd.msg.assert_called_with('Usage: rdel <vnum>')


### PR DESCRIPTION
## Summary
- avoid overwriting live exits when prototypes lack an `exits` key
- autosave room prototypes in `asave changed`
- add `rdel` command to remove rooms and prototypes
- document new command and how to set up mob spawns
- test rdel command

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6851b1f3aad0832c9dd1a44edabdb420