### PR TITLE
Refactor XP awarding helpers

### DIFF
--- a/combat/engine/damage_processor.py
+++ b/combat/engine/damage_processor.py
@@ -63,19 +63,19 @@ class DamageProcessor:
     def solo_gain(self, chara, exp: int) -> None:
         if not exp or not chara:
             return
-        if hasattr(chara, "msg"):
-            chara.msg(f"You gain |Y{exp}|n experience points.")
-        state_manager.gain_xp(chara, exp)
+        from combat.combat_utils import award_xp
+
+        award_xp(chara, exp)
 
     def group_gain(self, members: List[object], exp: int) -> None:
         members = [m for m in members if m]
         if not members or not exp:
             return
+        from combat.combat_utils import award_xp
+
         share = max(int(exp / len(members)), int(exp * 0.10))
         for member in members:
-            if hasattr(member, "msg"):
-                member.msg(f"You gain |Y{share}|n experience points.")
-            state_manager.gain_xp(member, share)
+            award_xp(member, share)
 
     def apply_damage(self, attacker, target, amount: int, damage_type: DamageType | None) -> int:
         if hasattr(target, "at_damage"):

--- a/commands/quests.py
+++ b/commands/quests.py
@@ -396,9 +396,9 @@ class CmdCompleteQuest(Command):
 
         rewards = []
         if quest.xp_reward:
-            from world.system import state_manager
+            from combat.combat_utils import award_xp
 
-            state_manager.gain_xp(caller, quest.xp_reward)
+            award_xp(caller, quest.xp_reward)
             rewards.append(f"{quest.xp_reward} XP")
 
         from utils.currency import to_copper, from_copper, format_wallet

--- a/commands/shops.py
+++ b/commands/shops.py
@@ -289,8 +289,9 @@ class CmdDonate(Command):
         for obj in objs:
             obj.delete()
 
-        from world.system import state_manager
-        state_manager.gain_xp(self.caller, total)
+        from combat.combat_utils import award_xp
+
+        award_xp(self.caller, total)
 
         self.msg(f"You exchange {obj_name} for {total} experience.")
 

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -1060,16 +1060,16 @@ class NPC(Character):
 
     def award_xp_to(self, attacker):
         """Grant experience reward to ``attacker``."""
-        from world.system import state_manager
+        from combat.combat_utils import award_xp
+
         exp_reward = getattr(self.db, "exp_reward", 0)
         if exp_reward is None:
             exp_reward = 0
         exp = int(exp_reward)
         if not attacker or not exp:
             return
-        if hasattr(attacker, "msg"):
-            attacker.msg(f"You gain |Y{exp}|n experience points.")
-        state_manager.gain_xp(attacker, exp)
+
+        award_xp(attacker, exp)
 
     def on_death(self, attacker):
         """Handle character death cleanup."""

--- a/typeclasses/tests/test_combat_engine.py
+++ b/typeclasses/tests/test_combat_engine.py
@@ -476,6 +476,29 @@ class TestCombatDeath(EvenniaTest):
         )
         self.assertEqual(corpse.db.corpse_of, npc.key)
 
+    def test_award_xp_to_uses_helper(self):
+        from evennia.utils import create
+        from typeclasses.characters import NPC
+
+        npc = create.create_object(NPC, key="mob", location=self.room1)
+        npc.db.exp_reward = 5
+
+        with patch("combat.combat_utils.award_xp") as mock_award:
+            npc.award_xp_to(self.char1)
+            mock_award.assert_called_with(self.char1, 5)
+
+    def test_on_death_uses_award_helper(self):
+        from evennia.utils import create
+        from typeclasses.characters import NPC
+
+        npc = create.create_object(NPC, key="mob", location=self.room1)
+        npc.db.drops = []
+        npc.db.exp_reward = 4
+
+        with patch("combat.combat_utils.award_xp") as mock_award:
+            npc.on_death(self.char1)
+            mock_award.assert_called_with(self.char1, 4, [self.char1])
+
 
 class TestCombatNPCTurn(EvenniaTest):
     def test_at_combat_turn_auto_attack(self):

--- a/world/recipes/base.py
+++ b/world/recipes/base.py
@@ -51,8 +51,9 @@ class SkillRecipe(CraftingRecipe):
         crafter.traits.mana.current -= 5
         # you should get the experience reward regardless of success
         if self.exp_gain:
-            from world.system import state_manager
-            state_manager.gain_xp(crafter, self.exp_gain)
+            from combat.combat_utils import award_xp
+
+            award_xp(crafter, self.exp_gain)
         # implement some randomness - the higher the difference, the lower the chance of failure
         if not randint(0, success_rate):
             self.msg("It doesn't seem to work out. Maybe you should try again?")


### PR DESCRIPTION
## Summary
- centralize XP distribution logic with `award_xp`
- use `award_xp` everywhere experience points are granted
- test that XP helper is called during NPC deaths

## Testing
- `pytest -q` *(fails: no such table accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6852db721aec832cb2881209d7a9cdc9