### PR TITLE
Fix look for dead objects

### DIFF
--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -132,7 +132,8 @@ class RoomParent(ObjectParent):
             if obj != looker
             and obj.access(looker, "view")
             and (not hasattr(looker, "can_see") or looker.can_see(obj))
-            and not getattr(obj.db, "is_dead", False)
+            and not getattr(obj.db, "dead", False)
+            and not getattr(obj.db, "_dead", False)
         ]
 
         characters = [

--- a/typeclasses/tests/test_look_command.py
+++ b/typeclasses/tests/test_look_command.py
@@ -31,7 +31,7 @@ class TestLookCommand(EvenniaTest):
         npc = create.create_object(BaseNPC, key="orc", location=self.room1)
         corpse = create.create_object(Corpse, key="orc corpse", location=self.room1)
         corpse.db.corpse_of = npc.key
-        npc.db.is_dead = True
+        npc.db.dead = True
 
         self.char1.execute_cmd("look")
         output = " ".join(


### PR DESCRIPTION
## Summary
- hide dead objects in room descriptions
- update look command test for dead NPC filtering

## Testing
- `evennia migrate`
- `pytest typeclasses/tests/test_look_command.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68520f4fe838832cb5e7dccd2d62e3a5