### PR TITLE
Auto respawn on asave changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,9 +376,9 @@ keeps rooms populated accordingly.
 
 Use `@spawnreload` to reload all spawn data from disk. Run
 `@forcerespawn <room_vnum>` to immediately repopulate a specific room,
-and `@showspawns [vnum]` to view the configured entries. After editing a
-room with `redit`, choose **Edit spawns** then call `@spawnreload` so the
-manager notices your changes.
+and `@showspawns [vnum]` to view the configured entries. Room prototypes
+saved through `redit` or with `asave changed` automatically update the
+manager and respawn mobs, so manual reloads are rarely needed.
 
 ## Weapon Creation and Inspection
 

--- a/commands/aedit.py
+++ b/commands/aedit.py
@@ -205,7 +205,7 @@ class CmdAList(Command):
 
 
 class CmdASave(Command):
-    """Save changed areas."""
+    """Save changed areas and refresh room spawns."""
 
     key = "asave"
     locks = "cmd:perm(Builder)"
@@ -236,6 +236,12 @@ class CmdASave(Command):
             for room in rooms:
                 proto = proto_from_room(room)
                 save_prototype("room", proto, vnum=room.db.room_id)
+                from evennia.scripts.models import ScriptDB
+                script = ScriptDB.objects.filter(db_key="spawn_manager").first()
+                if script and hasattr(script, "register_room_spawn"):
+                    script.register_room_spawn(proto)
+                    if hasattr(script, "force_respawn"):
+                        script.force_respawn(room.db.room_id)
                 updated += 1
             update_area(idx, area)
         self.msg(f"All areas saved. {updated} room prototypes updated.")

--- a/typeclasses/tests/test_asave_spawn_manager.py
+++ b/typeclasses/tests/test_asave_spawn_manager.py
@@ -1,0 +1,51 @@
+from unittest.mock import patch, MagicMock
+from django.test import override_settings
+from evennia.utils.test_resources import EvenniaTest
+from commands.admin import BuilderCmdSet
+from typeclasses.rooms import Room
+from world.areas import Area
+from commands import aedit
+
+
+@override_settings(DEFAULT_HOME=None)
+class TestASaveSpawnManager(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.char1.permissions.add("Builder")
+        self.char1.cmdset.add_default(BuilderCmdSet)
+        self.char1.msg = MagicMock()
+
+    @patch("commands.aedit.update_area")
+    @patch("commands.aedit.save_prototype")
+    @patch("commands.aedit.proto_from_room")
+    @patch("commands.aedit.ScriptDB.objects.filter")
+    @patch("commands.aedit.ObjectDB.objects.filter")
+    @patch("commands.aedit.get_areas")
+    def test_spawn_manager_called(
+        self,
+        mock_get_areas,
+        mock_obj_filter,
+        mock_script_filter,
+        mock_proto,
+        mock_save,
+        mock_update,
+    ):
+        room = self.room1
+        room.db.area = "zone"
+        room.db.room_id = 1
+        area = Area(key="zone", start=1, end=1, rooms=[1])
+        mock_get_areas.return_value = [area]
+        mock_obj_filter.return_value = [room]
+        proto = {"vnum": room.db.room_id}
+        mock_proto.return_value = proto
+        mock_script = MagicMock()
+        mock_script_filter.return_value.first.return_value = mock_script
+
+        cmd = aedit.CmdASave()
+        cmd.caller = self.char1
+        cmd.session = self.char1.sessions.get()
+        cmd.args = "changed"
+        cmd.func()
+
+        mock_script.register_room_spawn.assert_called_with(proto)
+        mock_script.force_respawn.assert_called_with(room.db.room_id)


### PR DESCRIPTION
## Summary
- trigger spawn manager updates during `asave changed`
- document automatic spawn refresh
- test respawn behaviour with mocked ScriptDB

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*
- `scripts/setup_test_env.sh` *(fails to install dependencies due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6851e4ce18e8832caa6ec90dc87028ad