### PR TITLE
Fix ability iterator

### DIFF
--- a/combat/ai_combat.py
+++ b/combat/ai_combat.py
@@ -40,6 +40,9 @@ def _iter_abilities(data: Any) -> Iterator[Tuple[str, int]]:
     if not data:
         return
 
+    if isinstance(data, str):
+        data = [data]
+
     if isinstance(data, dict):
         items = data.items()
     else:

--- a/typeclasses/tests/test_iter_abilities.py
+++ b/typeclasses/tests/test_iter_abilities.py
@@ -1,0 +1,17 @@
+import unittest
+from combat.ai_combat import _iter_abilities
+
+
+class TestIterAbilities(unittest.TestCase):
+    def test_from_list(self):
+        data = ["fireball(25%)"]
+        self.assertEqual(list(_iter_abilities(data)), [("fireball", 25)])
+
+    def test_from_dict(self):
+        data = {"fireball(25%)": 100}
+        self.assertEqual(list(_iter_abilities(data)), [("fireball", 25)])
+
+    def test_from_string(self):
+        self.assertEqual(list(_iter_abilities("fireball(25%)")), [("fireball", 25)])
+
+


### PR DESCRIPTION
## Summary
- make `_iter_abilities` treat string input as a single-item list
- add tests for dictionary, list and string inputs

## Testing
- `pytest typeclasses/tests/test_iter_abilities.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6852cb2fc5c0832cb1515f0a993a45ec