### PR TITLE
Implement wimpy flee behavior

### DIFF
--- a/typeclasses/tests/test_mob_ai.py
+++ b/typeclasses/tests/test_mob_ai.py
@@ -157,3 +157,20 @@ class TestMobAIBehaviors(EvenniaTest):
             mob_ai.process_mob_ai(caller)
             mock.assert_not_called()
         self.assertFalse(self.room1.msg_contents.called)
+
+    def test_wimpy_flees_when_low_hp(self):
+        from typeclasses.npcs import BaseNPC
+        from combat.round_manager import CombatRoundManager
+
+        npc = create.create_object(BaseNPC, key="coward", location=self.room1)
+        npc.db.actflags = ["wimpy"]
+        npc.hp = 20
+        npc.max_hp = 100
+        manager = CombatRoundManager.get()
+        manager.start_combat([npc, self.char1])
+
+        npc.execute_cmd = MagicMock()
+
+        mob_ai.process_mob_ai(npc)
+
+        npc.execute_cmd.assert_called_with("flee")

--- a/world/npc_handlers/mob_ai.py
+++ b/world/npc_handlers/mob_ai.py
@@ -215,6 +215,26 @@ def _call_for_help(npc: BaseNPC) -> None:
 
 
 
+def _check_wimpy(npc: BaseNPC) -> bool:
+    """Flee combat if health is low and the mob is wimpy."""
+
+    flags = set(npc.db.actflags or [])
+    if "wimpy" not in flags:
+        return False
+    if not npc.in_combat:
+        return False
+
+    threshold = npc.db.get("flee_at")
+    if threshold is None:
+        maxhp = npc.max_hp or 0
+        threshold = int(maxhp * 0.25)
+
+    if npc.hp <= threshold:
+        npc.execute_cmd("flee")
+        return True
+    return False
+
+
 # ------------------------------------------------------------
 # Main AI entry
 # ------------------------------------------------------------
@@ -226,6 +246,8 @@ def process_mob_ai(npc: BaseNPC) -> None:
 
     _assist_allies(npc)
     _call_for_help(npc)
+    if _check_wimpy(npc):
+        return
 
     if npc.in_combat and npc.db.combat_target:
         npc_take_turn(None, npc, npc.db.combat_target)


### PR DESCRIPTION
## Summary
- add `_check_wimpy` helper for wimpy mobs
- invoke new helper from mob AI processor
- test that wimpy NPC flees once low on health

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68536ad43b48832ca0d00392ce9af7d0