### PR TITLE
Add SpawnManager caching and batch tests

### DIFF
--- a/world/tests/conftest.py
+++ b/world/tests/conftest.py
@@ -1,0 +1,15 @@
+import pytest
+import types
+
+@pytest.fixture(autouse=True)
+def mock_timers(monkeypatch):
+    """Provide deterministic timers for spawn manager tests."""
+    counter = {"t": 0}
+
+    def fake_time():
+        counter["t"] += 1
+        return counter["t"]
+
+    monkeypatch.setattr("scripts.spawn_manager.time.time", fake_time)
+    yield
+

--- a/world/tests/test_spawn_manager.py
+++ b/world/tests/test_spawn_manager.py
@@ -139,3 +139,50 @@ class TestSpawnManager(EvenniaTest):
             self.script._spawn("orc", self.room)
 
         self.assertEqual(m_fin.call_count, 1)
+
+    def test_get_room_caches_lookup(self):
+        entry = {"room": "#1"}
+        fake_room = mock.Mock(dbref="#1")
+        with mock.patch(
+            "scripts.spawn_manager.ObjectDB.objects.filter"
+        ) as m_filter:
+            m_filter.return_value.first.return_value = fake_room
+            room1 = self.script._get_room(entry)
+            room2 = self.script._get_room(entry)
+        self.assertIs(room1, fake_room)
+        self.assertIs(room2, fake_room)
+        self.assertIs(entry["room"], fake_room)
+        m_filter.assert_called_once()
+
+    def test_batch_processing_spawns_by_tick(self):
+        self.script.db.batch_size = 2
+        self.script.db.entries = [
+            {
+                "prototype": "a",
+                "room": self.room,
+                "max_count": 1,
+                "respawn_rate": 5,
+                "last_spawn": 0,
+            },
+            {
+                "prototype": "b",
+                "room": self.room,
+                "max_count": 1,
+                "respawn_rate": 5,
+                "last_spawn": 0,
+            },
+        ]
+        with mock.patch.object(self.script, "_spawn") as m_spawn, mock.patch(
+            "scripts.spawn_manager.time.time",
+            return_value=10,
+        ):
+            self.script.at_repeat()
+        m_spawn.assert_called_once_with("a", self.room)
+
+        m_spawn.reset_mock()
+        with mock.patch(
+            "scripts.spawn_manager.time.time",
+            return_value=10,
+        ):
+            self.script.at_repeat()
+        m_spawn.assert_called_once_with("b", self.room)


### PR DESCRIPTION
## Summary
- cache rooms in `_get_room` to avoid repeat lookups
- process spawn entries in batches using `batch_size`
- ensure deterministic timers for tests
- add caching and batching tests for the spawn manager

## Testing
- `pytest world/tests/test_spawn_manager.py::TestSpawnManager::test_get_room_caches_lookup -q` *(fails: OperationalError: no such table)*

------
https://chatgpt.com/codex/tasks/task_e_6851ec4a33c4832c9aa06f4cda4468e6