### PR TITLE
Fix CmdPull messaging

### DIFF
--- a/commands/admin/puppeting.py
+++ b/commands/admin/puppeting.py
@@ -25,8 +25,9 @@ class CmdPull(Command):
             return
         if caller.location:
             target.move_to(caller.location, quiet=True)
-        caller.account.puppet_object(self.session, target)
-        caller.msg(f"You pull {target.key} to you and take control.")
+        session = self.session
+        caller.account.puppet_object(session, target)
+        session.msg(f"You pull {target.key} to you and take control.")
         target.msg(f"You are pulled into the game by {caller.key}.")
 
 


### PR DESCRIPTION
## Summary
- store the session before swapping the puppet to an object
- send message with that session so feedback reaches the right puppet

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6852b976054c832cb4196c88c5eb4d4b