### PR TITLE
Update Python requirement to 3.10

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.12'
+          python-version: '3.10'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Rooms can optionally store (x, y, "area") coordinates for use with xyzgrid mappi
 
 Installation
 Requirements
-Python 3.12+
+Python 3.10+
 
 Git
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "evennia-minimud"
 version = "1.1.2"
-requires-python = ">=3.12"
+requires-python = ">=3.10"
 authors = [
     {name = "InspectorCaracal"}
 ]


### PR DESCRIPTION
## Summary
- require Python 3.10+ in pyproject and README
- run CI on Python 3.10

## Testing
- `pip install -r requirements-test.txt` *(fails: Invalid requirement)*
- `pytest -q` *(fails: OperationalError: no such table)*

------
https://chatgpt.com/codex/tasks/task_e_6852ec9f9bb8832c821af2935e882ae6