### PR TITLE
Handle non numeric prototype filenames

### DIFF
--- a/utils/prototype_manager.py
+++ b/utils/prototype_manager.py
@@ -12,6 +12,8 @@ from pathlib import Path
 import json
 from typing import Dict, Optional
 
+from evennia.utils import logger
+
 from django.conf import settings
 
 from .vnum_registry import (
@@ -70,7 +72,11 @@ def load_all_prototypes(category: str) -> Dict[int, dict]:
         try:
             with file.open("r") as f:
                 proto = json.load(f)
-            result[int(file.stem)] = proto
+            try:
+                result[int(file.stem)] = proto
+            except ValueError:
+                logger.log_info(f"Skipped non-numeric prototype file: {file.name}")
+                continue
         except json.JSONDecodeError:
             continue
     return result

--- a/utils/tests/test_prototype_manager.py
+++ b/utils/tests/test_prototype_manager.py
@@ -1,0 +1,40 @@
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+import django
+from django.test import override_settings
+from evennia.utils.test_resources import EvenniaTest
+
+from utils import prototype_manager
+
+
+@override_settings(DEFAULT_HOME=None)
+class TestLoadAllPrototypes(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.tmp = TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        patcher = mock.patch.dict(
+            prototype_manager.CATEGORY_DIRS,
+            {
+                "room": Path(self.tmp.name) / "rooms",
+            },
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        prototype_manager.CATEGORY_DIRS["room"].mkdir(parents=True, exist_ok=True)
+
+    def test_skip_non_numeric_files(self):
+        numeric_file = prototype_manager.CATEGORY_DIRS["room"] / "100.json"
+        with numeric_file.open("w") as f:
+            json.dump({"vnum": 100}, f)
+
+        non_numeric_file = prototype_manager.CATEGORY_DIRS["room"] / "MIDGARD.json"
+        with non_numeric_file.open("w") as f:
+            json.dump([{"vnum": 200}], f)
+
+        result = prototype_manager.load_all_prototypes("room")
+        assert 100 in result
+        assert all(key != 200 for key in result)


### PR DESCRIPTION
## Summary
- skip prototype files with non-numeric filenames
- test that load_all_prototypes skips non-numeric prototype files

## Testing
- `pytest -q utils/tests/test_prototype_manager.py` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6851d195c1c8832cb9c4abce2382439f