### PR TITLE
Fix misses highlight logic

### DIFF
--- a/combat/combat_utils.py
+++ b/combat/combat_utils.py
@@ -2,6 +2,7 @@
 
 import logging
 import random
+import re
 from typing import Tuple, Iterable
 
 from world.system import state_manager
@@ -228,7 +229,10 @@ def highlight_keywords(text: str) -> str:
 
     if not text:
         return text
-    text = text.replace("misses", "|Cmisses|n")
+
+    # Only colorize "misses" if it is not already color coded
+    text = re.sub(r"(?<!\|C)misses", "|Cmisses|n", text)
+
     text = text.replace("Critical hit!", "|RCritical hit!|n")
     return text
 

--- a/combat/tests/test_highlight_keywords.py
+++ b/combat/tests/test_highlight_keywords.py
@@ -1,0 +1,14 @@
+import unittest
+from combat.combat_utils import highlight_keywords
+
+class TestHighlightKeywords(unittest.TestCase):
+    def test_colors_misses_when_plain(self):
+        result = highlight_keywords("Alice misses Bob")
+        self.assertIn("|Cmisses|n", result)
+
+    def test_skips_when_already_colored(self):
+        text = "Alice |Cmisses|n Bob"
+        self.assertEqual(highlight_keywords(text), text)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- skip highlight for already colorized "misses"
- test the new behavior

## Testing
- `pytest combat/tests/test_highlight_keywords.py -q`


------
https://chatgpt.com/codex/tasks/task_e_685319d118e8832c985621c193490807