### PR TITLE
Implement corpse decay timer

### DIFF
--- a/server/conf/settings.py
+++ b/server/conf/settings.py
@@ -53,6 +53,18 @@ DEFAULT_AREA_NAME = "Starter Zone"
 DEFAULT_AREA_START = 200000
 DEFAULT_AREA_END = 200999
 
+# ----------------------------------------------------------------------
+# Corpse decay settings
+# ----------------------------------------------------------------------
+# Minimum and maximum minutes before an NPC corpse decays. The exact
+# duration is chosen randomly for each corpse within this range.
+CORPSE_DECAY_MIN = 5
+CORPSE_DECAY_MAX = 10
+
+# When ``True`` a corpse will decay even if being carried in someone's
+# inventory. Set to ``False`` to only allow decay when lying in a room.
+ALLOW_CORPSE_DECAY_IN_INVENTORY = False
+
 ######################################################################
 # Config for contrib packages
 ######################################################################

--- a/typeclasses/objects.py
+++ b/typeclasses/objects.py
@@ -450,10 +450,11 @@ class Corpse(Object):
         if (decay := self.db.decay_time):
             # start auto-decay timer in minutes
             self.scripts.add(
-                "typeclasses.scripts.AutoDecayScript",
-                key="auto_decay",
+                "typeclasses.scripts.CorpseDecayScript",
+                key="corpse_decay",
                 interval=int(decay) * 60,
                 start_delay=True,
+                repeats=-1,
             )
 
     def at_object_post_creation(self):

--- a/typeclasses/tests/test_combat_engine.py
+++ b/typeclasses/tests/test_combat_engine.py
@@ -372,7 +372,7 @@ class TestCombatDeath(EvenniaTest):
             for obj in self.room1.contents
             if obj.is_typeclass("typeclasses.objects.Corpse", exact=False)
         )
-        script = corpse.scripts.get("auto_decay")[0]
+        script = corpse.scripts.get("corpse_decay")[0]
         self.assertEqual(script.interval, 60)
         script.at_repeat()
         self.assertNotIn(corpse, self.room1.contents)

--- a/utils/mob_utils.py
+++ b/utils/mob_utils.py
@@ -104,8 +104,16 @@ def make_corpse(npc):
         return existing[0]
 
     attrs = [("corpse_of", npc.key), ("corpse_of_id", npc.dbref), ("is_corpse", True)]
-    if decay := getattr(npc.db, "corpse_decay_time", None):
-        attrs.append(("decay_time", decay))
+    decay = getattr(npc.db, "corpse_decay_time", None)
+    if decay is None:
+        from django.conf import settings
+        from random import randint
+
+        decay = randint(
+            getattr(settings, "CORPSE_DECAY_MIN", 5),
+            getattr(settings, "CORPSE_DECAY_MAX", 10),
+        )
+    attrs.append(("decay_time", decay))
     corpse = create_object(
         "typeclasses.objects.Corpse",
         key=f"corpse of {npc.key}",


### PR DESCRIPTION
## Summary
- add corpse decay settings
- default corpse decay for NPCs between 5-10 minutes
- add CorpseDecayScript to clean up corpses with a room message
- run script on corpse creation
- update combat engine test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6851c35a080c832c8df8f0572e2bc2cf