### PR TITLE
Handle unsaved fighters in combat

### DIFF
--- a/combat/engine/turn_manager.py
+++ b/combat/engine/turn_manager.py
@@ -29,6 +29,8 @@ class TurnManager:
     def add_participant(self, actor: object) -> None:
         if hasattr(actor, "db") and getattr(actor, "pk", None) is not None:
             actor.db.in_combat = True
+        else:
+            setattr(actor, "in_combat", True)
         self.participants.append(CombatParticipant(actor=actor))
         if hasattr(actor, "ndb"):
             actor.ndb.combat_engine = self.engine
@@ -41,6 +43,8 @@ class TurnManager:
 
         if hasattr(actor, "db") and getattr(actor, "pk", None) is not None:
             actor.db.in_combat = False
+        else:
+            setattr(actor, "in_combat", False)
         if hasattr(actor, "on_exit_combat"):
             actor.on_exit_combat()
         if hasattr(actor, "ndb") and hasattr(actor.ndb, "combat_engine"):

--- a/typeclasses/tests/test_unsaved_round_manager.py
+++ b/typeclasses/tests/test_unsaved_round_manager.py
@@ -1,0 +1,40 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+from combat.round_manager import CombatRoundManager, CombatInstance
+from combat.engine import CombatEngine
+
+class Dummy:
+    def __init__(self, hp=10):
+        self.hp = hp
+        self.location = MagicMock()
+        self.traits = MagicMock()
+        self.traits.get.return_value = MagicMock(value=0)
+        self.traits.health = MagicMock(value=hp, max=hp)
+        self.db = type("DB", (), {"temp_bonuses": {}, "experience": 0, "tnl": 0, "level": 1})()
+        self.on_enter_combat = MagicMock()
+        self.on_exit_combat = MagicMock()
+        self.msg = MagicMock()
+
+class UnsavedDummy(Dummy):
+    class FakeDB:
+        def __setattr__(self, name, value):
+            raise AttributeError("unsaved object")
+
+    def __init__(self, hp=10):
+        super().__init__(hp)
+        self.pk = None
+        self.db = self.FakeDB()
+
+class TestUnsavedRoundManager(unittest.TestCase):
+    def test_unsaved_fighter_keeps_combat_alive(self):
+        player = Dummy()
+        npc = UnsavedDummy()
+        manager = CombatRoundManager.get()
+        manager.combats.clear()
+        manager.combatant_to_combat.clear()
+        with patch.object(CombatInstance, "_schedule_tick"), patch.object(CombatEngine, "process_round"):
+            inst = manager.create_combat([player, npc])
+            inst._tick()
+        self.assertFalse(inst.combat_ended)
+        self.assertTrue(getattr(npc, "in_combat", False))


### PR DESCRIPTION
## Summary
- handle missing persistent attributes for fighters
- mark unsaved fighters active when added or removed
- test unsaved fighters staying in combat

## Testing
- `pytest typeclasses/tests/test_unsaved_round_manager.py -q`
- `pytest -q` *(fails: 336 failed, 11 passed, 2 warnings, 1 error)*

------
https://chatgpt.com/codex/tasks/task_e_68520635dde8832ca8924dd0454dfb9a