### PR TITLE
Refactor spell proficiency tracking

### DIFF
--- a/typeclasses/tests/test_spell_proficiency.py
+++ b/typeclasses/tests/test_spell_proficiency.py
@@ -18,5 +18,5 @@ class TestSpellLearning(EvenniaTest):
         spells = self.char1.db.spells
         self.assertEqual(len(spells), 1)
         self.assertEqual(spells[0].key, "fireball")
-        self.assertEqual(spells[0].proficiency, 25)
+        self.assertEqual(self.char1.db.proficiencies.get("fireball"), 25)
         self.assertEqual(self.char1.db.practice_sessions, 0)

--- a/typeclasses/tests/test_spellbook_command.py
+++ b/typeclasses/tests/test_spellbook_command.py
@@ -7,7 +7,7 @@ class TestSpellbook(EvenniaTest):
     def setUp(self):
         super().setUp()
         # give char1 a known spell
-        self.char1.db.spells = [Spell("fireball", "INT", 10, "A fiery blast.", 50)]
+        self.char1.db.spells = [Spell("fireball", "INT", 10, "A fiery blast.")]
         self.char1.msg = MagicMock()
 
     def test_spellbook_lists_spells(self):

--- a/world/spells.py
+++ b/world/spells.py
@@ -8,7 +8,6 @@ class Spell:
     mana_cost: int
     desc: str = ""
     cooldown: int = 0
-    proficiency: int = 0
     # Optional skill providing a proficiency bonus to casting success
     support_skill: str | None = None
 


### PR DESCRIPTION
## Summary
- store spell proficiency in `caller.db.proficiencies`
- update spellbook and cast commands
- track proficiency when spells are learned and cast
- adjust tests for new behaviour

## Testing
- `pytest -q` *(fails: OperationalError - no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68534492a1c8832cb321de9dab95a9e7