### PR TITLE
Add cooldown and hit chance tests

### DIFF
--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -419,6 +419,16 @@ class TestInfoCommands(EvenniaTest):
         self.assertIn("Speed Boost", out)
         self.assertNotIn("Strength Bonus", out)
 
+    def test_affects_displays_active_cooldowns(self):
+        from world.system import state_manager
+
+        state_manager.add_cooldown(self.char1, "fireball", 5)
+        state_manager.add_cooldown(self.char1, "recall", 12)
+        self.char1.execute_cmd("affects")
+        out = self.char1.msg.call_args[0][0]
+        self.assertIn("Fireball", out)
+        self.assertIn("Recall", out)
+
     def test_guild(self):
         self.char1.db.guild = "Adventurers Guild"
         self.char1.execute_cmd("guild")

--- a/utils/tests/test_hit_chance.py
+++ b/utils/tests/test_hit_chance.py
@@ -1,0 +1,24 @@
+from unittest.mock import MagicMock, patch
+from evennia.utils.test_resources import EvenniaTest
+
+from utils.hit_chance import calculate_hit_success
+
+
+class TestCalculateHitSuccess(EvenniaTest):
+    def test_primary_proficiency(self):
+        char = MagicMock()
+        char.db = MagicMock(proficiencies={"cleave": 50})
+        with patch("random.randint", return_value=50):
+            self.assertTrue(calculate_hit_success(char, "cleave"))
+        with patch("random.randint", return_value=51):
+            self.assertFalse(calculate_hit_success(char, "cleave"))
+
+    def test_support_skill_bonus(self):
+        char = MagicMock()
+        char.db = MagicMock(proficiencies={"fireball": 50, "spellcasting": 30})
+        # total chance = 50 + 3 = 53
+        with patch("random.randint", return_value=53):
+            self.assertTrue(calculate_hit_success(char, "fireball", "spellcasting"))
+        with patch("random.randint", return_value=54):
+            self.assertFalse(calculate_hit_success(char, "fireball", "spellcasting"))
+


### PR DESCRIPTION
## Summary
- expand skill & spell usage tests to cover success and failure with patched hit chance
- ensure CmdAffects displays active cooldowns
- add unit tests for calculate_hit_success

## Testing
- `pytest -q` *(fails: OperationalError - no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68534d86966c832c867ef3b8b9a81431