### PR TITLE
Implement combat highlight helper

### DIFF
--- a/combat/combat_skills.py
+++ b/combat/combat_skills.py
@@ -17,6 +17,7 @@ class SkillCategory(str, Enum):
 from typing import TYPE_CHECKING
 
 from .combat_utils import roll_damage, roll_evade
+from . import combat_utils
 from .combat_states import CombatState
 from world.system import stat_manager
 from world.skills.kick import Kick
@@ -59,7 +60,9 @@ class ShieldBash(Skill):
                 return CombatResult(
                     actor=user,
                     target=target,
-                    message=f"{user.key}'s shield bash misses {target.key}.",
+                    message=combat_utils.highlight_keywords(
+                        f"{user.key}'s shield bash misses {target.key}."
+                    ),
                 )
             dmg = roll_damage(self.damage)
             target.hp = max(target.hp - dmg, 0)
@@ -72,7 +75,9 @@ class ShieldBash(Skill):
             return CombatResult(
                 actor=user,
                 target=target,
-                message=f"{user.key}'s shield bash misses {target.key}.",
+                message=combat_utils.highlight_keywords(
+                    f"{user.key}'s shield bash misses {target.key}."
+                ),
             )
 
 
@@ -91,13 +96,17 @@ class Cleave(Skill):
             return CombatResult(actor=user, target=target, message="They are already down.")
         if stat_manager.check_hit(user, target):
             if roll_evade(user, target):
-                msg = f"{user.key}'s cleave misses {target.key}."
+                msg = combat_utils.highlight_keywords(
+                    f"{user.key}'s cleave misses {target.key}."
+                )
             else:
                 dmg = roll_damage(self.damage)
                 target.hp = max(target.hp - dmg, 0)
                 msg = f"{user.key} cleaves {target.key} for {dmg} damage!"
         else:
-            msg = f"{user.key}'s cleave misses {target.key}."
+            msg = combat_utils.highlight_keywords(
+                f"{user.key}'s cleave misses {target.key}."
+            )
         return CombatResult(actor=user, target=target, message=msg)
 
 

--- a/combat/combat_utils.py
+++ b/combat/combat_utils.py
@@ -218,6 +218,16 @@ def format_combat_message(
     return f"{a_name} {action} {t_name}!"
 
 
+def highlight_keywords(text: str) -> str:
+    """Wrap common combat phrases in ANSI color codes."""
+
+    if not text:
+        return text
+    text = text.replace("misses", "|Cmisses|n")
+    text = text.replace("Critical hit!", "|RCritical hit!|n")
+    return text
+
+
 def get_condition_msg(hp: int, max_hp: int) -> str:
     """Return a short description of current health."""
 

--- a/typeclasses/tests/test_attack_parry_block_crit.py
+++ b/typeclasses/tests/test_attack_parry_block_crit.py
@@ -104,6 +104,7 @@ class TestAttackReactions(unittest.TestCase):
         self.assertEqual(self.defender.hp, 0)
         calls = [c.args[0] for c in self.attacker.location.msg_contents.call_args_list]
         self.assertTrue(any("Critical" in msg for msg in calls))
+        self.assertTrue(any("|R" in msg for msg in calls))
         mp.assert_called()
         mb.assert_called()
         mcrit.assert_called()

--- a/typeclasses/tests/test_skill_spell_usage.py
+++ b/typeclasses/tests/test_skill_spell_usage.py
@@ -42,6 +42,7 @@ class TestSkillAndSpellUsage(EvenniaTest):
             result = self.char1.use_skill("cleave", target=self.char2)
         self.assertEqual(self.char2.hp, 10)
         self.assertIn("misses", result.message)
+        self.assertIn("|C", result.message)
 
     def test_cast_spell_converts_dict(self):
         self.char1.db.spells = {"fireball": 100}

--- a/world/abilities.py
+++ b/world/abilities.py
@@ -11,6 +11,7 @@ from django.conf import settings
 from evennia.utils import logger
 
 from combat.combat_skills import SKILL_CLASSES, SkillCategory
+from combat import combat_utils
 from world.spells import SPELLS, Spell
 from world.system import state_manager
 from utils.ansi_utils import format_ansi_title
@@ -82,6 +83,7 @@ def use_skill(actor, target, skill_name: str) -> CombatResult:
         msg = f"{colorize_name(actor.key)}'s {skill.name} misses {colorize_name(target.key)}."
         if getattr(settings, "COMBAT_SHOW_HIT", False):
             msg += f" [HIT {hit_chance}%]"
+        msg = combat_utils.highlight_keywords(msg)
         return CombatResult(actor, target, msg)
 
     result = skill.resolve(actor, target)
@@ -89,6 +91,8 @@ def use_skill(actor, target, skill_name: str) -> CombatResult:
         result.message += f" [HIT {hit_chance}%]"
     for eff in getattr(skill, "effects", []):
         state_manager.add_status_effect(target, eff.key, eff.duration)
+    if result.message:
+        result.message = combat_utils.highlight_keywords(result.message)
     return result
 
 
@@ -141,6 +145,7 @@ def cast_spell(actor, spell_key: str, target: Optional[object] = None) -> Combat
         msg = f"{aname} casts {spell.key} at {tname}!"
     else:
         msg = f"{aname} casts {spell.key} at {tname}, but it fizzles."
+    msg = combat_utils.highlight_keywords(msg)
 
     if getattr(settings, "COMBAT_SHOW_HIT", False):
         msg += f" [HIT {hit_chance}%]"

--- a/world/skills/kick.py
+++ b/world/skills/kick.py
@@ -1,4 +1,4 @@
-from combat.combat_utils import roll_evade
+from combat.combat_utils import roll_evade, highlight_keywords
 from combat.damage_types import DamageType
 from world.system import stat_manager
 from .skill import Skill
@@ -28,7 +28,9 @@ class Kick(Skill):
             return CombatResult(
                 actor=user,
                 target=target,
-                message=f"{user.key}'s kick misses {target.key}.",
+                message=highlight_keywords(
+                    f"{user.key}'s kick misses {target.key}."
+                ),
             )
 
         str_val = stat_manager.get_effective_stat(user, "STR")
@@ -42,5 +44,7 @@ class Kick(Skill):
         return CombatResult(
             actor=user,
             target=target,
-            message=f"{user.key} kicks {target.key} for {dmg} damage!",
+            message=highlight_keywords(
+                f"{user.key} kicks {target.key} for {dmg} damage!"
+            ),
         )


### PR DESCRIPTION
## Summary
- colorize combat keywords with a new `highlight_keywords` helper
- apply highlight to combat actions, abilities and skills
- update tests for new color codes in skill/attack messages

## Testing
- `pytest typeclasses/tests/test_skill_spell_usage.py -q` *(fails: OperationalError no such table)*

------
https://chatgpt.com/codex/tasks/task_e_6852db6d7684832cbb9bcd6acb01d765