### PR TITLE
Add cooldowns to affects command

### DIFF
--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -419,6 +419,17 @@ class TestInfoCommands(EvenniaTest):
         self.assertIn("Speed Boost", out)
         self.assertNotIn("Strength Bonus", out)
 
+    def test_affects_alias(self):
+        self.char1.execute_cmd("aff")
+        self.assertTrue(self.char1.msg.called)
+
+    def test_affects_displays_cooldowns(self):
+        self.char1.cooldowns.add("recall", 10)
+        self.char1.execute_cmd("affects")
+        out = self.char1.msg.call_args[0][0]
+        self.assertIn("Recall - CD", out)
+        self.assertIn("10", out)
+
     def test_guild(self):
         self.char1.db.guild = "Adventurers Guild"
         self.char1.execute_cmd("guild")

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -166,7 +166,7 @@ Related:
         "text": """
 Help for affects
 
-View your active buffs and status effects.
+View your active buffs, status effects, and ability cooldowns.
 
 Status effects include temporary conditions like |wstunned|n or
 |wdefending|n applied during combat. They modify your stats or actions
@@ -174,6 +174,7 @@ until their duration expires.
 
 Usage:
     affects
+    aff
 
 Switches:
     None
@@ -186,6 +187,7 @@ Examples:
 
 Notes:
     - Displays any active effects along with their remaining duration in ticks.
+    - Active cooldowns show as "<ability> - CD" with time left in seconds.
 
 Related:
     help ansi


### PR DESCRIPTION
## Summary
- alias `aff` to `affects`
- list active cooldowns in affects output
- document cooldown listing and alias in help entry
- test new alias and cooldown display

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685259d29f20832cb4f620ea133d7d8d