### PR TITLE
Move midgard area import

### DIFF
--- a/server/conf/at_server_startstop.py
+++ b/server/conf/at_server_startstop.py
@@ -24,7 +24,6 @@ from evennia.utils import logger
 from evennia.server.models import ServerConfig
 from utils.prototype_manager import load_all_prototypes
 from utils.script_utils import resume_paused_scripts
-from world.scripts import create_midgard_area
 
 
 _PROTOTYPE_CACHE = {}
@@ -187,6 +186,7 @@ def at_server_start():
     _build_caches()
     _ensure_room_areas()
     from typeclasses.rooms import Room
+    from world.scripts import create_midgard_area
     if not (
         Room.objects.filter(db_tags__db_key__iexact="midgard").exists()
         or Room.objects.filter(


### PR DESCRIPTION
## Summary
- move `create_midgard_area` import inside `at_server_start`

## Testing
- `pytest -q` *(fails: OperationalError - no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_685234c792bc832c966bd72d50cd4ec5