### PR TITLE
Implement helper for clean Evennia startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,18 +213,16 @@ term to filter by account name or IP.
 
 ## Troubleshooting
 
-If `evennia start` fails with "Another twistd server is running", stale processes or files may be left over.
+If `evennia start` fails with "Another twistd server is running", stale
+processes or files may be left over. Launch the included helper script to
+clean up and start the server again:
 
-1. Kill any lingering twistd processes:
-   ```bash
-   pkill -9 twistd
-   ```
-2. Check for `server.pid` and `portal.pid` in the `server/` directory and delete them if present.
-3. Remove any `.twistd-*` directories if they exist.
-4. Run the helper script to reset Evennia:
-   ```bash
-   python reset_evennia.py
-   ```
-   This cleans up lingering processes, frees port 4005, and restarts the server. If Evennia is already running, the script exits with a message.
+```bash
+python start_evennia.py
+```
+
+The script removes stale PID files, kills any orphaned twistd processes, frees
+port 4005 and finally executes `evennia start`. If Evennia is already running it
+simply prints a warning and exits.
 
 Cleaning up these processes and files usually resolves the error.

--- a/start_evennia.py
+++ b/start_evennia.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Utility to cleanly start the Evennia server using `evennia start`.
+
+This script checks for lingering processes or files that might prevent
+Evennia from launching. It removes stale PID files and temporary
+directories and frees the default port before executing ``evennia start``.
+"""
+
+import glob
+import os
+import shutil
+import signal
+import subprocess
+import sys
+
+PORT = 4005
+
+
+def _twistd_processes():
+    """Return a list of running twistd processes as dictionaries."""
+    try:
+        output = subprocess.check_output(
+            ["ps", "axo", "pid,ppid,state,command"], text=True
+        )
+    except subprocess.CalledProcessError:
+        return []
+
+    procs = []
+    for line in output.strip().splitlines()[1:]:
+        parts = line.strip().split(None, 3)
+        if len(parts) < 4:
+            continue
+        pid, ppid, state, cmd = parts
+        if "twistd" in cmd:
+            procs.append({"pid": int(pid), "ppid": int(ppid), "state": state, "cmd": cmd})
+    return procs
+
+
+def _kill_defunct_parents(procs):
+    for p in procs:
+        if "<defunct>" in p["cmd"] or "Z" in p["state"]:
+            try:
+                os.kill(p["ppid"], signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+
+
+def _cleanup_files():
+    for pattern in ["server/*.pid", "server/*.log", ".twistd-*"]:
+        for path in glob.glob(pattern):
+            if os.path.isdir(path):
+                shutil.rmtree(path, ignore_errors=True)
+            else:
+                try:
+                    os.remove(path)
+                except FileNotFoundError:
+                    pass
+
+
+def _kill_port(port: int):
+    try:
+        output = subprocess.check_output(["lsof", "-ti", f":{port}"], text=True)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return
+    for pid in output.strip().splitlines():
+        try:
+            os.kill(int(pid), signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+
+
+def _is_running() -> bool:
+    return os.path.exists("server/server.pid") or os.path.exists("server/portal.pid")
+
+
+def main() -> None:
+    procs = _twistd_processes()
+    _kill_defunct_parents(procs)
+
+    if _is_running():
+        print("Evennia already running.")
+        return
+
+    _cleanup_files()
+    _kill_port(PORT)
+
+    try:
+        subprocess.run(["evennia", "start"], check=True)
+    except FileNotFoundError:
+        print("evennia executable not found.", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `start_evennia.py` script to cleanly start the server
- update README troubleshooting section to reference the new helper

## Testing
- `python -m py_compile start_evennia.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6853216d1494832cb488be1bd450662d