### PR TITLE
Fix miss message in Kick skill

### DIFF
--- a/world/skills/kick.py
+++ b/world/skills/kick.py
@@ -31,7 +31,7 @@ class Kick(Skill):
 
         if not hit or evade:
             msg = format_combat_message(user, target, "kick", miss=True)
-            return CombatResult(actor=user, target=target, message=highlight_keywords(msg))
+            return CombatResult(actor=user, target=target, message=msg)
 
         dmg = int(self.base_damage + str_val * 0.2)
 


### PR DESCRIPTION
## Summary
- return CombatResult with normal msg when Kick misses

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6853139e2fe8832cbfe402364e4a182e