### PR TITLE
Improve spawn manager room caching

### DIFF
--- a/commands/admin/resetworld.py
+++ b/commands/admin/resetworld.py
@@ -22,9 +22,11 @@ class CmdResetWorld(Command):
         for key in areas:
             for entry in script.db.entries:
                 if entry.get("area") == key:
-                    rid = entry.get("room")
-                    if isinstance(rid, str) and rid.isdigit():
-                        rid = int(rid)
+                    rid = entry.get("room_id")
+                    if rid is None:
+                        rid = entry.get("room")
+                        if isinstance(rid, str) and rid.isdigit():
+                            rid = int(rid)
                     script.force_respawn(rid)
         self.msg(f"World reset complete. [{len(areas)}] areas repopulated.")
 

--- a/commands/admin/spawncontrol.py
+++ b/commands/admin/spawncontrol.py
@@ -75,7 +75,7 @@ class CmdShowSpawns(Command):
 
         lines = []
         for entry in script.db.entries:
-            if script._normalize_room_id(entry.get("room")) != target_vnum:
+            if script._normalize_room_id(entry) != target_vnum:
                 continue
 
             obj = script._get_room(entry)

--- a/commands/areas.py
+++ b/commands/areas.py
@@ -551,9 +551,11 @@ class CmdAreasReset(Command):
             return
         for entry in script.db.entries:
             if entry.get("area") == area.key.lower():
-                rid = entry.get("room")
-                if isinstance(rid, str) and rid.isdigit():
-                    rid = int(rid)
+                rid = entry.get("room_id")
+                if rid is None:
+                    rid = entry.get("room")
+                    if isinstance(rid, str) and rid.isdigit():
+                        rid = int(rid)
                 script.force_respawn(rid)
         self.msg(f"Spawn entries reset for {area.key}.")
 

--- a/world/area_reset.py
+++ b/world/area_reset.py
@@ -21,8 +21,10 @@ class AreaReset(DefaultScript):
                 if script and hasattr(script, "force_respawn"):
                     for entry in script.db.entries:
                         if entry.get("area") == area.key.lower():
-                            rid = entry.get("room")
-                            if isinstance(rid, str) and rid.isdigit():
-                                rid = int(rid)
+                            rid = entry.get("room_id")
+                            if rid is None:
+                                rid = entry.get("room")
+                                if isinstance(rid, str) and rid.isdigit():
+                                    rid = int(rid)
                             script.force_respawn(rid)
             update_area(idx, area)

--- a/world/tests/test_showspawns_command.py
+++ b/world/tests/test_showspawns_command.py
@@ -13,6 +13,7 @@ class TestShowSpawns(TestCase):
         script.db.entries = [{"room": "#1", "prototype": "goblin", "max_count": 2, "respawn_rate": 30}]
         script._get_room.return_value = cmd.caller.location
         script._live_count.return_value = 1
+        script._normalize_room_id.return_value = 1
         with mock.patch("commands.admin.spawncontrol.ScriptDB") as mock_sdb:
             mock_sdb.objects.filter.return_value.first.return_value = script
             cmd.func()


### PR DESCRIPTION
## Summary
- normalize spawn entries with `room_id`
- cache resolved room object in spawn entries
- update spawn control commands for `room_id`
- add tests for room lookup caching

## Testing
- `pytest world/tests/test_showspawns_command.py::TestShowSpawns::test_entries_exist world/tests/test_spawn_manager.py::TestGetRoomCaching::test_get_room_caches_result -q`

------
https://chatgpt.com/codex/tasks/task_e_6851ec46479c832c8191549500dddcd2