### PR TITLE
Add vnum info to room look output

### DIFF
--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -106,6 +106,24 @@ class RoomParent(ObjectParent):
                 name = f"{name} - {room_id}"
         return name
 
+    def get_display_title(self, looker):
+        """Return the formatted room title used when displaying the room."""
+
+        title = self.key
+        if looker and (
+            looker.check_permstring("Builder") or looker.check_permstring("Admin")
+        ):
+            area = self.get_area()
+            room_id = self.get_room_id()
+            bits = []
+            if area:
+                bits.append(str(area))
+            if room_id is not None:
+                bits.append(f"[vnum: {room_id}]")
+            if bits:
+                title = f"{title} |w({' '.join(bits)})|n"
+        return title
+
     def get_display_footer(self, looker, **kwargs):
         cmd_keys = [
             f"|w{cmd.key}|n"
@@ -123,7 +141,8 @@ class RoomParent(ObjectParent):
         if not looker:
             return ""
 
-        text = f"|c{self.get_display_name(looker)}|n\n{self.db.desc}\n"
+        title = self.get_display_title(looker)
+        text = f"|c{title}|n\n{self.db.desc}\n"
         text += f"\n{self.get_display_exits(looker)}"
 
         visible = [

--- a/typeclasses/tests/test_objects_basic.py
+++ b/typeclasses/tests/test_objects_basic.py
@@ -221,6 +221,27 @@ class TestRoomDisplayName(EvenniaTest):
         self.assertEqual(name, "field")
 
 
+class TestRoomAppearanceMetadata(EvenniaTest):
+    def test_builder_sees_area_and_vnum(self):
+        from typeclasses.rooms import Room
+
+        room = create_object(Room, key="square")
+        room.set_area("Midgard", 200054)
+        self.char1.permissions.add("Builder")
+
+        out = room.return_appearance(self.char1)
+        self.assertIn("Midgard [vnum: 200054]", out)
+
+    def test_player_hides_area_and_vnum(self):
+        from typeclasses.rooms import Room
+
+        room = create_object(Room, key="square")
+        room.set_area("Midgard", 200054)
+
+        out = room.return_appearance(self.char1)
+        self.assertNotIn("vnum: 200054", out)
+
+
 class TestMeleeWeaponAtAttack(EvenniaTest):
     def test_damage_dice_only(self):
         weapon = create_object(


### PR DESCRIPTION
## Summary
- display area and VNUM in room titles for builders/admins
- verify new behaviour in tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685352d15d90832c805e9eed8957f13f