### PR TITLE
Add Midgard init builder command

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Copy
 Edit
 ic
 batchcmd initial_build
-py world.scripts.create_midgard_area.create()
+@initmidgard
 This populates rooms 200050-200150 so @teleport works.
 Creating NPCs
 Use:

--- a/commands/admin/__init__.py
+++ b/commands/admin/__init__.py
@@ -16,6 +16,7 @@ from ..building import (
     CmdRemoveFlag,
     CmdDelDir,
     CmdDelRoom,
+    CmdInitMidgard,
 )
 from world.stats import CORE_STAT_KEYS, ALL_STATS
 from world.system import stat_manager
@@ -1436,6 +1437,7 @@ class BuilderCmdSet(CmdSet):
         self.add(CmdRemoveFlag)
         self.add(CmdDelDir)
         self.add(CmdDelRoom)
+        self.add(CmdInitMidgard)
         self.add(CmdCNPC)
         self.add(CmdEditNPC)
         self.add(CmdDeleteNPC)

--- a/commands/building.py
+++ b/commands/building.py
@@ -700,3 +700,19 @@ class CmdRemoveFlag(Command):
         else:
             self.msg("Flag not set.")
 
+
+class CmdInitMidgard(Command):
+    """Create rooms and exits for the Midgard area."""
+
+    key = "@initmidgard"
+    locks = "cmd:perm(Admin) or perm(Builder)"
+    help_category = "Building"
+
+    def func(self):
+        from world.scripts import create_midgard_area
+
+        rooms_created, exits_created = create_midgard_area.create()
+        self.msg(
+            f"Midgard initialized: {rooms_created} rooms and {exits_created} exits created."
+        )
+

--- a/world/scripts/create_midgard_area.py
+++ b/world/scripts/create_midgard_area.py
@@ -4,11 +4,19 @@ from typeclasses.rooms import Room
 from utils.prototype_manager import load_all_prototypes
 
 
-def create():
-    """Instantiate Midgard rooms and their exits if missing."""
+def create() -> tuple[int, int]:
+    """Instantiate Midgard rooms and their exits if missing.
+
+    Returns
+    -------
+    tuple[int, int]
+        Number of rooms created and exits created.
+    """
     prototypes = load_all_prototypes("room")
     midgard = [p for p in prototypes.values() if p.get("area") == "midgard"]
+
     rooms = {}
+    rooms_created = 0
     for proto in midgard:
         vnum = int(proto.get("room_id"))
         objs = ObjectDB.objects.filter(
@@ -38,8 +46,10 @@ def create():
                 obj.tags.add(name, category=category)
             else:
                 obj.tags.add(tag)
+        rooms_created += 1
         rooms[vnum] = obj
-    # create exits
+
+    exits_created = 0
     for proto in midgard:
         vnum = int(proto.get("room_id"))
         room = rooms.get(vnum)
@@ -52,4 +62,7 @@ def create():
             room.db.exits = room.db.exits or {}
             if dir_name not in room.db.exits:
                 room.db.exits[dir_name] = dest
+                exits_created += 1
+
+    return rooms_created, exits_created
 


### PR DESCRIPTION
## Summary
- add `CmdInitMidgard` to `commands.building`
- expose command via `BuilderCmdSet`
- make `create_midgard_area.create()` return creation counts
- mention `@initmidgard` in setup docs

## Testing
- `pytest -q` *(fails: OperationalError - no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68522fe5ec3c832c9e0ae76098a5c901