### PR TITLE
Update asave changed to refresh coordinates

### DIFF
--- a/commands/aedit.py
+++ b/commands/aedit.py
@@ -180,8 +180,10 @@ class CmdASave(Command):
             return
         from commands.redit import proto_from_room
         from utils.prototype_manager import save_prototype
+        from commands.building import refresh_coordinates
         updated = 0
         for idx, area in enumerate(get_areas()):
+            rooms = []
             for room_vnum in area.rooms:
                 objs = ObjectDB.objects.filter(
                     db_attributes__db_key="room_id",
@@ -190,10 +192,13 @@ class CmdASave(Command):
                 room = next(
                     (o for o in objs if o.is_typeclass(Room, exact=False)), None
                 )
-                if not room:
-                    continue
+                if room:
+                    rooms.append(room)
+            if rooms:
+                refresh_coordinates(rooms)
+            for room in rooms:
                 proto = proto_from_room(room)
-                save_prototype("room", proto, vnum=room_vnum)
+                save_prototype("room", proto, vnum=room.db.room_id)
                 updated += 1
             update_area(idx, area)
         self.msg(f"All areas saved. {updated} room prototypes updated.")

--- a/typeclasses/tests/test_asave_coords.py
+++ b/typeclasses/tests/test_asave_coords.py
@@ -1,0 +1,51 @@
+from unittest.mock import patch, MagicMock
+from django.test import override_settings
+from evennia.utils.test_resources import EvenniaTest
+from commands.admin import BuilderCmdSet
+from typeclasses.rooms import Room
+from world.areas import Area
+from commands import aedit
+
+@override_settings(DEFAULT_HOME=None)
+class TestASaveCoordinates(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.char1.permissions.add("Builder")
+        self.char1.cmdset.add_default(BuilderCmdSet)
+        self.char1.msg = MagicMock()
+
+    @patch("commands.aedit.update_area")
+    @patch("commands.aedit.save_prototype")
+    @patch("commands.aedit.proto_from_room")
+    @patch("commands.aedit.ObjectDB.objects.filter")
+    @patch("commands.aedit.get_areas")
+    def test_coords_updated(self, mock_get_areas, mock_filter, mock_proto, mock_save, mock_update):
+        room1 = self.room1
+        room2 = self.room2
+        room1.db.coord = (0, 0)
+        room1.db.area = "zone"
+        room1.db.room_id = 1
+        room2.db.coord = (1, 0)
+        room2.db.area = "zone"
+        room2.db.room_id = 2
+        room1.db.exits = {"south": room2}
+        room2.db.exits = {"north": room1}
+
+        area = Area(key="zone", start=1, end=2, rooms=[1, 2])
+        mock_get_areas.return_value = [area]
+
+        def _filter(**kwargs):
+            val = kwargs.get("db_attributes__db_value")
+            return [room1] if val == 1 else [room2]
+
+        mock_filter.side_effect = _filter
+        mock_proto.side_effect = lambda r: {}
+
+        cmd = aedit.CmdASave()
+        cmd.caller = self.char1
+        cmd.session = self.char1.sessions.get()
+        cmd.args = "changed"
+        cmd.func()
+
+        self.assertEqual(room2.db.coord, (0, -1))
+


### PR DESCRIPTION
## Summary
- adjust `asave changed` to refresh coordinates for all rooms before saving
- implement `refresh_coordinates` helper to recalc coords from room exits
- add regression test for coordinate update on `asave`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6851ba8c6350832ca706a10c132a6e7d