### PR TITLE
Implement admin puppet commands

### DIFF
--- a/commands/admin/__init__.py
+++ b/commands/admin/__init__.py
@@ -64,6 +64,7 @@ from ..rpedit import CmdRPEdit
 from .resetworld import CmdResetWorld
 from .spawncontrol import CmdSpawnReload, CmdForceRespawn, CmdShowSpawns
 from .whoip import CmdWhoIP
+from .puppeting import CmdPull, CmdPush, CmdPuppet
 
 
 def _safe_split(text):
@@ -1408,6 +1409,9 @@ class AdminCmdSet(CmdSet):
         self.add(CmdShowSpawns)
         self.add(CmdWhoIP)
         self.add(CmdScan)
+        self.add(CmdPull)
+        self.add(CmdPush)
+        self.add(CmdPuppet)
 
 
 class BuilderCmdSet(CmdSet):

--- a/commands/admin/puppeting.py
+++ b/commands/admin/puppeting.py
@@ -1,0 +1,100 @@
+from evennia import CmdSet
+from ..command import Command
+
+
+class CmdPull(Command):
+    """Pull a character into play and take control."""
+
+    key = "@pull"
+    locks = "cmd:perm(Admin)"
+    help_category = "Admin"
+
+    def func(self):
+        caller = self.caller
+        if not self.args:
+            caller.msg("Usage: @pull <character>")
+            return
+        target = caller.search(self.args.strip(), global_search=True)
+        if not target:
+            return
+        if target.sessions.count():
+            caller.msg(f"{target.key} is already puppeted.")
+            return
+        if not target.access(caller.account, "puppet"):
+            caller.msg("You do not have permission to puppet that character.")
+            return
+        if caller.location:
+            target.move_to(caller.location, quiet=True)
+        caller.account.puppet_object(self.session, target)
+        caller.msg(f"You pull {target.key} to you and take control.")
+        target.msg(f"You are pulled into the game by {caller.key}.")
+
+
+class CmdPush(Command):
+    """Unpuppet a controlled character."""
+
+    key = "@push"
+    locks = "cmd:perm(Admin)"
+    help_category = "Admin"
+
+    def func(self):
+        caller = self.caller
+        if not self.args:
+            caller.msg("Usage: @push <character>")
+            return
+        target = caller.search(self.args.strip(), global_search=True)
+        if not target:
+            return
+        sess = target.sessions.get()
+        if not sess:
+            caller.msg(f"{target.key} is not currently puppeted.")
+            return
+        if sess.account != caller.account:
+            caller.msg(f"You are not controlling {target.key}.")
+            return
+        caller.account.unpuppet_object(sess)
+        sess.disconnect()
+        caller.msg(f"You push {target.key} out of the game.")
+
+
+class CmdPuppet(Command):
+    """Temporarily puppet another character without giving up your own body."""
+
+    key = "@puppet"
+    aliases = ["ghost"]
+    locks = "cmd:perm(Admin)"
+    help_category = "Admin"
+
+    def func(self):
+        caller = self.caller
+        if caller.ndb.puppet_proxy and not self.args:
+            target = caller.ndb.puppet_proxy
+            caller.ndb.puppet_proxy = None
+            caller.msg(f"Stopped puppeting {target.key}.")
+            return
+        if not self.args:
+            caller.msg("Usage: @puppet <character>")
+            return
+        if caller.ndb.puppet_proxy:
+            caller.msg("Already puppeting a character. Use '@puppet' to stop first.")
+            return
+        target = caller.search(self.args.strip(), global_search=True)
+        if not target:
+            return
+        if target.sessions.count():
+            caller.msg(f"{target.key} is already puppeted.")
+            return
+        caller.ndb.puppet_proxy = target
+        caller.msg(f"You begin puppeting {target.key}. Use '@puppet' again to stop.")
+
+
+class PuppetCmdSet(CmdSet):
+    """CmdSet bundling puppeting utilities."""
+
+    key = "PuppetCmdSet"
+
+    def at_cmdset_creation(self):
+        super().at_cmdset_creation()
+        self.add(CmdPull)
+        self.add(CmdPush)
+        self.add(CmdPuppet)

--- a/commands/command.py
+++ b/commands/command.py
@@ -26,6 +26,16 @@ class Command(BaseCommand):
             session = to_obj.sessions.get() if to_obj != self.caller else self.session
         to_obj.msg(text, from_obj=from_obj, session=session, **kwargs)
 
+    def at_pre_cmd(self):
+        """Proxy commands when ghost-puppeting another character."""
+        proxy = getattr(self.caller.ndb, "puppet_proxy", None)
+        if proxy and self.cmdstring != "@puppet":
+            self.caller.msg(f"[PUPPETING {proxy.key}]")
+            proxy.execute_cmd(self.raw_string, session=self.session)
+            self.caller.msg("[END PUPPET]")
+            return True
+        return super().at_pre_cmd()
+
     def at_post_cmd(self):
         """Hook called after command execution."""
         super().at_post_cmd()


### PR DESCRIPTION
## Summary
- add @pull, @push and @puppet commands for admins
- hook command proxying via caller.ndb.puppet_proxy
- register new commands in AdminCmdSet

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685264f32dd4832cad0fc8c4e68079d3