### PR TITLE
Fix spawn_manager room lookup for dbrefs

### DIFF
--- a/scripts/spawn_manager.py
+++ b/scripts/spawn_manager.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List
 from evennia.prototypes import spawner
 from evennia.objects.models import ObjectDB
 from evennia.utils import logger, search
+from typeclasses.rooms import Room
 
 from typeclasses.scripts import Script
 from utils.mob_proto import apply_proto_items, spawn_from_vnum
@@ -157,7 +158,7 @@ class SpawnManager(Script):
         rid = entry.get("room_id")
         if isinstance(room, str) and room.startswith("#") and room[1:].isdigit():
             obj = ObjectDB.objects.filter(id=int(room[1:])).first()
-            if obj:
+            if obj and obj.is_typeclass(Room, exact=False):
                 entry["room"] = obj
                 return obj
             if rid is None:


### PR DESCRIPTION
## Summary
- only return a room in `_get_room` if the dbref points at a Room
- adjust caching test for added check
- add regression test for falling back to room_id when dbref isn't a room

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6851f50b3ab8832c88755cc4587eaa74