### PR TITLE
Move call for help to mob AI

### DIFF
--- a/world/npc_handlers/ai.py
+++ b/world/npc_handlers/ai.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from evennia import DefaultObject
 from typeclasses.npcs import BaseNPC
 from combat.ai import get_ai_class
+from .mob_ai import _call_for_help
 
 
 def process_ai(npc: DefaultObject) -> None:
@@ -21,19 +22,7 @@ def process_ai(npc: DefaultObject) -> None:
             if leader.in_combat and target and not npc.in_combat:
                 npc.enter_combat(target)
 
-    if "call_for_help" in flags and npc.in_combat and not npc.ndb.get("called_for_help"):
-        npc.ndb.called_for_help = True
-        if npc.location:
-            npc.location.msg_contents(f"{npc.key} calls for help!")
-            target = npc.db.combat_target
-            if target:
-                for obj in npc.location.contents:
-                    if obj is npc or not isinstance(obj, BaseNPC):
-                        continue
-                    if obj.in_combat:
-                        continue
-                    if "assist" in set(obj.db.actflags or []):
-                        obj.enter_combat(target)
+    _call_for_help(npc)
 
     ai_cls = get_ai_class(ai_type.lower())
     if ai_cls:


### PR DESCRIPTION
## Summary
- centralize call for help behaviour in `world.npc_handlers.mob_ai`
- ensure mobs only call for help once per combat
- test that allies join combat when a caller asks for help

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6853639efd6c832cb3208a36fb3eb38a