### PR TITLE
Add area deletion command

### DIFF
--- a/commands/aedit.py
+++ b/commands/aedit.py
@@ -3,13 +3,14 @@ from evennia import CmdSet
 from evennia.objects.models import ObjectDB
 from evennia.server.models import ServerConfig
 from typeclasses.rooms import Room
-from .command import Command
+from .command import Command, MuxCommand
 from world.areas import (
     Area,
     get_areas,
     save_area,
     update_area,
     find_area,
+    delete_area,
     parse_area_identifier,
 )
 from world import area_npcs
@@ -409,6 +410,39 @@ class CmdAreaAge(Command):
         self.msg(f"{area.key} age: {area.age}")
 
 
+class CmdADel(MuxCommand):
+    """Delete an area and unassign its rooms."""
+
+    key = "adel"
+    locks = "cmd:perm(Builder)"
+    help_category = "Building"
+
+    def func(self):
+        force = False
+        if "--force" in self.switches:
+            force = True
+            self.switches.remove("--force")
+
+        if not self.args:
+            self.msg("Usage: adel <area>")
+            return
+
+        name = self.args.strip()
+        idx, area = find_area(name)
+        if area is None or idx == -1:
+            self.msg(f"Area '{name}' not found.")
+            return
+
+        if not force:
+            confirm = yield (f"Delete {area.key}? Yes/No")
+            if confirm.strip().lower() not in ("yes", "y"):
+                self.msg("Cancelled.")
+                return
+
+        delete_area(area.key)
+        self.msg(f"Area {area.key} deleted.")
+
+
 class AreaEditCmdSet(CmdSet):
     """CmdSet adding area editing commands."""
 
@@ -419,6 +453,7 @@ class AreaEditCmdSet(CmdSet):
         self.add(CmdAList)
         self.add(CmdASave)
         self.add(CmdAEdit)
+        self.add(CmdADel)
         self.add(CmdAreaReset)
         self.add(CmdAreaAge)
 

--- a/world/areas.py
+++ b/world/areas.py
@@ -92,6 +92,32 @@ def update_area(index: int, area: Area):
         json.dump(area.to_dict(), f, indent=4)
 
 
+def delete_area(name: str) -> bool:
+    """Remove area ``name`` from disk and unassign its rooms.
+
+    The comparison is case-insensitive. Returns ``True`` if an area file
+    was removed.
+    """
+
+    path = _file_path(name)
+    removed = False
+    if path.exists():
+        path.unlink()
+        removed = True
+
+    # clear area from any rooms currently assigned to it
+    from evennia.objects.models import ObjectDB
+    from typeclasses.rooms import Room
+
+    objs = ObjectDB.objects.filter(db_attributes__db_key="area",
+                                   db_attributes__db_strvalue__iexact=name)
+    for obj in objs:
+        if obj.is_typeclass(Room, exact=False):
+            obj.attributes.remove("area")
+
+    return removed
+
+
 def find_area(name: str) -> tuple[int, Optional[Area]]:
     """Return index and area matching ``name``.
 


### PR DESCRIPTION
## Summary
- add a helper for removing area files and clearing room assignments
- implement `adel` builder command with optional `--force`
- expose the new command in the area edit cmdset

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6851d5947db4832ca284a0756b591690