### PR TITLE
Add flag conflict warning in validate_prototype

### DIFF
--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -86,6 +86,9 @@ def validate_prototype(data: dict) -> list[str]:
     if "sentinel" in actflags and ai_type == "wander":
         warnings.append("Sentinel flag conflicts with wander AI type.")
 
+    if "sentinel" in actflags and "wander" in actflags:
+        warnings.append("Sentinel flag conflicts with wander flag.")
+
     combat_class = data.get("combat_class")
     npc_type = data.get("npc_type")
     try:


### PR DESCRIPTION
## Summary
- warn when both `sentinel` and `wander` flags are set in a prototype

## Testing
- `pytest -q` *(fails: Combat flow tests and many others fail)*

------
https://chatgpt.com/codex/tasks/task_e_6853709b9ee8832cb926c262b5de85a9