### PR TITLE
Delegate NPC combat turns to npc_take_turn

### DIFF
--- a/typeclasses/npcs/combat.py
+++ b/typeclasses/npcs/combat.py
@@ -17,8 +17,7 @@ class CombatNPC(BaseNPC):
         if not target:
             return
         engine = getattr(getattr(self, "ndb", None), "combat_engine", None)
-        if engine:
-            from combat.combat_actions import AttackAction
+        from combat.ai_combat import npc_take_turn
 
-            engine.queue_action(self, AttackAction(self, target))
+        npc_take_turn(engine, self, target)
 


### PR DESCRIPTION
## Summary
- hook CombatNPC to use `npc_take_turn` for deciding actions

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6852c31fc7a4832c80cabfa1da4307c9