### PR TITLE
Fix pip requirement line

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,6 +2,6 @@
 # Install these first with `pip install -r requirements-test.txt` before
 # running `pytest`. Evennia brings in Django but we list it explicitly to avoid
 # missing dependencies.
-"evennia[extra] >= 4.2, <5.0"
+evennia[extra] >= 4.2, <5.0
 Django>=4.2,<5.0
 pytest


### PR DESCRIPTION
## Summary
- remove quotes from the evennia dependency in `requirements-test.txt`

## Testing
- `pip install -r requirements-test.txt`
- `pip install -e .` *(fails: could not find build dependencies)*
- `pytest -q` *(fails: numerous test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6852f54df924832c96c8990831f9e1ec