### PR TITLE
Handle dead NPC visibility

### DIFF
--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -127,9 +127,12 @@ class RoomParent(ObjectParent):
         text += f"\n{self.get_display_exits(looker)}"
 
         visible = [
-            obj for obj in self.contents
-            if obj != looker and obj.access(looker, "view")
+            obj
+            for obj in self.contents
+            if obj != looker
+            and obj.access(looker, "view")
             and (not hasattr(looker, "can_see") or looker.can_see(obj))
+            and not getattr(obj.db, "is_dead", False)
         ]
 
         characters = [

--- a/typeclasses/tests/test_look_command.py
+++ b/typeclasses/tests/test_look_command.py
@@ -24,3 +24,18 @@ class TestLookCommand(EvenniaTest):
 
         self.char1.execute_cmd("look slime-2")
         self.char1.msg.assert_any_call(slime2.return_appearance(self.char1))
+
+    def test_dead_npc_hidden_in_room_contents(self):
+        from typeclasses.objects import Corpse
+
+        npc = create.create_object(BaseNPC, key="orc", location=self.room1)
+        corpse = create.create_object(Corpse, key="orc corpse", location=self.room1)
+        corpse.db.corpse_of = npc.key
+        npc.db.is_dead = True
+
+        self.char1.execute_cmd("look")
+        output = " ".join(
+            str(arg) for call in self.char1.msg.call_args_list for arg in call.args
+        )
+        self.assertIn(corpse.get_display_name(self.char1), output)
+        self.assertNotIn(npc.get_display_name(self.char1), output)


### PR DESCRIPTION
## Summary
- hide NPCs marked `is_dead` in room descriptions
- test that only the corpse is shown after a death

## Testing
- `evennia migrate`
- `pytest typeclasses/tests/test_look_command.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68520c98e770832c9d029e77149882c9