### PR TITLE
Adjust spawn manager startup behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,9 +163,9 @@ Room JSONs may include:
 "spawns": [
   {"proto": "mob_goblin", "max_spawns": 2, "spawn_interval": 300}
 ]
-SpawnManager automatically registers spawns when a room prototype is saved. If
-```
-spawns appear to be missing (for example after a server restart), use:
+SpawnManager automatically registers spawns when a room prototype is saved.
+Spawns are not automatically repopulated when the server starts. Use the
+commands below to load spawn data or force a respawn if NPCs are missing:
 
 ```bash
 @spawnreload

--- a/server/conf/at_server_startstop.py
+++ b/server/conf/at_server_startstop.py
@@ -173,8 +173,8 @@ def at_server_start():
                 script.start()
             elif getattr(script.db, "_paused_time", None):
                 script.unpause()
-        if hasattr(script, "reload_spawns"):
-            script.reload_spawns()
+        if hasattr(script, "load_spawn_data"):
+            script.load_spawn_data()
     except Exception as err:
         logger.log_err(f"Failed to initialize spawn_manager script: {err}")
 

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -1184,6 +1184,8 @@ Examples:
 Notes:
     - Room spawns are automatically registered when prototypes are saved. Use
       this command if spawns fail to appear or after manually editing files.
+    - NPCs are not automatically respawned on server startup; run this command
+      to load spawn data if mobs are missing.
 """,
     },
     {


### PR DESCRIPTION
## Summary
- call `load_spawn_data` instead of `reload_spawns` at server start
- clarify spawn manager commands in README and help entries

## Testing
- `pytest -q` *(fails: django-related errors)*

------
https://chatgpt.com/codex/tasks/task_e_68531f6b5df0832c9206d03e8c503cdb