### PR TITLE
Rename combat util var

### DIFF
--- a/combat/combat_utils.py
+++ b/combat/combat_utils.py
@@ -199,17 +199,18 @@ def format_combat_message(
         return f"|C{a_name}'s {action} misses {t_name}!|n"
 
     if damage is not None:
-        max_range = state_manager.get_effective_stat(actor, "attack_power")
-        if not max_range:
+        # Estimate the maximum possible damage for color coding
+        max_damage = state_manager.get_effective_stat(actor, "attack_power")
+        if not max_damage:
             level = getattr(getattr(actor, "db", None), "level", 0) or 0
-            max_range = level * 5
-        max_range = max(max_range, 1)
+            max_damage = level * 5
+        max_damage = max(max_damage, 1)
 
-        if damage >= 0.9 * max_range:
+        if damage >= 0.9 * max_damage:
             color = "|R"
-        elif damage >= 0.6 * max_range:
+        elif damage >= 0.6 * max_damage:
             color = "|r"
-        elif damage >= 0.3 * max_range:
+        elif damage >= 0.3 * max_damage:
             color = "|y"
         elif damage > 0:
             color = "|g"

--- a/utils/tests/test_combat_utils.py
+++ b/utils/tests/test_combat_utils.py
@@ -102,11 +102,11 @@ class TestCombatUtils(EvenniaTest):
 
         self.char1.db.level = 20
         with patch("world.system.state_manager.get_effective_stat", return_value=0):
-            max_range = self.char1.db.level * 5
+            max_damage = self.char1.db.level * 5
             levels = [
-                (int(max_range * 0.95), "|R"),
-                (int(max_range * 0.65), "|r"),
-                (int(max_range * 0.35), "|y"),
+                (int(max_damage * 0.95), "|R"),
+                (int(max_damage * 0.65), "|r"),
+                (int(max_damage * 0.35), "|y"),
                 (1, "|g"),
                 (0, "|w"),
             ]


### PR DESCRIPTION
## Summary
- rename `max_range` variable in `format_combat_message` to `max_damage`
- update unit tests accordingly

## Testing
- `pytest -q` *(fails: 636 failed, 49 passed, 2 warnings, 2 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685318296490832cacd8d07b1626b0cb