### PR TITLE
Improve spawn manager interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,8 @@ Edit
 "spawns": [
   {"proto": "mob_goblin", "max_spawns": 2, "spawn_interval": 300}
 ]
-SpawnManager checks only those rooms and spreads load using batch_size. Use:
+SpawnManager automatically registers spawns when a room prototype is saved. If
+spawns appear to be missing (for example after a server restart), use:
 
 bash
 Copy

--- a/scripts/spawn_manager.py
+++ b/scripts/spawn_manager.py
@@ -19,7 +19,8 @@ class SpawnManager(Script):
     def at_script_creation(self):
         self.key = "spawn_manager"
         self.desc = "Handles mob respawning for rooms"
-        self.interval = 60
+        # run frequently so short spawn intervals are respected
+        self.interval = 5
         self.persistent = True
         self.db.entries = self.db.entries or []
         self.db.batch_size = self.db.batch_size or 1

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -1180,7 +1180,8 @@ Examples:
     @spawnreload
 
 Notes:
-    - Run this after editing room spawns so the SpawnManager picks up the changes.
+    - Room spawns are automatically registered when prototypes are saved. Use
+      this command if spawns fail to appear or after manually editing files.
 """,
     },
     {
@@ -1236,7 +1237,8 @@ This describes how to make NPCs automatically appear in a room.
 2. Save the prototype with a VNUM.
 3. Use |wredit <room_vnum>|n and choose |wEdit spawns|n to add the prototype,
    max count and respawn interval.
-4. Save the room prototype and run |w@spawnreload|n or |wasave changed|n.
+4. Save the room prototype. Spawns are registered automatically, but you can
+   use |w@spawnreload|n or |wasave changed|n to refresh them manually.
 5. Check spawns with |w@showspawns <room_vnum>|n.
 """,
     },


### PR DESCRIPTION
## Summary
- spawn manager checks more frequently for short intervals
- update documentation to clarify automatic spawn registration

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6851fcf9cd78832c8c5b21e1a67c7c48