### PR TITLE
Enable NPC skills & spells with color output

### DIFF
--- a/combat/combat_actions.py
+++ b/combat/combat_actions.py
@@ -254,10 +254,13 @@ class SpellAction(Action):
         success = getattr(self.actor, "cast_spell", None)
         if callable(success):
             success(self.spell.key, self.target)
+        from world.spells import colorize_spell
+
+        colored = colorize_spell(self.spell.key)
         result = CombatResult(
             actor=self.actor,
             target=self.target or self.actor,
-            message=f"{self.actor.key} casts {self.spell.key}!",
+            message=f"{self.actor.key} casts {colored}!",
         )
         if getattr(result, "damage", 0):
             result.damage, crit = CombatMath.apply_critical(self.actor, result.target, result.damage)

--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -676,6 +676,10 @@ def finalize_mob_prototype(caller, npc):
     meta = npc.db.metadata or {}
 
     npc.tags.add("npc")
+    if isinstance(npc.db.skills, dict):
+        npc.db.skills = list(npc.db.skills.keys())
+    if isinstance(npc.db.spells, dict):
+        npc.db.spells = list(npc.db.spells.keys())
     npc_type = meta.get("type") or getattr(npc.db, "npc_type", None)
     if npc_type:
         npc.tags.add(npc_type, category="npc_type")

--- a/commands/spells.py
+++ b/commands/spells.py
@@ -1,7 +1,7 @@
 from evennia import CmdSet
 from evennia.utils.evtable import EvTable
 from .command import Command
-from world.spells import SPELLS, Spell
+from world.spells import SPELLS, Spell, colorize_spell
 
 
 class CmdSpellbook(Command):
@@ -112,13 +112,14 @@ class CmdCast(Command):
             if not target:
                 return
         self.caller.traits.mana.current -= spell.mana_cost
+        colored = colorize_spell(spell.key)
         if target:
             self.caller.location.msg_contents(
-                f"{self.caller.get_display_name(self.caller)} casts {spell.key} at {target.get_display_name(self.caller)}!"
+                f"{self.caller.get_display_name(self.caller)} casts {colored} at {target.get_display_name(self.caller)}!"
             )
         else:
             self.caller.location.msg_contents(
-                f"{self.caller.get_display_name(self.caller)} casts {spell.key}!"
+                f"{self.caller.get_display_name(self.caller)} casts {colored}!"
             )
         if isinstance(spell_entry, Spell):
             if spell_entry.proficiency < 100:

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -654,7 +654,7 @@ class Character(ObjectParent, ClothedCharacter):
 
     def cast_spell(self, spell_key, target=None):
         """Cast a known spell, spending mana."""
-        from world.spells import SPELLS
+        from world.spells import SPELLS, colorize_spell
         from world.system import state_manager
 
         spell = SPELLS.get(spell_key)
@@ -680,13 +680,14 @@ class Character(ObjectParent, ClothedCharacter):
             return False
         self.traits.mana.current -= spell.mana_cost
         state_manager.add_cooldown(self, spell.key, spell.cooldown)
+        colored = colorize_spell(spell.key)
         if target:
             self.location.msg_contents(
-                f"{self.get_display_name(self)} casts {spell.key} at {target.get_display_name(self)}!"
+                f"{self.get_display_name(self)} casts {colored} at {target.get_display_name(self)}!"
             )
         else:
             self.location.msg_contents(
-                f"{self.get_display_name(self)} casts {spell.key}!"
+                f"{self.get_display_name(self)} casts {colored}!"
             )
         if srec.proficiency < 100:
             srec.proficiency = min(100, srec.proficiency + 1)

--- a/typeclasses/tests/test_vnum_mobs.py
+++ b/typeclasses/tests/test_vnum_mobs.py
@@ -308,3 +308,17 @@ class TestVnumMobs(EvenniaTest):
             npc.db.primary_stats.get("STR"),
         )
 
+    def test_spawn_converts_skill_spell_lists(self):
+        proto = {
+            "key": "mage",
+            "typeclass": "typeclasses.npcs.BaseNPC",
+            "skills": {"cleave": 100},
+            "spells": {"fireball": 100},
+        }
+        vnum = register_prototype(proto, vnum=81)
+        npc = spawn_from_vnum(vnum, location=self.char1.location)
+        self.assertIsInstance(npc.db.skills, list)
+        self.assertIsInstance(npc.db.spells, list)
+        self.assertIn("cleave", npc.db.skills)
+        self.assertIn("fireball", npc.db.spells)
+

--- a/utils/mob_proto.py
+++ b/utils/mob_proto.py
@@ -214,6 +214,17 @@ def spawn_from_vnum(vnum: int, location=None):
     npc.db.vnum = vnum
     npc.tags.add(f"M{vnum}", category="vnum")
 
+    skills = proto_data.get("skills") or {}
+    if isinstance(skills, dict):
+        npc.db.skills = list(skills.keys())
+    elif isinstance(skills, list):
+        npc.db.skills = [str(s) for s in skills]
+    spells = proto_data.get("spells") or {}
+    if isinstance(spells, dict):
+        npc.db.spells = list(spells.keys())
+    elif isinstance(spells, list):
+        npc.db.spells = [str(s) for s in spells]
+
     mobprogs = proto_data.get("mobprogs") or []
     npc.db.mobprogs = mobprogs
 

--- a/world/spells.py
+++ b/world/spells.py
@@ -15,3 +15,23 @@ SPELLS: Dict[str, Spell] = {
     "fireball": Spell("fireball", "INT", 10, "Hurl a ball of fire at your target.", cooldown=5),
     "heal": Spell("heal", "WIS", 8, "Restore a small amount of health.", cooldown=3),
 }
+
+
+def colorize_spell(name: str) -> str:
+    """Return ``name`` wrapped in an ANSI color based on keywords."""
+
+    lname = name.lower()
+    if any(key in lname for key in ("fire", "flame", "burn")):
+        color = "|r"
+    elif any(key in lname for key in ("ice", "frost", "cold")):
+        color = "|c"
+    elif any(key in lname for key in ("nature", "druid", "plant")):
+        color = "|g"
+    elif any(key in lname for key in ("necrom", "shadow")):
+        color = "|m"
+    elif any(key in lname for key in ("holy", "heal", "light")):
+        color = "|w"
+    else:
+        color = "|M"
+    return f"{color}{name}|n"
+

--- a/world/tests/test_spell_colorization.py
+++ b/world/tests/test_spell_colorization.py
@@ -1,0 +1,12 @@
+from evennia.utils.test_resources import EvenniaTest
+from world.spells import colorize_spell
+
+class TestSpellColor(EvenniaTest):
+    def test_fire_spell_color(self):
+        colored = colorize_spell("fireball")
+        assert colored.startswith("|r") and colored.endswith("|n")
+
+    def test_heal_spell_color(self):
+        colored = colorize_spell("heal")
+        assert colored.startswith("|w") and colored.endswith("|n")
+


### PR DESCRIPTION
## Summary
- support colorized spell names
- convert NPC skill and spell data to player format when spawning or finalizing
- highlight spells for players and NPCs in combat log
- test spawn conversion and spell colorization

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6853352a21fc832c98ff16ed654f219a