### PR TITLE
Add configurable Echo service port

### DIFF
--- a/server/conf/portal_services_plugins.py
+++ b/server/conf/portal_services_plugins.py
@@ -17,6 +17,7 @@ process.
 
 from twisted.internet import protocol
 from twisted.application import internet
+from django.conf import settings
 
 
 class Echo(protocol.Protocol):
@@ -35,5 +36,6 @@ def start_plugin_services(portal):
     # older installs may not define it yet, so fall back to the Portal's
     # parent service when needed.
     application = getattr(portal, "application", None) or portal.parent
-    application.addService(internet.TCPServer(9000, factory))
+    port = getattr(settings, "ECHO_SERVICE_PORT", 9000)
+    application.addService(internet.TCPServer(port, factory))
 

--- a/server/conf/settings.py
+++ b/server/conf/settings.py
@@ -150,6 +150,9 @@ MAX_NR_CHARACTERS = 3
 CMDSET_UNLOGGEDIN = "evennia.contrib.base_systems.menu_login.UnloggedinCmdSet"
 CONNECTION_SCREEN_MODULE = "evennia.contrib.base_systems.menu_login.connection_screens"
 
+# Default port for the Echo portal plugin service
+ECHO_SERVICE_PORT = 9000
+
 ######################################################################
 # Settings given in secret_settings.py override those in this file.
 ######################################################################


### PR DESCRIPTION
## Summary
- allow configuring the echo service port
- read `ECHO_SERVICE_PORT` from settings when starting the portal echo service

## Testing
- `pip install -r requirements-test.txt` *(fails: Invalid requirement)*
- `pytest -q` *(fails: 22 failed, 9 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6852f553dd58832cacce591674d1305d