### PR TITLE
Add combat skills documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Can I use this as a base for my own game?
 Yes! Please do. Installation instructions are below, and additional documentation can be found on the Evennia website.
 
 Getting Started
-This project uses a round-based combat system that processes queued actions each tick. Refer to docs/combat_loop_mapping.md for a full walkthrough of combat.
+This project uses a round-based combat system that processes queued actions each tick. Refer to docs/combat_loop_mapping.md for a full walkthrough of combat. A summary of default combat abilities can be found in docs/combat_skills.md.
 
 Currency
 There are four coin types:

--- a/docs/combat_skills.md
+++ b/docs/combat_skills.md
@@ -1,0 +1,27 @@
+# Combat Skills
+
+This document summarizes the default combat abilities granted to characters. Skills consume stamina and trigger a cooldown before they can be used again.
+
+## Kick
+- **Cooldown:** 4 seconds
+- **Stamina Cost:** 5
+- **Targets:** Single enemy
+- **Effects:** A basic unarmed attack dealing modest damage.
+
+## Shield Bash
+- **Cooldown:** 6 seconds
+- **Stamina Cost:** 15
+- **Targets:** Single enemy
+- **Effects:** Deals minor damage and has a chance to stun the target for one round.
+
+## Thrust
+- **Cooldown:** 6 seconds
+- **Stamina Cost:** 15
+- **Targets:** Single enemy
+- **Effects:** A precise melee attack for moderate damage. Thrust is a single-target technique.
+
+## Cleave
+- **Cooldown:** 8 seconds
+- **Stamina Cost:** 20
+- **Targets:** 1&ndash;3 nearby enemies
+- **Effects:** Sweeping strike that can hit multiple foes. Cleave can strike several enemies in the same room.


### PR DESCRIPTION
## Summary
- document the default combat skills in `docs/combat_skills.md`
- note that Thrust is single-target while Cleave can hit multiple foes
- link the new document from README

## Testing
- `pytest -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6853139f0f00832ca24c06fe5ba5cec9