### PR TITLE
Improve area listing formatting

### DIFF
--- a/commands/aedit.py
+++ b/commands/aedit.py
@@ -1,5 +1,4 @@
 from evennia.utils.evtable import EvTable
-import textwrap
 from evennia import CmdSet
 from evennia.objects.models import ObjectDB
 from evennia.server.models import ServerConfig
@@ -159,6 +158,9 @@ class CmdAList(Command):
             "Interval",
             border="cells",
         )
+        table.reformat_column(2, align="r")  # Rooms
+        table.reformat_column(8, align="r")  # Age
+        table.reformat_column(9, align="r")  # Interval
         for area in areas:
             if hasattr(area, "_temp_room_count"):
                 room_count = area._temp_room_count
@@ -190,9 +192,15 @@ class CmdAList(Command):
                 area._temp_room_ids = room_ids
 
             spawn_count = spawn_counts.get(area.key.lower(), 0)
-            vnum_text = ", ".join(str(r) for r in room_ids) if room_ids else "-"
-            if vnum_text != "-":
-                vnum_text = textwrap.shorten(vnum_text, width=60, placeholder="...")
+            if room_ids:
+                limit = 5
+                if len(room_ids) > limit:
+                    first = ", ".join(str(r) for r in room_ids[:limit])
+                    vnum_text = f"{first}, ... (count: {len(room_ids)})"
+                else:
+                    vnum_text = ", ".join(str(r) for r in room_ids)
+            else:
+                vnum_text = "-"
             table.add_row(
                 area.key,
                 f"{area.start}-{area.end}",

--- a/typeclasses/tests/test_alist_command.py
+++ b/typeclasses/tests/test_alist_command.py
@@ -81,8 +81,9 @@ class TestAListCommand(EvenniaTest):
         out = self.char1.msg.call_args[0][0]
         row = next(line for line in out.splitlines() if line.startswith("| zone"))
         cols = [c.strip() for c in row.split("|")[1:-1]]
-        self.assertLessEqual(len(cols[3]), 60)
-        self.assertTrue(cols[3].endswith("..."))
+        self.assertEqual(
+            cols[3], "1, 2, 3, 4, 5, ... (count: 29)"
+        )
 
     def test_current(self):
         self.char1.location = self.room1

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -1599,7 +1599,9 @@ Examples:
     alist current
 
 Notes:
-    - The Vnums column lists all room ids defined for the area.
+    - The Vnums column lists up to five room ids for each area.
+      Longer lists are truncated as "..., (count: N)" where N is the total
+      number of rooms.
 
 Related:
     help ansi


### PR DESCRIPTION
## Summary
- reformat `alist` output with clearer table layout
- right-align numeric columns
- truncate long vnum lists after five entries
- update help entry and tests for new behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685256e4ef4c832cba02d3436e8924de