### PR TITLE
Improve map padding

### DIFF
--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -6,6 +6,7 @@ Rooms are simple containers that have no location of their own.
 
 from evennia import create_object
 from evennia.utils import iter_to_str, logger, lazy_property
+from utils import ansi_pad
 from evennia.objects.objects import DefaultRoom
 from evennia.contrib.grid.xyzgrid.xyzroom import XYZRoom
 from evennia.contrib.grid.wilderness.wilderness import WildernessRoom
@@ -214,12 +215,13 @@ class Room(RoomParent, DefaultRoom):
             row = []
             for col_x in range(x - 1, x + 2):
                 if (col_x, row_y) == (x, y):
-                    row.append("[X]")
+                    symbol = "|g@|n"
                 elif (row_y == y and abs(col_x - x) == 1) or (col_x == x and abs(row_y - y) == 1):
                     room_exists = bool(ObjectDB.objects.get_by_attribute(key="coord", value=(col_x, row_y)))
-                    row.append("[ ]" if room_exists else "   ")
+                    symbol = "|g#|n" if room_exists else ""
                 else:
-                    row.append("   ")
+                    symbol = ""
+                row.append(ansi_pad(symbol, 3))
             map_lines.append("".join(row))
 
         return "\n".join(map_lines)

--- a/typeclasses/tests/test_room_minimap.py
+++ b/typeclasses/tests/test_room_minimap.py
@@ -33,9 +33,9 @@ class TestRoomMinimap(EvenniaTest):
         
         map_output = room.generate_map(self.char1)
         expected = [
-            "   [ ]   ",
-            "[ ][X][ ]",
-            "   [ ]   ",
+            "    |g#|n    ",
+            " |g#|n  |g@|n  |g#|n ",
+            "    |g#|n    ",
         ]
         self.assertEqual(map_output.splitlines(), expected)
 
@@ -46,7 +46,7 @@ class TestRoomMinimap(EvenniaTest):
         map_output = room.generate_map(self.char1)
         expected = [
             "         ",
-            "   [X]   ",
+            "    |g@|n    ",
             "         ",
         ]
         self.assertEqual(map_output.splitlines(), expected)
@@ -89,9 +89,9 @@ class TestRoomMinimap(EvenniaTest):
         
         # Expected 3x3 map with surrounding rooms
         expected_map = "\n".join([
-            "   [ ]   ",
-            "[ ][X][ ]",
-            "   [ ]   ",
+            "    |g#|n    ",
+            " |g#|n  |g@|n  |g#|n ",
+            "    |g#|n    ",
         ])
         
         generated_map = center.generate_map(self.char1)

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -2,7 +2,7 @@ from .roles import has_role, is_guildmaster, is_receptionist
 
 
 from .slots import VALID_SLOTS, normalize_slot
-from .ansi_utils import format_ansi_title
+from .ansi_utils import format_ansi_title, ansi_pad
 from .menu_utils import add_back_skip
 try:  # optional during early initialization
     from .mob_utils import (

--- a/utils/ansi_utils.py
+++ b/utils/ansi_utils.py
@@ -1,4 +1,19 @@
 import re
+from evennia.utils.ansi import strip_ansi
+
+
+def ansi_pad(text: str, width: int, align: str = "c") -> str:
+    """Return ``text`` padded to ``width`` while ignoring ANSI codes."""
+
+    real_len = len(strip_ansi(text))
+    pad_len = max(width - real_len, 0)
+    if align == "l":
+        return text + " " * pad_len
+    if align == "r":
+        return " " * pad_len + text
+    left = pad_len // 2
+    right = pad_len - left
+    return " " * left + text + " " * right
 
 
 def format_ansi_title(name: str) -> str:

--- a/world/maps/overworld.py
+++ b/world/maps/overworld.py
@@ -91,6 +91,7 @@ from evennia.contrib.grid.wilderness import wilderness
 from evennia.prototypes import spawner
 from evennia.utils.search import search_tag
 from evennia.utils import logger, pad
+from utils import ansi_pad
 
 
 class OverworldMapProvider(wilderness.WildernessMapProvider):
@@ -146,6 +147,7 @@ class OverworldMapProvider(wilderness.WildernessMapProvider):
             if i == y:
                 # mark our location
                 row = row[:2] + "|g@|n" + row[3:]
+            row = ansi_pad(row, 5)
             minimap.append(" " * 12 + row + " " * 12)
         minimap.append(border)
         room.ndb.minimap = "\n".join(minimap)


### PR DESCRIPTION
## Summary
- add `ansi_pad` helper for padding text containing ANSI colors
- update `generate_map` with 3-wide padded tiles
- pad overworld minimap rows with `ansi_pad`
- export helper from utils
- adjust minimap tests to expect padded/colored output

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685354fa4dd0832c9fe015d2bb87b4bd