### PR TITLE
Improve NPC death handling

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -1148,7 +1148,12 @@ class NPC(Character):
             if inst:
                 inst.remove_combatant(self)
 
-        corpse = self.drop_loot(attacker)
+        corpse = None
+        try:
+            corpse = self.drop_loot(attacker)
+        except Exception as err:  # pragma: no cover - log errors
+            logger.log_err(f"Loot drop error on {self}: {err}")
+
         if corpse:
             corpse.location = self.location
 


### PR DESCRIPTION
## Summary
- prevent NPC death from halting on loot drop failures

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: django)*

------
https://chatgpt.com/codex/tasks/task_e_68521ced7d70832c8dabd94b2845c20e