### PR TITLE
Fix corpse decay script call

### DIFF
--- a/typeclasses/objects.py
+++ b/typeclasses/objects.py
@@ -454,7 +454,6 @@ class Corpse(Object):
                 key="corpse_decay",
                 interval=int(decay) * 60,
                 start_delay=True,
-                repeats=-1,
             )
 
     def at_object_post_creation(self):


### PR DESCRIPTION
## Summary
- remove `repeats` parameter from `Corpse` decay script call

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6851ce0d38c0832cbbdefed9834f00b1