### PR TITLE
Add support skill bonuses

### DIFF
--- a/combat/combat_skills.py
+++ b/combat/combat_skills.py
@@ -30,6 +30,8 @@ class Skill:
     damage: tuple[int, int] | None = None
     stamina_cost: int = 0
     cooldown: int = 0
+    # Optional skill granting a proficiency bonus to success chance
+    support_skill: str | None = None
     effects: List[CombatState] = field(default_factory=list)
 
     def resolve(self, user, target) -> CombatResult:
@@ -38,6 +40,7 @@ class Skill:
 
 class ShieldBash(Skill):
     name = "shield bash"
+    support_skill = None
     category = SkillCategory.MELEE
     damage = (2, 6)
     cooldown = 6
@@ -74,6 +77,7 @@ class Cleave(Skill):
     """Powerful swing hitting a single foe."""
 
     name = "cleave"
+    support_skill = "swords"
     category = SkillCategory.MELEE
     damage = (3, 6)
     stamina_cost = 20

--- a/utils/hit_chance.py
+++ b/utils/hit_chance.py
@@ -11,7 +11,8 @@ def calculate_hit_success(chara, ability_key, support_skill=None):
     ability_key : str
         Key of the primary ability being attempted.
     support_skill : str, optional
-        Name of a supporting skill providing a small bonus.
+        Name of a secondary skill providing a proficiency bonus. Every
+        10 points in this skill adds +1% to the success chance.
     """
     profs = getattr(getattr(chara, "db", None), "proficiencies", {}) or {}
     chance = profs.get(ability_key, 0)

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -3823,6 +3823,8 @@ Usage:
 Learn new spells from trainers with |wlearn|n. Spells start at 25% proficiency.
 Use practice sessions with |wlearn|n to raise proficiency up to 75%. Casting
 spells will slowly increase proficiency to a maximum of 100%.
+Some spells list a supporting skill such as |wspellcasting|n. Every 10 points in
+that skill grants +1% casting success chance.
 Usage: |wcast <spell> [on <target>]|n consumes mana based on the spell.
 """,
     },

--- a/world/skills/kick.py
+++ b/world/skills/kick.py
@@ -9,6 +9,8 @@ class Kick(Skill):
     """Basic unarmed kick attack."""
 
     name = "kick"
+    #: Proficiency with this skill is boosted by unarmed training
+    support_skill = "unarmed"
     cooldown = 4
     stamina_cost = 5
     base_damage = 5

--- a/world/spells.py
+++ b/world/spells.py
@@ -13,8 +13,22 @@ class Spell:
 
 
 SPELLS: Dict[str, Spell] = {
-    "fireball": Spell("fireball", "INT", 10, "Hurl a ball of fire at your target.", cooldown=5),
-    "heal": Spell("heal", "WIS", 8, "Restore a small amount of health.", cooldown=3),
+    "fireball": Spell(
+        "fireball",
+        "INT",
+        10,
+        "Hurl a ball of fire at your target.",
+        cooldown=5,
+        support_skill="spellcasting",
+    ),
+    "heal": Spell(
+        "heal",
+        "WIS",
+        8,
+        "Restore a small amount of health.",
+        cooldown=3,
+        support_skill="spellcasting",
+    ),
 }
 
 


### PR DESCRIPTION
## Summary
- set `support_skill` on Kick, Cleave, Shield Bash and spells
- include `support_skill` in skill dataclass
- document bonus behaviour in hit chance helper and spell help

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_685347246810832c8e9133345b89f88e