### PR TITLE
Colorize ability names in combat actions

### DIFF
--- a/combat/combat_actions.py
+++ b/combat/combat_actions.py
@@ -8,6 +8,7 @@ import logging
 
 from .engine.combat_math import CombatMath
 from world.system import state_manager
+from world.abilities import colorize_name
 
 logger = logging.getLogger(__name__)
 
@@ -214,6 +215,10 @@ class SkillAction(Action):
         if self.stamina_cost and hasattr(self.actor.traits, "stamina"):
             self.actor.traits.stamina.current -= self.stamina_cost
         result = self.skill.resolve(self.actor, self.target)
+        if result.message:
+            result.message = result.message.replace(
+                self.skill.name, colorize_name(self.skill.name)
+            )
         if getattr(result, "damage", 0):
             result.damage, crit = CombatMath.apply_critical(self.actor, result.target, result.damage)
             if crit:
@@ -257,7 +262,7 @@ class SpellAction(Action):
         result = CombatResult(
             actor=self.actor,
             target=self.target or self.actor,
-            message=f"{self.actor.key} casts {self.spell.key}!",
+            message=f"{self.actor.key} casts {colorize_name(self.spell.key)}!",
         )
         if getattr(result, "damage", 0):
             result.damage, crit = CombatMath.apply_critical(self.actor, result.target, result.damage)

--- a/utils/tests/test_abilities.py
+++ b/utils/tests/test_abilities.py
@@ -1,0 +1,7 @@
+from evennia.utils.test_resources import EvenniaTest
+from world.abilities import colorize_name
+
+
+class TestColorizeName(EvenniaTest):
+    def test_colorize_fireball(self):
+        self.assertEqual(colorize_name("Fireball"), "|cFireball|n")

--- a/world/abilities.py
+++ b/world/abilities.py
@@ -1,0 +1,6 @@
+from utils.ansi_utils import format_ansi_title
+
+
+def colorize_name(name: str, color: str = "c") -> str:
+    """Return ``name`` capitalized and wrapped in ANSI color codes."""
+    return f"|{color}{format_ansi_title(name)}|n"


### PR DESCRIPTION
## Summary
- implement `world.abilities.colorize_name` utility
- use `colorize_name` in `SkillAction` and `SpellAction`
- test ability name colorizing

## Testing
- `pytest -q` *(fails: OperationalError: no such table: accounts_accountdb)*
- `pytest utils/tests/test_abilities.py -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6852cf7cae38832c8ca40b6db566bdb1