### PR TITLE
Implement assign and remove in aedit

### DIFF
--- a/commands/aedit.py
+++ b/commands/aedit.py
@@ -360,6 +360,72 @@ class CmdAEdit(Command):
             update_area(idx, area)
             self.msg(f"Room {room_vnum} added to {area.key}.")
             return
+        if sub == "assign":
+            args = rest.split()
+            if len(args) != 2 or not args[1].isdigit():
+                self.msg("Usage: aedit assign <area> <room_vnum>")
+                return
+            area_arg, vnum_str = args
+            room_vnum = int(vnum_str)
+            area = parse_area_identifier(area_arg)
+            if area:
+                idx, _ = find_area(area.key)
+            else:
+                idx = -1
+            if area is None:
+                self.msg(
+                    f"Area '{area_arg}' not found. Use 'alist' to view available areas."
+                )
+                return
+            proto = load_prototype("room", room_vnum)
+            if not proto:
+                self.msg("Room prototype not found.")
+                return
+
+            proto["area"] = area.key
+            proto.setdefault("room_id", room_vnum)
+
+            if room_vnum not in area.rooms:
+                area.rooms.append(room_vnum)
+            out_of_range = not (area.start <= room_vnum <= area.end)
+            if out_of_range:
+                self.msg(
+                    f"Warning: room {room_vnum} outside {area.key} range {area.start}-{area.end}."
+                )
+                if room_vnum < area.start:
+                    area.start = room_vnum
+                if room_vnum > area.end:
+                    area.end = room_vnum
+
+            save_prototype("room", proto, vnum=room_vnum)
+
+            update_area(idx, area)
+            self.msg(f"Room {room_vnum} assigned to {area.key}.")
+            return
+        if sub == "remove":
+            args = rest.split()
+            if len(args) != 2 or not args[1].isdigit():
+                self.msg("Usage: aedit remove <area> <room_vnum>")
+                return
+            area_arg, vnum_str = args
+            room_vnum = int(vnum_str)
+            area = parse_area_identifier(area_arg)
+            if area:
+                idx, _ = find_area(area.key)
+            else:
+                idx = -1
+            if area is None:
+                self.msg(
+                    f"Area '{area_arg}' not found. Use 'alist' to view available areas."
+                )
+                return
+            if room_vnum in area.rooms:
+                area.rooms.remove(room_vnum)
+                update_area(idx, area)
+                self.msg(f"Room {room_vnum} removed from {area.key}.")
+            else:
+                self.msg("Room VNUM not found in area.")
+            return
         self.msg("Unknown subcommand.")
 
 

--- a/typeclasses/tests/test_aedit_assign_remove.py
+++ b/typeclasses/tests/test_aedit_assign_remove.py
@@ -1,0 +1,46 @@
+from unittest.mock import MagicMock, patch
+from django.test import override_settings
+from evennia.utils.test_resources import EvenniaTest
+from commands.admin import BuilderCmdSet
+from world.areas import Area
+from commands import aedit
+
+
+@override_settings(DEFAULT_HOME=None)
+class TestAEditAssignRemove(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.char1.msg = MagicMock()
+        self.char1.cmdset.add_default(BuilderCmdSet)
+
+    @patch("commands.aedit.update_area")
+    @patch("commands.aedit.save_prototype")
+    @patch("commands.aedit.load_prototype")
+    @patch("commands.aedit.parse_area_identifier")
+    def test_assign_room(self, mock_parse, mock_load_proto, mock_save, mock_update):
+        area = Area(key="zone", start=5, end=10, rooms=[6, 7])
+        mock_parse.return_value = area
+        mock_load_proto.return_value = {"vnum": 12}
+        cmd = aedit.CmdAEdit()
+        cmd.caller = self.char1
+        cmd.session = self.char1.sessions.get()
+        cmd.args = "assign zone 12"
+        cmd.func()
+        assert 12 in area.rooms
+        assert area.end == 12
+        proto = mock_save.call_args[0][1]
+        assert proto["area"] == "zone"
+        mock_update.assert_called_with(0, area)
+
+    @patch("commands.aedit.update_area")
+    @patch("commands.aedit.parse_area_identifier")
+    def test_remove_room(self, mock_parse, mock_update):
+        area = Area(key="zone", start=1, end=5, rooms=[1, 2, 3])
+        mock_parse.return_value = area
+        cmd = aedit.CmdAEdit()
+        cmd.caller = self.char1
+        cmd.session = self.char1.sessions.get()
+        cmd.args = "remove zone 2"
+        cmd.func()
+        assert 2 not in area.rooms
+        mock_update.assert_called_with(0, area)


### PR DESCRIPTION
## Summary
- extend `CmdAEdit` with `assign` and `remove` subcommands
- add tests for assigning and removing rooms from areas

## Testing
- `pytest -q` *(fails: OperationalError - no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6851d78af158832cb3e3bbf6905c35f8