### PR TITLE
Handle npc death cleanup

### DIFF
--- a/combat/engine/damage_processor.py
+++ b/combat/engine/damage_processor.py
@@ -161,6 +161,7 @@ class DamageProcessor:
             should_remove = (
                 getattr(actor, "location", None) is None
                 or hp <= 0
+                or getattr(getattr(actor, "db", None), "is_dead", False)
                 or (target is None and not participant.next_action)
             )
             if should_remove:

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -1137,6 +1137,7 @@ class NPC(Character):
             return
         self.db._dead = True
         self.db.dead = True
+        self.db.is_dead = True
 
         # remove from combat if necessary. The combat script may have been
         # cleaned up already, so verify it before using it.
@@ -1182,6 +1183,7 @@ class NPC(Character):
         if attacker and getattr(attacker.db, "combat_target", None) is self:
             attacker.db.combat_target = None
 
+        self.location = None
         self.delete()
 
     # property to mimic weapons


### PR DESCRIPTION
## Summary
- add is_dead flag and clear location before deletion in NPC.on_death
- ignore dead actors in combat cleanup
- test npc death cleanup and damage processor

## Testing
- `pytest typeclasses/tests/test_combat_engine.py::TestCombatDeath::test_npc_on_death_sets_flag_and_moves_out -q` *(fails: no such table: accounts_accountdb)*
- `pytest typeclasses/tests/test_combat_engine.py::TestCleanupEnvironment::test_cleanup_removes_dead_actor -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68520c92b4e4832cb63d49f16914ea2d