### PR TITLE
Fix admin imports and add account commands

### DIFF
--- a/commands/admin/__init__.py
+++ b/commands/admin/__init__.py
@@ -63,11 +63,8 @@ from ..opedit import CmdOPEdit
 from ..rpedit import CmdRPEdit
 from .resetworld import CmdResetWorld
 from .spawncontrol import CmdSpawnReload, CmdForceRespawn, CmdShowSpawns
-<<<<<<< codex/add-cmdaccounts-command-to-admin
 from .accounts import CmdAccounts
-=======
 from .whoip import CmdWhoIP
->>>>>>> main
 
 
 def _safe_split(text):
@@ -1410,11 +1407,8 @@ class AdminCmdSet(CmdSet):
         self.add(CmdSpawnReload)
         self.add(CmdForceRespawn)
         self.add(CmdShowSpawns)
-<<<<<<< codex/add-cmdaccounts-command-to-admin
         self.add(CmdAccounts)
-=======
         self.add(CmdWhoIP)
->>>>>>> main
         self.add(CmdScan)
 
 


### PR DESCRIPTION
## Summary
- clean up merge markers
- add `CmdAccounts` and `CmdWhoIP` to `AdminCmdSet`
- keep `CmdAccounts` in `BuilderCmdSet`
- run tests
- run migrations to start the server

## Testing
- `pytest -q` *(fails: OperationalError)*
- `evennia migrate`
- `evennia start` *(prompted for superuser, cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_6852610dbc60832cafd2bb200057eafc