### PR TITLE
Add proficiency hit function and use in Kick skill

### DIFF
--- a/world/skills/kick.py
+++ b/world/skills/kick.py
@@ -18,7 +18,12 @@ class Kick(Skill):
 
         self.improve(user)
 
-        if not stat_manager.check_hit(user, target) or roll_evade(user, target):
+        profs = user.db.proficiencies or {}
+        prof = profs.get(self.name, 0)
+        dex = stat_manager.get_effective_stat(user, "DEX")
+        chance = stat_manager.proficiency_hit(prof, dex)
+
+        if not stat_manager.check_hit(user, target, base=chance) or roll_evade(user, target):
             return CombatResult(
                 actor=user,
                 target=target,

--- a/world/system/stat_manager.py
+++ b/world/system/stat_manager.py
@@ -519,6 +519,13 @@ def get_effective_stat(obj, key: str) -> int:
     return int(base)
 
 
+def proficiency_hit(proficiency: int, stat: int) -> int:
+    """Return a hit chance based on proficiency and a stat."""
+
+    bonus = max((stat - 10) * 0.5, 0)
+    return int(min(95, proficiency + bonus))
+
+
 def compute_hit_chance(obj) -> int:
     """Return the attacker's base hit chance."""
 


### PR DESCRIPTION
## Summary
- add `proficiency_hit` helper in stat_manager
- use proficiency based hit chance for Kick skill

## Testing
- `python -m py_compile world/system/stat_manager.py world/skills/kick.py`
- `pytest utils/tests/test_combat_utils.py::TestCombatCalculations::test_check_hit_uses_hit_chance_and_dodge -q` *(fails: OperationalError no such table)*

------
https://chatgpt.com/codex/tasks/task_e_6852cf84dad0832ca1c107a7405c5a96