### PR TITLE
Update Midgard area setup

### DIFF
--- a/world/tests/test_midgard_area.py
+++ b/world/tests/test_midgard_area.py
@@ -38,6 +38,8 @@ class TestMidgardArea(EvenniaTest):
         assert target
         assert self.char1.location == target
 
+        assert target.db.area == "midgard"
+
         data = create_midgard_area.midgard_rooms[200050]
         assert target.key == data["name"]
         assert target.db.desc == data["desc"]


### PR DESCRIPTION
## Summary
- delete invalid objects when making Midgard rooms
- assign Midgard area after room creation
- create exits without Exit import
- verify Midgard area in tests

## Testing
- `pip install 'evennia[extra]>=4.2,<5.0' 'Django>=4.2,<5.0' pytest`
- `pytest -q world/tests/test_midgard_area.py` *(fails: OperationalError no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_685246df5c90832c90f2900d39ecfd1b