### PR TITLE
Fix wander flag inclusion in NPC AI

### DIFF
--- a/typeclasses/npcs/__init__.py
+++ b/typeclasses/npcs/__init__.py
@@ -8,7 +8,7 @@ class BaseNPC(NPC):
 
     def at_object_creation(self):
         super().at_object_creation()
-        ai_flags = {"aggressive", "scavenger", "assist", "call_for_help"}
+        ai_flags = {"aggressive", "scavenger", "assist", "call_for_help", "wander"}
         flags = set(self.db.actflags or [])
         if self.db.ai_type or ai_flags.intersection(flags):
             self.tags.add("npc_ai")


### PR DESCRIPTION
## Summary
- include "wander" in the auto-tagging list for BaseNPC creation

## Testing
- `scripts/setup_test_env.sh` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68536d646bd4832cbf38c6a5d243875b