### PR TITLE
Improve AI ability handling

### DIFF
--- a/combat/ai_combat.py
+++ b/combat/ai_combat.py
@@ -3,7 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Callable, Iterable
+from typing import Callable, Iterable, Iterator, Tuple, Any
+from random import random
+import re
+
+from .combat_utils import check_distance
+from world.system import state_manager
 
 from .combat_actions import AttackAction, SkillAction, SpellAction
 from .engine import CombatEngine
@@ -20,14 +25,69 @@ class Behavior:
     act: Callable[[CombatEngine | None, object, object], None] = field(compare=False)
 
 
+def _iter_abilities(data: Any) -> Iterator[Tuple[str, int]]:
+    """Yield ``(name, chance)`` pairs from ``data``.
+
+    Args:
+        data: Iterable or mapping of ability entries. List items may include
+            a chance value using ``"name(25%)"`` notation. Dictionary values
+            are interpreted as chance percentages.
+
+    Yields:
+        Tuple[str, int]: Ability key/name and usage chance.
+    """
+
+    if not data:
+        return
+
+    if isinstance(data, dict):
+        items = data.items()
+    else:
+        items = [(entry, None) for entry in data]
+
+    for name, chance in items:
+        abil_name = name
+        perc = chance
+
+        if isinstance(abil_name, str):
+            match = re.match(r"\s*(.+?)\s*\((\d+)%\)\s*$", abil_name)
+            if match:
+                abil_name = match.group(1)
+                perc = match.group(2)
+
+        if hasattr(abil_name, "key"):
+            abil_name = abil_name.key
+        elif hasattr(abil_name, "name"):
+            abil_name = abil_name.name
+
+        if isinstance(perc, str):
+            m = re.match(r"(\d+)", perc)
+            perc = int(m.group(1)) if m else 100
+        elif isinstance(perc, (int, float)):
+            perc = int(perc)
+        else:
+            perc = 100
+
+        yield str(abil_name), perc
+
+
 def _default_behaviors(npc) -> Iterable[Behavior]:
     """Yield behaviors for any skills or spells the NPC knows."""
 
     # Spells are highest priority if the NPC has mana for them.
-    def make_spell_behavior(spell_key, spell):
+    def make_spell_behavior(spell_key: str, spell, chance: int):
         def check(engine, n, t):
+            if random() > chance / 100:
+                return False
+            if state_manager.has_status(n, "stunned") or state_manager.has_status(n, "silenced"):
+                return False
             mana = getattr(n.traits, "mana", None)
-            return mana and mana.current >= spell.mana_cost and n.cooldowns.ready(spell.key)
+            if not (mana and mana.current >= spell.mana_cost and n.cooldowns.ready(spell.key)):
+                return False
+            action = SpellAction(n, spell_key, t)
+            if not check_distance(n, t, action.range):
+                return False
+            return True
 
         def act(engine, n, t):
             if engine:
@@ -37,18 +97,27 @@ def _default_behaviors(npc) -> Iterable[Behavior]:
 
         return Behavior(30, check, act)
 
-    for sp in getattr(npc.db, "spells", []):
-        spell_key = sp.key if hasattr(sp, "key") else sp
+    for name, chance in _iter_abilities(getattr(npc.db, "spells", [])):
+        spell_key = name
         spell = SPELLS.get(spell_key)
         if not spell:
             continue
-        yield make_spell_behavior(spell_key, spell)
+        yield make_spell_behavior(spell_key, spell, chance)
 
     # Skills next.
-    def make_skill_behavior(skill):
+    def make_skill_behavior(skill, chance: int):
         def check(engine, n, t):
+            if random() > chance / 100:
+                return False
+            if state_manager.has_status(n, "stunned") or state_manager.has_status(n, "silenced"):
+                return False
             stam = getattr(n.traits, "stamina", None)
-            return stam and stam.current >= skill.stamina_cost and n.cooldowns.ready(skill.name)
+            if not (stam and stam.current >= skill.stamina_cost and n.cooldowns.ready(skill.name)):
+                return False
+            action = SkillAction(n, skill, t)
+            if not check_distance(n, t, action.range):
+                return False
+            return True
 
         def act(engine, n, t):
             if engine:
@@ -58,12 +127,12 @@ def _default_behaviors(npc) -> Iterable[Behavior]:
 
         return Behavior(20, check, act)
 
-    for sk in getattr(npc.db, "skills", []):
-        skill_cls = SKILL_CLASSES.get(sk)
+    for name, chance in _iter_abilities(getattr(npc.db, "skills", [])):
+        skill_cls = SKILL_CLASSES.get(name)
         if not skill_cls:
             continue
         skill = skill_cls()
-        yield make_skill_behavior(skill)
+        yield make_skill_behavior(skill, chance)
 
     # Fallback to a normal attack.
     def atk_check(engine, n, t):


### PR DESCRIPTION
## Summary
- add `_iter_abilities` helper for reading ability definitions with chances
- check ability chance, statuses and range when using spells or skills
- support ability lists and dicts with percent chances

## Testing
- `pytest typeclasses/tests/test_ai_combat.py::TestAICombat::test_prefers_spell_over_skill -q` *(fails: TypeError: 'NoneType' object is not subscriptable)*

------
https://chatgpt.com/codex/tasks/task_e_6852c320cb0c832cbcd00da2c37c502f