### PR TITLE
Add map spacing and wander flag

### DIFF
--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -212,7 +212,9 @@ class Room(RoomParent, DefaultRoom):
     def return_appearance(self, looker):
         appearance = super().return_appearance(looker)
         minimap = self.generate_map(looker)
-        return f"{minimap}\n{appearance}" if minimap else appearance
+        if minimap:
+            return f"\n{minimap}\n\n{appearance}"
+        return appearance
 
     def get_display_header(self, looker, **kwargs):
         area = self.get_area()

--- a/typeclasses/tests/test_mob_ai.py
+++ b/typeclasses/tests/test_mob_ai.py
@@ -87,3 +87,18 @@ class TestMobAIBehaviors(EvenniaTest):
         with patch.object(helper, "enter_combat") as mock:
             mob_ai.process_mob_ai(helper)
             mock.assert_called_with(self.char1)
+
+    def test_wander_flag_moves(self):
+        from typeclasses.npcs import BaseNPC
+        from typeclasses.exits import Exit
+
+        dest = create.create_object("typeclasses.rooms.Room", key="dest")
+        exit_obj = create.create_object(Exit, key="east", location=self.room1)
+        exit_obj.destination = dest
+
+        npc = create.create_object(BaseNPC, key="wander", location=self.room1)
+        npc.db.actflags = ["wander"]
+
+        with patch.object(exit_obj, "at_traverse") as mock:
+            mob_ai.process_mob_ai(npc)
+            mock.assert_called_with(npc, dest)

--- a/typeclasses/tests/test_room_minimap.py
+++ b/typeclasses/tests/test_room_minimap.py
@@ -61,9 +61,9 @@ class TestRoomMinimap(EvenniaTest):
         
         appearance = room.return_appearance(self.char1)
         map_lines = room.generate_map(self.char1).splitlines()
-        
+
         # Confirm that map appears at the top of room description
-        self.assertEqual(appearance.splitlines()[:len(map_lines)], map_lines)
+        self.assertEqual(appearance.splitlines()[1 : len(map_lines) + 1], map_lines)
 
     def test_xygrid_map_and_appearance(self):
         # Center + 4 directions
@@ -98,4 +98,4 @@ class TestRoomMinimap(EvenniaTest):
         self.assertEqual(generated_map, expected_map)
         
         appearance = center.return_appearance(self.char1)
-        self.assertTrue(appearance.startswith(expected_map))
+        self.assertTrue(appearance.startswith("\n" + expected_map + "\n"))

--- a/world/mob_constants.py
+++ b/world/mob_constants.py
@@ -69,6 +69,7 @@ class ACTFLAGS(_StrEnum):
     ASSIST = "assist"
     CALL_FOR_HELP = "call_for_help"
     NOLOOT = "noloot"
+    WANDER = "wander"
 
 
 class AFFECTED_BY(_StrEnum):

--- a/world/npc_handlers/mob_ai.py
+++ b/world/npc_handlers/mob_ai.py
@@ -89,9 +89,11 @@ def _scavenge(npc: BaseNPC) -> None:
 
 
 def _roam(npc: BaseNPC) -> None:
-    """Move randomly if not a sentinel."""
+    """Move randomly if allowed."""
     flags = set(npc.db.actflags or [])
     if "sentinel" in flags:
+        return
+    if "wander" not in flags and npc.db.ai_type != "wander":
         return
     if not npc.location:
         return


### PR DESCRIPTION
## Summary
- add blank lines around minimap in room appearance
- include `wander` in `ACTFLAGS`
- roam only when wander AI or flag enabled
- update minimap tests for new padding
- test wander act flag movement

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6852c78f460c832c8d673ccb4d6499f3