### PR TITLE
Add skill/spell hit calculation and AI helper tests

### DIFF
--- a/typeclasses/tests/test_ai_combat.py
+++ b/typeclasses/tests/test_ai_combat.py
@@ -92,3 +92,17 @@ class TestAICombat(unittest.TestCase):
         action = self.engine.queue_action.call_args[0][1]
         self.assertIsInstance(action, SkillAction)
         self.assertEqual(action.skill.name, "shield bash")
+
+    def test_attack_action_uses_combat_math(self):
+        """Ensure NPC basic attacks rely on CombatMath helpers."""
+
+        self.npc.db.spells = []
+        self.npc.db.skills = []
+        self.engine.queue_action.reset_mock()
+        npc_take_turn(self.engine, self.npc, self.target)
+        action = self.engine.queue_action.call_args[0][1]
+        with patch("combat.combat_actions.CombatMath.check_hit", return_value=(True, "")) as mock_hit, \
+             patch("combat.combat_actions.CombatMath.calculate_damage", return_value=(5, None)), \
+             patch("combat.combat_actions.CombatMath.apply_critical", return_value=(5, False)):
+            action.resolve()
+        mock_hit.assert_called()

--- a/typeclasses/tests/test_skill_spell_usage.py
+++ b/typeclasses/tests/test_skill_spell_usage.py
@@ -1,4 +1,5 @@
 from unittest.mock import patch
+from evennia.utils import create
 from evennia.utils.test_resources import EvenniaTest
 from combat.combat_skills import SKILL_CLASSES
 from world.spells import SPELLS, Spell
@@ -50,4 +51,110 @@ class TestSkillAndSpellUsage(EvenniaTest):
         self.assertIsInstance(spells, list)
         self.assertIsInstance(spells[0], Spell)
         self.assertEqual(spells[0].key, "fireball")
+
+    def test_skill_hit_and_miss_calculation(self):
+        """Players should hit or miss based on stat calculations."""
+
+        self.char2.hp = 10
+        # First ensure a hit
+        with patch("world.system.stat_manager.get_effective_stat") as get_stat, \
+             patch("random.randint", return_value=20), \
+             patch("combat.combat_skills.roll_damage", return_value=4):
+
+            def getter(obj, stat):
+                if obj is self.char1 and stat == "hit_chance":
+                    return 90
+                if obj is self.char2 and stat == "dodge":
+                    return 10
+                return 0
+
+            get_stat.side_effect = getter
+            result = self.char1.use_skill("cleave", target=self.char2)
+
+        self.assertEqual(self.char2.hp, 6)
+        self.assertIn("cleaves", result.message)
+
+        # Now force a miss
+        self.char2.hp = 10
+        with patch("world.system.stat_manager.get_effective_stat") as get_stat, \
+             patch("random.randint", return_value=100), \
+             patch("combat.combat_skills.roll_damage", return_value=4):
+
+            def getter(obj, stat):
+                if obj is self.char1 and stat == "hit_chance":
+                    return 10
+                if obj is self.char2 and stat == "dodge":
+                    return 30
+                return 0
+
+            get_stat.side_effect = getter
+            result = self.char1.use_skill("cleave", target=self.char2)
+
+        self.assertEqual(self.char2.hp, 10)
+        self.assertIn("misses", result.message)
+
+    def test_mob_hit_and_miss_calculation(self):
+        """NPCs should use the same hit formula as players."""
+
+        from evennia.utils import create
+        from typeclasses.npcs import BaseNPC
+
+        npc = create.create_object(BaseNPC, key="mob", location=self.room1)
+        npc.db.skills = ["cleave"]
+
+        self.char1.hp = 10
+        with patch("world.system.stat_manager.get_effective_stat") as get_stat, \
+             patch("random.randint", return_value=20), \
+             patch("combat.combat_skills.roll_damage", return_value=4):
+
+            def getter(obj, stat):
+                if obj is npc and stat == "hit_chance":
+                    return 90
+                if obj is self.char1 and stat == "dodge":
+                    return 10
+                return 0
+
+            get_stat.side_effect = getter
+            result = npc.use_skill("cleave", target=self.char1)
+
+        self.assertEqual(self.char1.hp, 6)
+        self.assertIn("cleaves", result.message)
+
+        self.char1.hp = 10
+        with patch("world.system.stat_manager.get_effective_stat") as get_stat, \
+             patch("random.randint", return_value=100), \
+             patch("combat.combat_skills.roll_damage", return_value=4):
+
+            def getter(obj, stat):
+                if obj is npc and stat == "hit_chance":
+                    return 10
+                if obj is self.char1 and stat == "dodge":
+                    return 30
+                return 0
+
+            get_stat.side_effect = getter
+            result = npc.use_skill("cleave", target=self.char1)
+
+        self.assertEqual(self.char1.hp, 10)
+        self.assertIn("misses", result.message)
+
+    def test_spell_and_skill_messages_use_colorized_names(self):
+        """Casting and skill use should include color codes in messages."""
+
+        self.char1.name_color = "g"
+        self.char2.name_color = "r"
+
+        with patch.object(self.room1, "msg_contents") as mock_msg:
+            self.char1.cast_spell("fireball", target=self.char2)
+            msg = mock_msg.call_args[0][0]
+            self.assertIn("|g", msg)
+            self.assertIn("|r", msg)
+
+        with patch("world.system.stat_manager.check_hit", return_value=True), \
+             patch("combat.combat_skills.roll_evade", return_value=False), \
+             patch("combat.combat_skills.roll_damage", return_value=4):
+            result = self.char1.use_skill("cleave", target=self.char2)
+
+        self.assertIn("|g", result.message)
+        self.assertIn("|r", result.message)
 


### PR DESCRIPTION
## Summary
- extend skill/spell tests for hit calculations and color messages
- ensure NPC AI uses CombatMath helpers

## Testing
- `pytest -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6852cf876920832c86655b6882b1e540