### PR TITLE
Clarify test setup requirements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,8 @@ python -m pip install --upgrade pip
 pip install -r requirements-test.txt
 pip install -e .
 ```
+Running `pytest` before installing these packages will lead to test
+collection errors because Django and Evennia cannot be imported.
 
 You can run `scripts/setup_test_env.sh` to perform these commands
 automatically. Once everything is installed, run the tests with:

--- a/README.md
+++ b/README.md
@@ -212,6 +212,8 @@ Copy
 Edit
 pip install -r requirements-test.txt
 pip install -e .
+If these packages are not installed before running `pytest`, test collection
+will fail with import errors for Django/Evennia.
 Then run:
 
 bash


### PR DESCRIPTION
## Summary
- document that installing test requirements and Evennia is necessary
- mention import failures if Django/Evennia aren't installed

## Testing
- `pytest -q` *(fails: django import error)*

------
https://chatgpt.com/codex/tasks/task_e_68520f5ad3dc832c98bd67816d3380c5