### PR TITLE
Change spawn location to numeric

### DIFF
--- a/commands/redit.py
+++ b/commands/redit.py
@@ -426,7 +426,7 @@ def _handle_spawn_cmd(caller, raw_string, **kwargs):
                     "prototype": proto_key,
                     "max_spawns": maxc,
                     "spawn_interval": rate,
-                    "location": f"#{caller.ndb.current_vnum}",
+                    "location": caller.ndb.current_vnum,
                 }
             )
         return "menunode_spawns"

--- a/typeclasses/tests/test_redit_spawns.py
+++ b/typeclasses/tests/test_redit_spawns.py
@@ -33,7 +33,7 @@ class TestReditSpawns(EvenniaTest):
             "prototype": "goblin",
             "max_spawns": 2,
             "spawn_interval": 10,
-            "location": "#5",
+            "location": 5,
         })
         self.char1.ndb.room_protos[5] = proto
 


### PR DESCRIPTION
## Summary
- store numeric room vnum when adding spawn entries via redit
- adjust spawn tests to expect integer `location`

## Testing
- `pytest typeclasses/tests/test_redit_spawns.py::TestReditSpawns::test_spawn_edit_keeps_exits -q` *(fails: django.db.utils.OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6851f5127f64832ca0a22b270e33de67