### PR TITLE
Implement area rename command

### DIFF
--- a/commands/aedit.py
+++ b/commands/aedit.py
@@ -9,6 +9,7 @@ from world.areas import (
     get_areas,
     save_area,
     update_area,
+    rename_area,
     find_area,
     parse_area_identifier,
 )
@@ -317,6 +318,19 @@ class CmdAEdit(Command):
             area.flags = [f.strip().lower() for f in flags.split(',') if f.strip()]
             update_area(idx, area)
             self.msg("Flags updated.")
+            return
+        if sub == "rename":
+            args = rest.split()
+            if len(args) != 2:
+                self.msg("Usage: aedit rename <old> <new>")
+                return
+            old, new = args
+            try:
+                rename_area(old, new)
+            except ValueError as err:
+                self.msg(str(err))
+                return
+            self.msg(f"|gArea '{old}' renamed to '{new}'.|n")
             return
         if sub == "add":
             args = rest.split()

--- a/world/areas.py
+++ b/world/areas.py
@@ -4,7 +4,7 @@ from typing import List, Dict, Optional
 from pathlib import Path
 import json
 from django.conf import settings
-from utils.prototype_manager import load_all_prototypes
+from utils.prototype_manager import load_all_prototypes, save_prototype
 
 
 @dataclass
@@ -90,6 +90,35 @@ def update_area(index: int, area: Area):
     _BASE_PATH.mkdir(parents=True, exist_ok=True)
     with path.open("w") as f:
         json.dump(area.to_dict(), f, indent=4)
+
+
+def rename_area(old: str, new: str) -> None:
+    """Rename area ``old`` to ``new``.
+
+    The area's JSON file is renamed and all room prototypes
+    referencing the area are updated.
+    """
+
+    idx, area = find_area(old)
+    if area is None or idx == -1:
+        raise ValueError("Area not found")
+    if find_area(new)[1]:
+        raise ValueError("Area with that name already exists")
+
+    old_path = _file_path(area.key)
+    new_path = _file_path(new)
+    if old_path.exists():
+        new_path.parent.mkdir(parents=True, exist_ok=True)
+        old_path.rename(new_path)
+
+    area.key = new
+    save_area(area)
+
+    room_protos = load_all_prototypes("room")
+    for vnum, proto in room_protos.items():
+        if str(proto.get("area", "")).lower() == old.lower():
+            proto["area"] = new
+            save_prototype("room", proto, vnum=vnum)
 
 
 def find_area(name: str) -> tuple[int, Optional[Area]]:

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -1616,6 +1616,7 @@ Usage:
     aedit builders <name> <list>
     aedit flags <name> <list>
     aedit interval <name> <ticks>
+    aedit rename <old> <new>
     aedit add <area|vnum> <room_vnum>
 
 Switches:
@@ -1630,6 +1631,7 @@ Examples:
     aedit builders town Alice,Bob
     aedit flags dungeon dark,safe
     aedit interval dungeon 60
+    aedit rename oldarea newarea
     aedit add dungeon 5
 
 Notes:


### PR DESCRIPTION
## Summary
- add helper to rename area files and update room prototypes
- extend aedit with `rename` subcommand
- document rename usage

## Testing
- `pytest -q` *(fails: no such table `accounts_accountdb`)*

------
https://chatgpt.com/codex/tasks/task_e_6851d65cb0c8832ca82981b80e9ab3af