### PR TITLE
Add BaseNPC import to at_server_start

### DIFF
--- a/server/conf/at_server_startstop.py
+++ b/server/conf/at_server_startstop.py
@@ -112,6 +112,7 @@ def at_server_start():
     from evennia.utils import create
     from evennia.scripts.models import ScriptDB
     from world.scripts.mob_db import get_mobdb
+    from typeclasses.npcs import BaseNPC
 
     script = ScriptDB.objects.filter(db_key="global_tick").first()
     if not script or script.typeclass_path != "typeclasses.scripts.GlobalTick":


### PR DESCRIPTION
## Summary
- import BaseNPC during server startup to tag NPCs with AI appropriately

## Testing
- `pytest -q` *(fails: 324 failed, 11 passed, 2 warnings, 1 error)*

------
https://chatgpt.com/codex/tasks/task_e_68523a61af90832cbc9856be71ce87fa