### PR TITLE
Unify corpse and object decay

### DIFF
--- a/typeclasses/objects.py
+++ b/typeclasses/objects.py
@@ -27,6 +27,7 @@ from utils.currency import COIN_VALUES
 from commands.interact import GatherCmdSet
 from world.system import stat_manager
 from utils import normalize_slot
+from django.conf import settings
 
 
 class ObjectParent:
@@ -450,10 +451,11 @@ class Corpse(Object):
         if (decay := self.db.decay_time):
             # start auto-decay timer in minutes
             self.scripts.add(
-                "typeclasses.scripts.CorpseDecayScript",
-                key="corpse_decay",
+                "typeclasses.scripts.DecayScript",
+                key="decay",
                 interval=int(decay) * 60,
                 start_delay=True,
+                room_only=not settings.ALLOW_CORPSE_DECAY_IN_INVENTORY,
             )
 
     def at_object_post_creation(self):
@@ -461,12 +463,13 @@ class Corpse(Object):
         name = self.db.corpse_of or self.key or "someone"
         self.db.desc = f"The corpse of {name} lies here."
         decay = self.db.decay_time
-        if decay and not self.scripts.get("corpse_decay"):
+        if decay and not self.scripts.get("decay"):
             self.scripts.add(
-                "typeclasses.scripts.CorpseDecayScript",
-                key="corpse_decay",
+                "typeclasses.scripts.DecayScript",
+                key="decay",
                 interval=int(decay) * 60,
                 start_delay=True,
+                room_only=not settings.ALLOW_CORPSE_DECAY_IN_INVENTORY,
             )
 
     def get_display_name(self, looker, **kwargs):

--- a/typeclasses/tests/test_combat_engine.py
+++ b/typeclasses/tests/test_combat_engine.py
@@ -372,7 +372,7 @@ class TestCombatDeath(EvenniaTest):
             for obj in self.room1.contents
             if obj.is_typeclass("typeclasses.objects.Corpse", exact=False)
         )
-        script = corpse.scripts.get("corpse_decay")[0]
+        script = corpse.scripts.get("decay")[0]
         self.assertEqual(script.interval, 60)
         script.at_repeat()
         self.assertNotIn(corpse, self.room1.contents)

--- a/utils/tests/test_mob_utils.py
+++ b/utils/tests/test_mob_utils.py
@@ -47,5 +47,5 @@ class TestMobUtils(EvenniaTest):
         npc.db.corpse_decay_time = 1
 
         corpse = make_corpse(npc)
-        script = corpse.scripts.get("corpse_decay")[0]
+        script = corpse.scripts.get("decay")[0]
         self.assertEqual(script.interval, 60)


### PR DESCRIPTION
## Summary
- consolidate AutoDecayScript and CorpseDecayScript into DecayScript
- use DecayScript for corpse objects
- update tests for new script name

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_685200ce135c832caea3491c8236285d