### PR TITLE
Fix long vnum lists overflowing

### DIFF
--- a/commands/aedit.py
+++ b/commands/aedit.py
@@ -1,4 +1,5 @@
 from evennia.utils.evtable import EvTable
+import textwrap
 from evennia import CmdSet
 from evennia.objects.models import ObjectDB
 from evennia.server.models import ServerConfig
@@ -189,11 +190,14 @@ class CmdAList(Command):
                 area._temp_room_ids = room_ids
 
             spawn_count = spawn_counts.get(area.key.lower(), 0)
+            vnum_text = ", ".join(str(r) for r in room_ids) if room_ids else "-"
+            if vnum_text != "-":
+                vnum_text = textwrap.shorten(vnum_text, width=60, placeholder="...")
             table.add_row(
                 area.key,
                 f"{area.start}-{area.end}",
                 str(room_count),
-                ", ".join(str(r) for r in room_ids) if room_ids else "-",
+                vnum_text,
                 str(mob_count),
                 str(spawn_count),
                 ", ".join(area.builders),

--- a/typeclasses/tests/test_alist_command.py
+++ b/typeclasses/tests/test_alist_command.py
@@ -70,6 +70,20 @@ class TestAListCommand(EvenniaTest):
         self.assertEqual(cols[3], "1, 2, 3")
         self.assertEqual(cols[4], "1")
 
+    @patch("commands.aedit.ObjectDB.objects.filter", return_value=[])
+    @patch("commands.aedit.get_areas")
+    @patch("commands.aedit.area_npcs.get_area_npc_list")
+    def test_vnums_truncated(self, mock_npcs, mock_get_areas, mock_filter):
+        area = Area(key="zone", start=1, end=100, rooms=list(range(1, 30)))
+        mock_get_areas.return_value = [area]
+        mock_npcs.return_value = []
+        self.char1.execute_cmd("alist")
+        out = self.char1.msg.call_args[0][0]
+        row = next(line for line in out.splitlines() if line.startswith("| zone"))
+        cols = [c.strip() for c in row.split("|")[1:-1]]
+        self.assertLessEqual(len(cols[3]), 60)
+        self.assertTrue(cols[3].endswith("..."))
+
     def test_current(self):
         self.char1.location = self.room1
         self.char1.execute_cmd("alist current")


### PR DESCRIPTION
## Summary
- show vnums in area listing without overflowing the column
- test that long vnum lists are truncated to 60 chars

## Testing
- `pytest typeclasses/tests/test_alist_command.py::TestAListCommand::test_vnums_truncated -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_685228007f78832cbab72e6ec86fe7af