### PR TITLE
Fix midgard area creation

### DIFF
--- a/world/scripts/create_midgard_area.py
+++ b/world/scripts/create_midgard_area.py
@@ -1,6 +1,6 @@
-from evennia import create_object, search_object
+from evennia import create_object
+from evennia.objects.models import ObjectDB
 from typeclasses.rooms import Room
-from typeclasses.exits import Exit
 from utils.prototype_manager import load_all_prototypes
 
 
@@ -11,15 +11,33 @@ def create():
     rooms = {}
     for proto in midgard:
         vnum = int(proto.get("room_id"))
-        if search_object(f"#{vnum}"):
-            rooms[vnum] = search_object(f"#{vnum}")[0]
+        objs = ObjectDB.objects.filter(
+            db_attributes__db_key="room_id", db_attributes__db_value=vnum
+        )
+        room_obj = None
+        for obj in objs:
+            if obj.is_typeclass(Room, exact=False):
+                room_obj = obj
+                break
+        if room_obj:
+            rooms[vnum] = room_obj
             continue
-        obj = create_object(proto.get("typeclass", Room), key=proto.get("key"))
+
+        obj = create_object(
+            proto.get("typeclass", Room), key=proto.get("key"), nohome=True
+        )
         obj.db.desc = proto.get("desc", "")
-        obj.db.vnum = vnum
+        obj.db.room_id = vnum
         obj.db.area = proto.get("area")
         if proto.get("xyz"):
             obj.db.xyz = proto["xyz"]
+        for tag in proto.get("tags", []):
+            if isinstance(tag, (list, tuple)) and len(tag) >= 1:
+                name = tag[0]
+                category = tag[1] if len(tag) > 1 else None
+                obj.tags.add(name, category=category)
+            else:
+                obj.tags.add(tag)
         rooms[vnum] = obj
     # create exits
     for proto in midgard:
@@ -31,6 +49,7 @@ def create():
             dest = rooms.get(int(dest_vnum))
             if not dest:
                 continue
-            if not room.exits.get(dir_name):
-                create_object(Exit, key=dir_name, location=room, destination=dest)
+            room.db.exits = room.db.exits or {}
+            if dir_name not in room.db.exits:
+                room.db.exits[dir_name] = dest
 

--- a/world/tests/test_midgard_area.py
+++ b/world/tests/test_midgard_area.py
@@ -1,8 +1,14 @@
+from unittest import mock
+from django.test import override_settings
+
+from evennia.objects.models import ObjectDB
 from evennia.utils.test_resources import EvenniaTest
+from typeclasses.rooms import Room
 from world.areas import find_area_by_vnum
 from utils.prototype_manager import load_prototype
 
 
+@override_settings(DEFAULT_HOME=None)
 class TestMidgardArea(EvenniaTest):
     def test_lookup_midgard(self):
         area = find_area_by_vnum(200050)
@@ -11,3 +17,39 @@ class TestMidgardArea(EvenniaTest):
     def test_load_room_prototype(self):
         proto = load_prototype("room", 200070)
         assert proto and proto.get("area") == "midgard"
+
+    def test_create_and_teleport(self):
+        from commands.building import CmdTeleport
+        from world.scripts import create_midgard_area
+        proto = {
+            200050: {
+                "room_id": 200050,
+                "key": "Midgard Square",
+                "typeclass": "typeclasses.rooms.Room",
+                "area": "midgard",
+                "exits": {},
+            }
+        }
+        with mock.patch(
+            "world.scripts.create_midgard_area.load_all_prototypes",
+            return_value=proto,
+        ):
+            create_midgard_area.create()
+
+        cmd = CmdTeleport()
+        cmd.caller = self.char1
+        cmd.caller.location = self.room1
+        cmd.args = "200050"
+        cmd.msg = mock.Mock()
+        cmd.func()
+
+        objs = ObjectDB.objects.filter(
+            db_attributes__db_key="room_id", db_attributes__db_value=200050
+        )
+        target = None
+        for obj in objs:
+            if obj.is_typeclass(Room, exact=False):
+                target = obj
+                break
+        assert target
+        assert self.char1.location == target


### PR DESCRIPTION
## Summary
- create Midgard rooms using room_id query
- copy prototype tags, store exits and room_id on rooms
- add test for spawning rooms via create_midgard_area

## Testing
- `pytest world/tests/test_midgard_area.py::TestMidgardArea::test_create_and_teleport -q`

------
https://chatgpt.com/codex/tasks/task_e_685227ffa9bc832ca8f5431438960116