### PR TITLE
Check room type on spawn search

### DIFF
--- a/scripts/spawn_manager.py
+++ b/scripts/spawn_manager.py
@@ -174,9 +174,10 @@ class SpawnManager(Script):
             return obj
         objs = search.search_object(room)
         obj = objs[0] if objs else None
-        if obj:
+        if obj and obj.is_typeclass(Room, exact=False):
             entry["room"] = obj
-        return obj
+            return obj
+        return None
 
     def _live_count(self, proto: Any, room: Any) -> int:
         return len([

--- a/world/tests/test_spawn_manager.py
+++ b/world/tests/test_spawn_manager.py
@@ -194,3 +194,15 @@ class TestSpawnManager(EvenniaTest):
             self.script.force_respawn(1)
 
         self.assertEqual(npc.location, self.room)
+
+    def test_get_room_ignores_nonroom_search_result(self):
+        entry = {"room": "fake"}
+        fake_obj = mock.Mock()
+        fake_obj.is_typeclass.return_value = False
+        with mock.patch(
+            "scripts.spawn_manager.search.search_object",
+            return_value=[fake_obj],
+        ):
+            room = self.script._get_room(entry)
+        self.assertIsNone(room)
+        self.assertEqual(entry["room"], "fake")


### PR DESCRIPTION
## Summary
- validate rooms returned by `search_object` in `SpawnManager._get_room`
- add unit test ensuring non-room objects are ignored

## Testing
- `pytest -q` *(fails: OperationalError - no such table: accounts_accountdb)*


------
https://chatgpt.com/codex/tasks/task_e_685200c8625c832c82136dded74f184e