### PR TITLE
Add docstrings for combat skills

### DIFF
--- a/combat/combat_skills.py
+++ b/combat/combat_skills.py
@@ -67,6 +67,7 @@ class ShieldBash(Skill):
 
 
 class Thrust(Skill):
+    """Basic piercing attack with a melee weapon."""
     name = "thrust"
     category = SkillCategory.MELEE
     damage = (3, 6)
@@ -93,6 +94,7 @@ class Thrust(Skill):
 
 
 class Cleave(Skill):
+    """Wide swing hitting multiple nearby targets."""
     name = "cleave"
     category = SkillCategory.MELEE
     damage = (3, 6)


### PR DESCRIPTION
## Summary
- add short class docstrings for `Thrust` and `Cleave`

## Testing
- `pytest -q` *(fails: OperationalError - no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6853182a3b34832cb803531cb4f7068f