### PR TITLE
Check spawn prototypes against registry

### DIFF
--- a/scripts/spawn_manager.py
+++ b/scripts/spawn_manager.py
@@ -46,6 +46,7 @@ class SpawnManager(Script):
 
         self.db.entries = []
         room_protos = load_all_prototypes("room")
+        npc_registry = prototypes.get_npc_prototypes()
         for proto in room_protos.values():
             spawns = proto.get("spawns") or []
             if not spawns:
@@ -53,6 +54,11 @@ class SpawnManager(Script):
             for entry in spawns:
                 proto_key = entry.get("prototype") or entry.get("proto")
                 if not proto_key:
+                    continue
+                if str(proto_key) not in npc_registry:
+                    logger.log_err(
+                        f"SpawnManager: missing NPC prototype '{proto_key}' for room spawn"
+                    )
                     continue
                 room_loc = entry.get("location") or proto.get("vnum") or proto.get("room_id")
                 data = {

--- a/world/tests/test_spawn_manager.py
+++ b/world/tests/test_spawn_manager.py
@@ -30,3 +30,23 @@ class TestSpawnManager(EvenniaTest):
         npcs = [obj for obj in self.room.contents if obj.is_typeclass(BaseNPC, exact=False)]
         self.assertEqual(len(npcs), 1)
         self.assertEqual(npcs[0].db.prototype_key, "basic_merchant")
+
+    def test_load_spawn_data_skips_missing_proto(self):
+        with mock.patch("utils.prototype_manager.load_all_prototypes") as m_load, \
+             mock.patch("world.prototypes.get_npc_prototypes") as m_npcs, \
+             mock.patch("evennia.utils.logger.log_err") as m_log:
+            m_load.return_value = {
+                1: {
+                    "vnum": 1,
+                    "area": "testarea",
+                    "spawns": [
+                        {"prototype": "valid_proto"},
+                        {"prototype": "missing_proto"},
+                    ],
+                }
+            }
+            m_npcs.return_value = {"valid_proto": {}}
+            self.script.load_spawn_data()
+        self.assertEqual(len(self.script.db.entries), 1)
+        self.assertEqual(self.script.db.entries[0]["prototype"], "valid_proto")
+        m_log.assert_called_once()


### PR DESCRIPTION
## Summary
- verify spawn prototype exists in registry when loading spawn data
- log errors and skip invalid prototypes
- test that invalid spawn entries are ignored

## Testing
- `pytest -q` *(fails: django.db...)*

------
https://chatgpt.com/codex/tasks/task_e_6851dbb4fe90832cbfa878161a8f7b07