### PR TITLE
Add default room option to @forcerespawn

### DIFF
--- a/commands/admin/spawncontrol.py
+++ b/commands/admin/spawncontrol.py
@@ -28,14 +28,22 @@ class CmdForceRespawn(Command):
 
     def func(self):
         arg = self.args.strip()
-        if not arg.isdigit():
-            self.msg("Usage: @forcerespawn <room_vnum>")
-            return
-        room_vnum = int(arg)
         script = ScriptDB.objects.filter(db_key="spawn_manager").first()
         if not script or not hasattr(script, "force_respawn"):
             self.msg("Spawn manager not found.")
             return
+
+        if arg:
+            if not arg.isdigit():
+                self.msg("Usage: @forcerespawn <room_vnum>")
+                return
+            room_vnum = int(arg)
+        else:
+            room_vnum = getattr(self.caller.location.db, "room_id", None)
+            if room_vnum is None:
+                self.msg("Current room has no VNUM.")
+                return
+
         script.force_respawn(room_vnum)
         self.msg(f"Respawn check run for room {room_vnum}.")
 

--- a/world/tests/test_spawncontrol_commands.py
+++ b/world/tests/test_spawncontrol_commands.py
@@ -26,3 +26,17 @@ class TestSpawnControlCommands(TestCase):
             cmd.func()
             script.force_respawn.assert_called_with(5)
             cmd.msg.assert_called_with("Respawn check run for room 5.")
+
+    def test_force_respawn_defaults_to_current_room(self):
+        cmd = CmdForceRespawn()
+        cmd.caller = mock.Mock()
+        cmd.caller.location = mock.Mock()
+        cmd.caller.location.db.room_id = 3
+        cmd.args = ""
+        cmd.msg = mock.Mock()
+        with mock.patch("commands.admin.spawncontrol.ScriptDB") as mock_sdb:
+            script = mock.Mock()
+            mock_sdb.objects.filter.return_value.first.return_value = script
+            cmd.func()
+            script.force_respawn.assert_called_with(3)
+            cmd.msg.assert_called_with("Respawn check run for room 3.")


### PR DESCRIPTION
## Summary
- allow `@forcerespawn` to run without arguments
- test that it calls the script with the caller's location

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6851dbb63484832c95c378fe2e1f8eea