### PR TITLE
Trigger immediate room respawns after spawn reload

### DIFF
--- a/scripts/spawn_manager.py
+++ b/scripts/spawn_manager.py
@@ -129,6 +129,12 @@ class SpawnManager(Script):
         """Reload spawn data from prototypes and spawn initial mobs."""
         self.load_spawn_data()
         self.at_start()
+        # Force an immediate respawn in every room after reloading. This helps
+        # during debugging so changes to prototypes are reflected right away.
+        for entry in self.db.entries:
+            room_vnum = self._normalize_room_id(entry.get("room"))
+            if room_vnum is not None:
+                self.force_respawn(room_vnum)
 
     # ------------------------------------------------------------
     # internal helpers

--- a/world/tests/test_spawn_manager.py
+++ b/world/tests/test_spawn_manager.py
@@ -30,3 +30,18 @@ class TestSpawnManager(EvenniaTest):
         npcs = [obj for obj in self.room.contents if obj.is_typeclass(BaseNPC, exact=False)]
         self.assertEqual(len(npcs), 1)
         self.assertEqual(npcs[0].db.prototype_key, "basic_merchant")
+
+    def test_reload_spawns_forces_respawn(self):
+        """reload_spawns should trigger force_respawn for each room."""
+        self.script.db.entries = [
+            {"room": 1},
+            {"room": 2},
+        ]
+        with mock.patch.object(self.script, "load_spawn_data"), \
+             mock.patch.object(self.script, "at_start") as mock_start, \
+             mock.patch.object(self.script, "force_respawn") as mock_force:
+            self.script.reload_spawns()
+            mock_start.assert_called_once()
+            mock_force.assert_any_call(1)
+            mock_force.assert_any_call(2)
+            self.assertEqual(mock_force.call_count, 2)


### PR DESCRIPTION
## Summary
- reload spawns across all rooms
- test that reload_spawns calls force_respawn for each room

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6851dbb3e7f4832c941ffe06c0357a2d