### PR TITLE
Fix skill usage call

### DIFF
--- a/combat/ai_combat.py
+++ b/combat/ai_combat.py
@@ -152,7 +152,7 @@ def _default_behaviors(npc) -> Iterable[Behavior]:
             if engine:
                 engine.queue_action(n, SkillAction(n, skill, t))
             else:
-                abilities.use_skill(n, skill.name, target=t)
+                abilities.use_skill(n, t, skill.name)
 
         return Behavior(20, check, act)
 

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -621,11 +621,11 @@ class Character(ObjectParent, ClothedCharacter):
         # return the list of hands that are no longer holding the weapon
         return freed
 
-    def use_skill(self, skill_name, *args, **kwargs):
+    def use_skill(self, skill_name, target=None, *args, **kwargs):
         """Attempt to use a skill."""
         from world import abilities
 
-        return abilities.use_skill(self, skill_name, *args, **kwargs)
+        return abilities.use_skill(self, target or self, skill_name, *args, **kwargs)
 
     def cast_spell(self, spell_key, target=None):
         """Cast a known spell."""

--- a/world/abilities.py
+++ b/world/abilities.py
@@ -57,7 +57,7 @@ def use_skill(actor, target, skill_name: str) -> CombatResult:
     """
     from combat.combat_actions import CombatResult
     use_fn = getattr(actor, "use_skill", None)
-    if callable(use_fn):
+    if callable(use_fn) and getattr(use_fn, "__func__", None) is not use_skill:
         return use_fn(skill_name, target=target)
 
     skill_cls = SKILL_CLASSES.get(skill_name)


### PR DESCRIPTION
## Summary
- correct argument order when calling `abilities.use_skill`
- avoid recursion in `world.abilities.use_skill`
- fix NPC AI to use new argument ordering

## Testing
- `pytest -q` *(fails: OperationalError - no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68530f55f7a0832c89ccc02d280dd5e8