### PR TITLE
Ensure corpse decay script persists

### DIFF
--- a/typeclasses/objects.py
+++ b/typeclasses/objects.py
@@ -460,6 +460,14 @@ class Corpse(Object):
         super().at_object_post_creation()
         name = self.db.corpse_of or self.key or "someone"
         self.db.desc = f"The corpse of {name} lies here."
+        decay = self.db.decay_time
+        if decay and not self.scripts.get("corpse_decay"):
+            self.scripts.add(
+                "typeclasses.scripts.CorpseDecayScript",
+                key="corpse_decay",
+                interval=int(decay) * 60,
+                start_delay=True,
+            )
 
     def get_display_name(self, looker, **kwargs):
         name = self.db.corpse_of or self.key or "corpse"

--- a/utils/tests/test_mob_utils.py
+++ b/utils/tests/test_mob_utils.py
@@ -8,6 +8,7 @@ from utils.mob_utils import (
     add_to_mlist,
     auto_calc,
     auto_calc_secondary,
+    make_corpse,
 )
 from world.scripts.mob_db import get_mobdb
 from world.system import stat_manager
@@ -37,3 +38,14 @@ class TestMobUtils(EvenniaTest):
         self.assertEqual(derived["HP"], expected_hp)
         sec = auto_calc_secondary(prims)
         self.assertNotIn("HP", sec)
+
+    def test_make_corpse_adds_decay_script(self):
+        from evennia.utils import create
+        from typeclasses.characters import NPC
+
+        npc = create.create_object(NPC, key="mob", location=self.room1)
+        npc.db.corpse_decay_time = 1
+
+        corpse = make_corpse(npc)
+        script = corpse.scripts.get("corpse_decay")[0]
+        self.assertEqual(script.interval, 60)


### PR DESCRIPTION
## Summary
- verify `decay_time` when a corpse loads
- start corpse decay script if missing
- test that `make_corpse` attaches the decay script

## Testing
- `evennia migrate`
- `pytest utils/tests/test_mob_utils.py::TestMobUtils::test_make_corpse_adds_decay_script -q` *(fails: OperationalError or missing objects)*

------
https://chatgpt.com/codex/tasks/task_e_6851e85a24b4832c9731a072d1b66fbc