### PR TITLE
Add startup kill_port utility

### DIFF
--- a/reset_evennia.py
+++ b/reset_evennia.py
@@ -8,6 +8,8 @@ import glob
 import shutil
 import sys
 
+from utils.startup_utils import kill_port
+
 PORT = 4005
 
 
@@ -56,18 +58,6 @@ def cleanup_files():
                     os.remove(path)
                 except FileNotFoundError:
                     pass
-
-
-def kill_port(port):
-    try:
-        output = subprocess.check_output(["lsof", "-ti", f":{port}"], text=True)
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        return
-    for pid in output.strip().splitlines():
-        try:
-            os.kill(int(pid), signal.SIGKILL)
-        except ProcessLookupError:
-            pass
 
 
 def evennia_running(procs):

--- a/start_evennia.py
+++ b/start_evennia.py
@@ -13,6 +13,8 @@ import signal
 import subprocess
 import sys
 
+from utils.startup_utils import kill_port
+
 PORT = 4005
 
 
@@ -57,18 +59,6 @@ def _cleanup_files():
                     pass
 
 
-def _kill_port(port: int):
-    try:
-        output = subprocess.check_output(["lsof", "-ti", f":{port}"], text=True)
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        return
-    for pid in output.strip().splitlines():
-        try:
-            os.kill(int(pid), signal.SIGKILL)
-        except ProcessLookupError:
-            pass
-
-
 def _is_running() -> bool:
     return os.path.exists("server/server.pid") or os.path.exists("server/portal.pid")
 
@@ -82,7 +72,7 @@ def main() -> None:
         return
 
     _cleanup_files()
-    _kill_port(PORT)
+    kill_port(PORT)
 
     try:
         subprocess.run(["evennia", "start"], check=True)

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -23,6 +23,7 @@ except Exception:  # pragma: no cover - may fail before Django setup
 from .dice import roll_dice_string
 from .defense_scaling import DefensiveStats
 from .directions import sort_exit_names
+from .startup_utils import kill_port
 
 
 def display_auto_prompt(account, caller, msg_func, *, force=False):

--- a/utils/startup_utils.py
+++ b/utils/startup_utils.py
@@ -1,0 +1,60 @@
+"""Helpers used by startup scripts."""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+
+
+def kill_port(port: int) -> None:
+    """Terminate processes bound to ``port`` if possible."""
+
+    try:  # prefer psutil when available
+        import psutil  # type: ignore
+    except Exception:  # pragma: no cover - optional dependency
+        psutil = None
+
+    if psutil:
+        for proc in psutil.process_iter(["pid", "connections"]):
+            try:
+                for conn in proc.connections(kind="inet"):
+                    if conn.laddr and conn.laddr.port == port:
+                        try:
+                            proc.kill()
+                        finally:
+                            break
+            except Exception:
+                continue
+        return
+
+    if os.name == "posix":
+        try:
+            output = subprocess.check_output(["lsof", "-ti", f":{port}"], text=True)
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            return
+        for pid in output.strip().splitlines():
+            try:
+                os.kill(int(pid), signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+        return
+
+    if os.name == "nt":  # Windows
+        try:
+            output = subprocess.check_output(["netstat", "-ano"], text=True)
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            return
+        for line in output.splitlines():
+            if f":{port} " in line:
+                pid = line.split()[-1]
+                try:
+                    subprocess.run(
+                        ["taskkill", "/F", "/PID", pid],
+                        check=True,
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                    )
+                except subprocess.CalledProcessError:
+                    pass
+


### PR DESCRIPTION
## Summary
- add `utils/startup_utils.py` with cross-platform `kill_port`
- export `kill_port` in `utils.__init__`
- use `kill_port` helper in `start_evennia.py` and `reset_evennia.py`

## Testing
- `pytest -q` *(fails: 240 failed, 24 passed, 2 warnings, 1 error)*

------
https://chatgpt.com/codex/tasks/task_e_6853260a4048832c8f62924c73ed1534