### PR TITLE
Add padding around minimap output

### DIFF
--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -227,7 +227,10 @@ class Room(RoomParent, DefaultRoom):
     def return_appearance(self, looker):
         appearance = super().return_appearance(looker)
         minimap = self.generate_map(looker)
-        return f"{minimap}\n{appearance}" if minimap else appearance
+        if minimap:
+            # Surround the visual map with blank lines for readability
+            return f"\n{minimap}\n\n{appearance}"
+        return appearance
 
     def get_display_header(self, looker, **kwargs):
         area = self.get_area()

--- a/typeclasses/tests/test_room_minimap.py
+++ b/typeclasses/tests/test_room_minimap.py
@@ -61,9 +61,12 @@ class TestRoomMinimap(EvenniaTest):
         
         appearance = room.return_appearance(self.char1)
         map_lines = room.generate_map(self.char1).splitlines()
-        
-        # Confirm that map appears at the top of room description
-        self.assertEqual(appearance.splitlines()[:len(map_lines)], map_lines)
+
+        # Confirm the blank line and map at the top of room description
+        appearance_lines = appearance.splitlines()
+        self.assertEqual(appearance_lines[0], "")
+        self.assertEqual(appearance_lines[1:1 + len(map_lines)], map_lines)
+        self.assertEqual(appearance_lines[1 + len(map_lines)], "")
 
     def test_xygrid_map_and_appearance(self):
         # Center + 4 directions
@@ -96,6 +99,13 @@ class TestRoomMinimap(EvenniaTest):
         
         generated_map = center.generate_map(self.char1)
         self.assertEqual(generated_map, expected_map)
-        
+
         appearance = center.return_appearance(self.char1)
-        self.assertTrue(appearance.startswith(expected_map))
+        appearance_lines = appearance.splitlines()
+        expected_lines = expected_map.splitlines()
+
+        self.assertEqual(appearance_lines[0], "")
+        self.assertEqual(
+            appearance_lines[1:1 + len(expected_lines)], expected_lines
+        )
+        self.assertEqual(appearance_lines[1 + len(expected_lines)], "")


### PR DESCRIPTION
## Summary
- add blank lines before and after room minimap output
- update minimap tests for new padded output

## Testing
- `pytest typeclasses/tests/test_room_minimap.py::TestRoomMinimap::test_map_in_return_appearance -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6853572cb530832c89db37a3b6e5cb8d