### PR TITLE
Sort exits by preferred direction order

### DIFF
--- a/commands/info.py
+++ b/commands/info.py
@@ -859,8 +859,11 @@ class CmdScan(Command):
             if things:
                 lines.append("|wYou see:|n " + ", ".join(things))
 
-            exits = [e.key.capitalize() for e in dest.exits if is_admin or e.access(caller, "view")]
-            lines.append("|wExits:|n " + (", ".join(exits) if exits else "None"))
+            from utils.directions import sort_exit_names
+
+            exit_keys = [e.key for e in dest.exits if is_admin or e.access(caller, "view")]
+            exit_keys = sort_exit_names(exit_keys)
+            lines.append("|wExits:|n " + (", ".join(name.capitalize() for name in exit_keys) if exit_keys else "None"))
 
             out.append("\n".join(lines))
 

--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -116,7 +116,11 @@ class RoomParent(ObjectParent):
         return f"Special commands here: {', '.join(cmd_keys)}" if cmd_keys else ""
 
     def get_display_exits(self, looker, **kwargs):
-        exit_names = [key.capitalize() for key in (self.db.exits or {})]
+        from utils.directions import sort_exit_names
+
+        exit_keys = list((self.db.exits or {}).keys())
+        ordered = sort_exit_names(exit_keys)
+        exit_names = [name.capitalize() for name in ordered]
         return "|wExits:|n " + ", ".join(exit_names) if exit_names else "|wExits:|n None"
 
     def return_appearance(self, looker):

--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -581,6 +581,11 @@ class TestReturnAppearance(EvenniaTest):
         self.assertIn(f"[fighting {npc.get_display_name(self.char1)}]", out)
         self.assertIn("[idle]", out)
 
+    def test_exit_display_order(self):
+        self.room1.db.exits = {"south": self.room2, "east": self.room2, "west": self.room2, "north": self.room2}
+        display = self.room1.get_display_exits(self.char1)
+        self.assertEqual(display, "|wExits:|n North, South, West, East")
+
 
 class TestRestCommands(EvenniaTest):
     def setUp(self):

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -22,6 +22,7 @@ except Exception:  # pragma: no cover - may fail before Django setup
 
 from .dice import roll_dice_string
 from .defense_scaling import DefensiveStats
+from .directions import sort_exit_names
 
 
 def display_auto_prompt(account, caller, msg_func, *, force=False):

--- a/utils/directions.py
+++ b/utils/directions.py
@@ -1,0 +1,10 @@
+"""Utilities for handling room directions and exit ordering."""
+
+# Preferred display order for cardinal exits.
+EXIT_DISPLAY_ORDER = ["north", "south", "west", "east"]
+
+
+def sort_exit_names(names):
+    """Return ``names`` sorted using ``EXIT_DISPLAY_ORDER``."""
+    order_map = {name: idx for idx, name in enumerate(EXIT_DISPLAY_ORDER)}
+    return sorted(names, key=lambda n: (order_map.get(n.lower(), len(EXIT_DISPLAY_ORDER)), n))


### PR DESCRIPTION
## Summary
- sort exit names with new utility to ensure display order
- import and use sort_exit_names in commands
- check exit order in tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6852bc6dad88832c859b63b7933dcdb0