### PR TITLE
Add unlink command

### DIFF
--- a/commands/admin/__init__.py
+++ b/commands/admin/__init__.py
@@ -15,6 +15,7 @@ from ..building import (
     CmdSetFlag,
     CmdRemoveFlag,
     CmdDelDir,
+    CmdUnlink,
     CmdDelRoom,
     CmdInitMidgard,
 )
@@ -1442,6 +1443,7 @@ class BuilderCmdSet(CmdSet):
         self.add(CmdSetFlag)
         self.add(CmdRemoveFlag)
         self.add(CmdDelDir)
+        self.add(CmdUnlink)
         self.add(CmdDelRoom)
         self.add(CmdInitMidgard)
         self.add(CmdCNPC)

--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -828,6 +828,17 @@ class TestDelDirCommand(EvenniaTest):
         self.assertNotIn("south", new_room.db.exits)
 
 
+class TestUnlinkCommand(EvenniaTest):
+    def test_unlink_removes_two_way_exit(self):
+        start = self.char1.location
+        self.char1.execute_cmd("dig east")
+        new_room = start.db.exits.get("east")
+        self.assertIsNotNone(new_room)
+        self.char1.execute_cmd("unlink east")
+        self.assertNotIn("east", start.db.exits)
+        self.assertNotIn("west", new_room.db.exits)
+
+
 class TestDelRoomCommand(EvenniaTest):
     def test_delroom_by_direction(self):
         start = self.char1.location

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -1814,6 +1814,33 @@ Related:
 """,
     },
     {
+        "key": "unlink",
+        "category": "Building",
+        "text": """Help for unlink
+
+Remove an exit from the current room.
+
+Usage:
+    unlink <direction>
+
+Switches:
+    None
+
+Arguments:
+    None
+
+Examples:
+    unlink north
+
+Notes:
+    - Removes the exit in the given direction. If the adjoining room
+    - links back here, that exit is removed as well.
+
+Related:
+    help ansi
+""",
+    },
+    {
         "key": "delroom",
         "category": "Building",
         "text": """


### PR DESCRIPTION
## Summary
- add a new `unlink` command for removing two-way exits
- register `unlink` in the Builder command set
- document `unlink` in help entries
- test the new command

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6852bed43b98832cbffe6ed17cb6f3c3