### PR TITLE
Auto-populate Midgard area on startup

### DIFF
--- a/server/conf/at_server_startstop.py
+++ b/server/conf/at_server_startstop.py
@@ -24,6 +24,7 @@ from evennia.utils import logger
 from evennia.server.models import ServerConfig
 from utils.prototype_manager import load_all_prototypes
 from utils.script_utils import resume_paused_scripts
+from world.scripts import create_midgard_area
 
 
 _PROTOTYPE_CACHE = {}
@@ -185,6 +186,16 @@ def at_server_start():
 
     _build_caches()
     _ensure_room_areas()
+    from typeclasses.rooms import Room
+    if not (
+        Room.objects.filter(db_tags__db_key__iexact="midgard").exists()
+        or Room.objects.filter(
+            db_attributes__db_key="area",
+            db_attributes__db_strvalue__iexact="midgard",
+        ).exists()
+    ):
+        create_midgard_area.create()
+        logger.log_info("Populated Midgard area")
     resume_paused_scripts()
     ServerConfig.objects.conf("server_start_time", time.time())
 


### PR DESCRIPTION
## Summary
- import `world.scripts.create_midgard_area`
- when starting the server, create Midgard rooms from prototypes if none exist

## Testing
- `pytest -q` *(fails: AttributeError 'NoneType' object has no attribute 'CharacterCmdSet')*

------
https://chatgpt.com/codex/tasks/task_e_68522fe4e10c832ca541c12636c1916b