### PR TITLE
Add wander act flag to mob constants

### DIFF
--- a/world/menus/mob_builder_menu.py
+++ b/world/menus/mob_builder_menu.py
@@ -1148,7 +1148,7 @@ def menunode_actflags(caller, raw_string="", **kwargs):
     if default:
         text += f" [default: {' '.join(default)}]"
     text += f"\nAvailable: {flags}"
-    text += "\nExample: |wsentinel aggressive assist call_for_help|n"
+    text += "\nExample: |wsentinel wander aggressive assist call_for_help|n"
     text += "\n(back to go back, skip for default)"
     options = add_back_skip({"key": "_default", "goto": _set_actflags}, _set_actflags)
     return with_summary(caller, text), options

--- a/world/mob_constants.py
+++ b/world/mob_constants.py
@@ -65,6 +65,7 @@ class ACTFLAGS(_StrEnum):
     SCAVENGER = "scavenger"
     AGGRESSIVE = "aggressive"
     STAY_AREA = "stay_area"
+    WANDER = "wander"
     WIMPY = "wimpy"
     ASSIST = "assist"
     CALL_FOR_HELP = "call_for_help"


### PR DESCRIPTION
## Summary
- support wander act flag for mobs
- mention wander in mob builder UI

## Testing
- `pytest -q` *(fails: 625 failed, 28 passed, 2 warnings, 2 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68535b41cae4832c86fc806805faba2e