### PR TITLE
Move Room import into create_midgard_area.create

### DIFF
--- a/world/scripts/create_midgard_area.py
+++ b/world/scripts/create_midgard_area.py
@@ -1,7 +1,6 @@
 from evennia import create_object
 from evennia.objects.models import ObjectDB
 from evennia.utils import logger
-from typeclasses.rooms import Room
 from utils.prototype_manager import load_all_prototypes
 
 
@@ -14,6 +13,7 @@ def create() -> tuple[int, int]:
     tuple[int, int]
         Number of rooms created and exits created.
     """
+    from typeclasses.rooms import Room
     prototypes = load_all_prototypes("room")
     midgard = [p for p in prototypes.values() if p.get("area") == "midgard"]
 


### PR DESCRIPTION
## Summary
- import `Room` inside the `create` function rather than globally

## Testing
- `pytest -q` *(fails: no such table `accounts_accountdb`)*

------
https://chatgpt.com/codex/tasks/task_e_685234cab468832cbef553ed756a0e66