### PR TITLE
Group combat messages per round

### DIFF
--- a/typeclasses/tests/test_attack_condition_messages.py
+++ b/typeclasses/tests/test_attack_condition_messages.py
@@ -25,7 +25,8 @@ class TestAttackConditionMessages(EvenniaTest):
         expected = get_condition_msg(
             target.traits.health.current, target.traits.health.max
         )
-        calls = [c.args[0] for c in self.room1.msg_contents.call_args_list]
+        output = self.room1.msg_contents.call_args_list[0].args[0]
+        calls = output.splitlines()
         self.assertFalse(any(f"The {target.key} {expected}" in msg for msg in calls))
 
     def test_barehand_condition(self):

--- a/typeclasses/tests/test_attack_parry_block_crit.py
+++ b/typeclasses/tests/test_attack_parry_block_crit.py
@@ -72,7 +72,8 @@ class TestAttackReactions(unittest.TestCase):
              patch("world.system.stat_manager.roll_crit", return_value=False):
             self._run_engine()
         self.assertEqual(self.defender.hp, 10)
-        calls = [c.args[0] for c in self.attacker.location.msg_contents.call_args_list]
+        output = self.attacker.location.msg_contents.call_args_list[0].args[0]
+        calls = output.splitlines()
         self.assertTrue(any("parries" in msg for msg in calls))
         mock_parry.assert_called()
 
@@ -86,7 +87,8 @@ class TestAttackReactions(unittest.TestCase):
              patch("world.system.stat_manager.roll_crit", return_value=False):
             self._run_engine()
         self.assertEqual(self.defender.hp, 10)
-        calls = [c.args[0] for c in self.attacker.location.msg_contents.call_args_list]
+        output = self.attacker.location.msg_contents.call_args_list[0].args[0]
+        calls = output.splitlines()
         self.assertTrue(any("blocks" in msg for msg in calls))
         mp.assert_called()
         mb.assert_called()
@@ -102,7 +104,8 @@ class TestAttackReactions(unittest.TestCase):
              patch("world.system.stat_manager.crit_damage", return_value=10) as mcd:
             self._run_engine()
         self.assertEqual(self.defender.hp, 0)
-        calls = [c.args[0] for c in self.attacker.location.msg_contents.call_args_list]
+        output = self.attacker.location.msg_contents.call_args_list[0].args[0]
+        calls = output.splitlines()
         self.assertTrue(any("Critical" in msg for msg in calls))
         mp.assert_called()
         mb.assert_called()

--- a/typeclasses/tests/test_combat_actions.py
+++ b/typeclasses/tests/test_combat_actions.py
@@ -36,8 +36,9 @@ class TestDefendAction(unittest.TestCase):
         ):
             engine.start_round()
             engine.process_round()
-        messages = [call.args[0] for call in a.location.msg_contents.call_args_list]
-        self.assertIn("braces", messages[0])
+        output = a.location.msg_contents.call_args_list[0].args[0]
+        messages = output.splitlines()
+        self.assertTrue(any("braces" in m for m in messages))
         a.tags.add.assert_any_call("defending", category="status")
 
 

--- a/typeclasses/tests/test_combat_engine.py
+++ b/typeclasses/tests/test_combat_engine.py
@@ -215,7 +215,8 @@ class TestCombatEngine(unittest.TestCase):
                 engine.process_round()
 
             expected = get_condition_msg(b.hp, b.traits.health.max)
-            calls = [c.args[0] for c in room.msg_contents.call_args_list]
+            output = room.msg_contents.call_args_list[0].args[0]
+            calls = output.splitlines()
             self.assertFalse(any(f"The {b.key} {expected}" in msg for msg in calls))
             room.reset_mock()
 
@@ -241,7 +242,8 @@ class TestCombatEngine(unittest.TestCase):
             engine.start_round()
             engine.process_round()
 
-        calls = [c.args[0] for c in room.msg_contents.call_args_list]
+        output = room.msg_contents.call_args_list[0].args[0]
+        calls = output.splitlines()
         self.assertTrue(any("attacker dealt 3 damage" in msg for msg in calls))
 
     def test_participant_without_hp_removed(self):

--- a/typeclasses/tests/test_combat_flow.py
+++ b/typeclasses/tests/test_combat_flow.py
@@ -169,7 +169,8 @@ class TestAttackAction(unittest.TestCase):
             engine.start_round()
             engine.process_round()
 
-        calls = [c.args[0] for c in attacker.location.msg_contents.call_args_list]
+        output = attacker.location.msg_contents.call_args_list[0].args[0]
+        calls = output.splitlines()
         self.assertTrue(any("fists" in msg for msg in calls))
 
 def test_npc_attack_uses_natural_weapon(self):


### PR DESCRIPTION
## Summary
- accumulate damage messages during `_execute_action`
- join collected messages for one broadcast per round
- update unit tests to parse grouped output

## Testing
- `pytest -q` *(fails: django setup errors)*

------
https://chatgpt.com/codex/tasks/task_e_6852db635eec832ca8cdf839e6c5414c