### PR TITLE
Support dice strings for coin loot

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -1045,6 +1045,7 @@ class NPC(Character):
         """Create a corpse and deposit any drops and coins."""
         from utils.currency import COIN_VALUES
         from utils.prototype_manager import load_prototype
+        from utils.dice import roll_dice_string
 
         drops = list(self.db.drops or [])
         coin_loot: dict[str, int] = {}
@@ -1062,7 +1063,14 @@ class NPC(Character):
                     guaranteed is not None and count >= int(guaranteed)
                 ):
                     if isinstance(proto, str) and proto.lower() in COIN_VALUES:
-                        amt = int(entry.get("amount", 1))
+                        amount = entry.get("amount", 1)
+                        if isinstance(amount, str) and not amount.isdigit():
+                            try:
+                                amt = roll_dice_string(amount)
+                            except Exception:
+                                amt = 0
+                        else:
+                            amt = int(amount)
                         coin_loot[proto.lower()] = coin_loot.get(proto.lower(), 0) + amt
                     else:
                         if isinstance(proto, int) or (isinstance(proto, str) and proto.isdigit()):

--- a/typeclasses/tests/test_loot_table.py
+++ b/typeclasses/tests/test_loot_table.py
@@ -64,3 +64,16 @@ class TestNPCLootTable(EvenniaTest):
             npc.at_damage(self.char1, 2)
         self.assertEqual(to_copper(self.char1.db.coins), to_copper({"gold": 5}))
 
+    def test_loot_table_coin_dice_amount(self):
+        from typeclasses.characters import NPC
+
+        npc = create.create_object(NPC, key="mob", location=self.room1)
+        npc.db.drops = []
+        npc.db.loot_table = [{"proto": "gold", "chance": 100, "amount": "2d6"}]
+        npc.traits.health.current = 1
+        self.char1.db.coins = from_copper(0)
+        with patch("evennia.prototypes.spawner.spawn", return_value=[]), \
+             patch("utils.dice.roll_dice_string", return_value=7):
+            npc.at_damage(self.char1, 2)
+        self.assertEqual(to_copper(self.char1.db.coins), to_copper({"gold": 7}))
+

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -3835,14 +3835,14 @@ Usage:
 Examples:
     @mset wolf loot_table "[{\"proto\": 100001, \"chance\": 75}]"
     @mset bandit loot_table "[{\"proto\": \"IRON_SWORD\", \"chance\": 25}]"
-    @mset goblin loot_table "[{\"proto\": \"gold\", \"chance\": 100, \"amount\": 5}]"
+    @mset goblin loot_table "[{\"proto\": \"gold\", \"chance\": 100, \"amount\": \"1d4+1\"}]"
 
 Notes:
     - ``chance`` is a percent from 1-100.
     - Items with 100% chance always drop.
     - ``guaranteed_after`` optionally guarantees the item will drop after the
       given number of failed attempts.
-    - ``amount`` may be used with coin drops to give more than one coin.
+    - ``amount`` may be a number or dice string when dropping coins.
 
 Related:
     help cnpc


### PR DESCRIPTION
## Summary
- allow dice expressions like `2d6` for loot table amounts
- roll dice strings when NPCs drop loot
- document dice amounts in loot table help
- test dice amounts

## Testing
- `pytest typeclasses/tests/test_loot_table.py::TestNPCLootTable::test_loot_table_coin_dice_amount -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6851d78c86a0832cb452d1fce12d498d