### PR TITLE
Create physical Midgard rooms

### DIFF
--- a/world/scripts/cleanup_areas.py
+++ b/world/scripts/cleanup_areas.py
@@ -1,0 +1,30 @@
+"""Utility to wipe all areas except Midgard and Verdant Overgrowth."""
+
+from evennia.objects.models import ObjectDB
+
+AREAS_TO_KEEP = {"midgard", "verdant_overgrowth"}
+
+all_rooms = ObjectDB.objects.filter(db_tags__db_category="area")
+
+deleted_areas: set[str] = set()
+exits_deleted = 0
+
+for room in all_rooms:
+    area_tag = next((tag.db_key for tag in room.tags.all() if tag.category == "area"), None)
+
+    if not area_tag or not room.is_typeclass("typeclasses.rooms.Room", exact=False):
+        continue
+
+    if area_tag not in AREAS_TO_KEEP:
+        deleted_areas.add(area_tag)
+        room.delete()
+        continue
+
+    for exit_obj in list(room.exits):
+        exit_obj.delete()
+        exits_deleted += 1
+    room.db.exits = {}
+
+print("✅ Cleanup complete.")
+print(f"- Deleted areas: {', '.join(sorted(deleted_areas)) or 'None'}")
+print(f"- Exits deleted in kept areas: {exits_deleted}")

--- a/world/tests/test_midgard_area.py
+++ b/world/tests/test_midgard_area.py
@@ -5,7 +5,6 @@ from evennia.objects.models import ObjectDB
 from evennia.utils.test_resources import EvenniaTest
 from typeclasses.rooms import Room
 from world.areas import find_area_by_vnum
-from utils.prototype_manager import load_prototype
 
 
 @override_settings(DEFAULT_HOME=None)
@@ -14,28 +13,12 @@ class TestMidgardArea(EvenniaTest):
         area = find_area_by_vnum(200050)
         assert area and area.key == "midgard"
 
-    def test_load_room_prototype(self):
-        proto = load_prototype("room", 200070)
-        assert proto and proto.get("area") == "midgard"
-
     def test_create_and_teleport(self):
         from commands.building import CmdTeleport
         from world.scripts import create_midgard_area
-        proto = {
-            200050: {
-                "room_id": 200050,
-                "key": "Midgard Square",
-                "typeclass": "typeclasses.rooms.Room",
-                "area": "midgard",
-                "exits": {},
-            }
-        }
-        with mock.patch(
-            "world.scripts.create_midgard_area.load_all_prototypes",
-            return_value=proto,
-        ):
-            rooms_created, exits_created = create_midgard_area.create()
-            assert rooms_created == 1
+
+        rooms_created, exits_created = create_midgard_area.create()
+        assert rooms_created >= 1
 
         cmd = CmdTeleport()
         cmd.caller = self.char1
@@ -54,3 +37,11 @@ class TestMidgardArea(EvenniaTest):
                 break
         assert target
         assert self.char1.location == target
+
+        data = create_midgard_area.midgard_rooms[200050]
+        assert target.key == data["name"]
+        assert target.db.desc == data["desc"]
+        assert target.db.exits.get("south")
+        exit_objs = [ex for ex in target.exits if ex.key.lower() == "south"]
+        assert exit_objs
+        assert "s" in exit_objs[0].aliases.all()


### PR DESCRIPTION
## Summary
- fix Midgard creation to use a built-in list of rooms
- update Midgard area tests
- add exit connections with room db mapping
- alias exits with single-letter directions
- add cleanup script to delete unused areas

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68524003cce0832c8baa991f4a4e10dc