### PR TITLE
Add periodic spawn manager test

### DIFF
--- a/typeclasses/tests/test_spawn_manager.py
+++ b/typeclasses/tests/test_spawn_manager.py
@@ -97,3 +97,45 @@ class TestSpawnManager(EvenniaTest):
         self.script.register_room_spawn(self.room_proto)
         self.script.register_room_spawn(self.room_proto)
         self.assertEqual(len(self.script.db.entries), 1)
+
+    def test_periodic_spawn_interval(self):
+        proto = {
+            "vnum": self.room1.db.room_id,
+            "area": "zone",
+            "spawns": [
+                {
+                    "prototype": "goblin",
+                    "max_spawns": 2,
+                    "spawn_interval": 5,
+                    "location": f"#{self.room1.db.room_id}",
+                }
+            ],
+        }
+        with patch("evennia.prototypes.spawner.spawn", side_effect=self._fake_spawn), patch(
+            "evennia.utils.delay",
+            lambda t, func, *a, **kw: None,
+        ), patch(
+            "world.prototypes.get_npc_prototypes",
+            return_value={"goblin": {"key": "goblin"}},
+        ):
+            with patch("scripts.spawn_manager.time.time", return_value=1000):
+                self.script.register_room_spawn(proto)
+                self.script.at_start()
+
+            npc = [o for o in self.room1.contents if o.key == "goblin"][0]
+            npc.delete()
+
+            # interval not reached, no spawn
+            with patch("scripts.spawn_manager.time.time", return_value=1003):
+                self.script.at_repeat()
+            self.assertEqual(len([o for o in self.room1.contents if o.key == "goblin"]), 1)
+
+            # interval reached, should spawn one
+            with patch("scripts.spawn_manager.time.time", return_value=1006):
+                self.script.at_repeat()
+            self.assertEqual(len([o for o in self.room1.contents if o.key == "goblin"]), 2)
+
+            # not enough time since last spawn
+            with patch("scripts.spawn_manager.time.time", return_value=1007):
+                self.script.at_repeat()
+            self.assertEqual(len([o for o in self.room1.contents if o.key == "goblin"]), 2)


### PR DESCRIPTION
## Summary
- test SpawnManager's interval-based spawning

## Testing
- `pytest typeclasses/tests/test_spawn_manager.py::TestSpawnManager::test_periodic_spawn_interval -q` *(fails: no such table)*

------
https://chatgpt.com/codex/tasks/task_e_6851e06d8540832ca9e81ba53cb10b2e