### PR TITLE
Handle noloot flag in corpse creation

### DIFF
--- a/utils/mob_utils.py
+++ b/utils/mob_utils.py
@@ -121,18 +121,21 @@ def make_corpse(npc):
         attributes=attrs,
     )
 
-    # move carried items
-    for obj in list(npc.contents):
-        obj.location = corpse
+    no_loot = ACTFLAGS.NOLOOT.value in (npc.db.actflags or [])
 
-    moved = set()
-    for item in npc.equipment.values():
-        if item and item not in moved:
-            item.location = corpse
-            moved.add(item)
+    if not no_loot:
+        # move carried items
+        for obj in list(npc.contents):
+            obj.location = corpse
+
+        moved = set()
+        for item in npc.equipment.values():
+            if item and item not in moved:
+                item.location = corpse
+                moved.add(item)
 
     # drop carried coins unless flagged NOLOOT
-    if ACTFLAGS.NOLOOT.value not in (npc.db.actflags or []):
+    if not no_loot:
         for coin, amt in (npc.db.coins or {}).items():
             if int(amt):
                 pile = create_object(

--- a/utils/tests/test_mob_utils.py
+++ b/utils/tests/test_mob_utils.py
@@ -49,3 +49,20 @@ class TestMobUtils(EvenniaTest):
         corpse = make_corpse(npc)
         script = corpse.scripts.get("decay")[0]
         self.assertEqual(script.interval, 60)
+
+    def test_make_corpse_no_loot_empty(self):
+        from evennia.utils import create
+        from typeclasses.characters import NPC
+        from typeclasses.objects import Object
+
+        npc = create.create_object(NPC, key="mob", location=self.room1)
+        npc.db.actflags = ["noloot"]
+
+        inv_item = create.create_object(Object, key="inv", location=npc)
+        eq_item = create.create_object(Object, key="sword", location=npc)
+        npc.db.equipment = {"mainhand": eq_item}
+
+        corpse = make_corpse(npc)
+        self.assertFalse(corpse.contents)
+        self.assertEqual(inv_item.location, npc)
+        self.assertEqual(eq_item.location, npc)


### PR DESCRIPTION
## Summary
- respect `noloot` flag when creating corpses
- ensure no items transfer to a noloot corpse

## Testing
- `pytest utils/tests/test_mob_utils.py::TestMobUtils::test_make_corpse_no_loot_empty -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68536e404944832cb9a09833f17a2e26