### PR TITLE
Fix README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ This project uses a round-based combat system that processes queued actions each
 Currency
 There are four coin types:
 
-Copy
-Edit
 1 Silver   = 100 Copper
 1 Gold     = 10 Silver   = 1,000 Copper
 1 Platinum = 100 Gold    = 100,000 Copper
@@ -35,19 +33,16 @@ Platinum – rare transactions or guild-level assets.
 
 Use the bank command near a banker:
 
-php-template
-Copy
-Edit
+```bash
 bank balance
 bank deposit <amount [coin]>
 bank withdraw <amount [coin]>
 bank transfer <amount [coin]> <player>
+```
 Minimap
 Rooms display a visual minimap:
 
-mathematica
-Copy
-Edit
+```
      N
   __^__
  |     |
@@ -55,6 +50,7 @@ W<| [X] |>E
  |____|
      v
      S
+```
 Rooms can optionally store (x, y, "area") coordinates for use with xyzgrid mapping.
 
 Installation
@@ -64,9 +60,7 @@ Python 3.12+
 Git
 
 Windows
-bash
-Copy
-Edit
+```bash
 git clone https://github.com/InspectorCaracal/evennia-minimud.git
 cd evennia-minimud
 py -m venv .venv
@@ -75,10 +69,9 @@ pip install .
 py -m evennia
 evennia migrate
 evennia start
+```
 Linux / macOS
-bash
-Copy
-Edit
+```bash
 git clone https://github.com/InspectorCaracal/evennia-minimud.git
 cd evennia-minimud
 python3 -m venv .venv
@@ -86,32 +79,29 @@ source .venv/bin/activate
 pip install .
 evennia migrate
 evennia start
+```
 Follow the prompt to create your superuser account.
 
 Setup Continued
-bash
-Copy
-Edit
+```bash
 evennia xyzgrid init
 evennia xyzgrid add world.maps.starter_town
 evennia xyzgrid spawn
 evennia reload
+```
 Then, in-game:
-
-bash
-Copy
-Edit
+```bash
 ic
 batchcmd initial_build
 @initmidgard
+```
 This populates rooms 200050-200150 so @teleport works.
 Creating NPCs
 Use:
 
-bash
-Copy
-Edit
+```bash
 cnpc start <key>
+```
 This launches the builder menu. Choose an NPC type:
 
 merchant, banker, trainer, wanderer, combatant
@@ -119,32 +109,32 @@ merchant, banker, trainer, wanderer, combatant
 Combatants use CombatNPC and require a class from world.scripts.classes.
 
 Trigger syntax is flexible:
+```json
 
-json
-Copy
-Edit
 {
   "on_enter": [
     {"match": "", "responses": ["say Hello", "emote waves"]}
   ]
 }
+```
 You can also run mob commands such as:
+```bash
 
 mob mpdamage <target> <amount> [type]
 
 mob mpapply <target> <effect> [duration]
 
 mob mpcall <module.func>
+```
 
 To respawn, clone, or list:
 
-bash
-Copy
-Edit
+```bash
 @spawnnpc <proto>
 @clonenpc <existing> [= new_name]
 @deletenpc <npc>
 @listnpcs [area]
+```
 To assign AI:
 
 passive, aggressive, defensive, wander, scripted
@@ -152,55 +142,51 @@ passive, aggressive, defensive, wander, scripted
 Mob Builder & MEdit
 Use mobbuilder or quickmob:
 
-bash
-Copy
-Edit
+```bash
 @quickmob goblin warrior
+```
 Use medit <vnum> to edit a numeric prototype or:
 
-bash
-Copy
-Edit
+```bash
 medit create <vnum>
 Set stats, then save as a prototype. Mobs saved with mobbuilder use the prefix mob_.
 
+```
 Mob Prototype Manager
-bash
-Copy
-Edit
+```bash
 @mobproto create 1 goblin
 @mobproto set 1 level 3
 @mobproto spawn 1
+```
 Spawning and Room Systems
 Room JSONs may include:
+```json
 
-json
-Copy
-Edit
 "spawns": [
   {"proto": "mob_goblin", "max_spawns": 2, "spawn_interval": 300}
 ]
 SpawnManager automatically registers spawns when a room prototype is saved. If
+```
 spawns appear to be missing (for example after a server restart), use:
 
-bash
-Copy
-Edit
+```bash
 @spawnreload
 @forcerespawn <vnum>
 @showspawns [vnum]
+```
 Weapon Creation
-bash
-Copy
-Edit
+```bash
 cweapon "longsword" mainhand 1d8 4 STR+2 A reliable longsword.
 inspect longsword-1
+```
 Supports flat or dice damage (e.g. 2d6). Add /unidentified to hide stats.
 
 Combat System
 Modular combat using a 2-second tick:
 
+```python
 CombatRoundManager.get().start_combat([fighter1, fighter2])
+```
 
 Supports action queues, status effects, resistances
 
@@ -208,20 +194,17 @@ Fully pluggable and extendable
 
 Running Tests
 Install test dependencies:
-
-bash
-Copy
-Edit
+```bash
 pip install -r requirements-test.txt
 pip install -e .
-If these packages are not installed before running `pytest`, test collection
-will fail with import errors for Django/Evennia.
+```
+If these packages are not installed before running `pytest`, test collection will fail with import errors for Django/Evennia.
 Then run:
 
-bash
-Copy
-Edit
+```bash
 pytest -q
+```
+
 Area JSON Format
 Room VNUMs now tracked in world/prototypes/areas/*.json under a rooms list. See docs/area_json.md for format details.
 


### PR DESCRIPTION
## Summary
- remove stray words like `Copy` and `Edit`
- format setup steps and examples with fenced code blocks

## Testing
- `pytest -q` *(fails: django import errors)*

------
https://chatgpt.com/codex/tasks/task_e_68523a655b20832cbb3dc851b88d2189