### PR TITLE
Add act flag explanations

### DIFF
--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -3136,6 +3136,29 @@ Related:
 """,
     },
     {
+        "key": "npc act flags",
+        "aliases": ["actflags", "actflag"],
+        "category": "Building",
+        "text": """Help for npc act flags
+
+NPC act flags enable automatic behavior:
+    sentinel - never moves on its own
+    wander - randomly move through exits
+    stay_area - do not wander outside the current area
+    scavenger - pick up items in the room
+    aggressive - attack the first player seen
+    wimpy - flee when health is low
+    assist - join allies already fighting
+    call_for_help - ask allies with assist to join
+    noloot - drop no loot when killed
+
+Set flags in the mob builder or with |w@mset <proto> actflags|n.
+
+Related:
+    help cnpc
+""",
+    },
+    {
         "key": "@deletenpc",
         "category": "Building",
         "text": """Help for @deletenpc

--- a/world/menus/mob_builder_menu.py
+++ b/world/menus/mob_builder_menu.py
@@ -32,6 +32,8 @@ _cancel = npc_builder._cancel
 _create_npc = npc_builder._create_npc
 validate_prototype = npc_builder.validate_prototype
 format_mob_summary = npc_builder.format_mob_summary
+
+
 def with_summary(caller, text: str) -> str:
     """Prepend the current build summary to ``text``."""
     data = getattr(caller.ndb, "buildnpc", None)
@@ -180,7 +182,11 @@ def _set_weight(caller, raw_string, **kwargs):
             )
             return "menunode_weight"
     caller.ndb.buildnpc["weight"] = string
-    next_step = "menunode_creature_type" if caller.ndb.buildnpc.get("vnum") is not None else "menunode_vnum"
+    next_step = (
+        "menunode_creature_type"
+        if caller.ndb.buildnpc.get("vnum") is not None
+        else "menunode_vnum"
+    )
     return _next_node(caller, next_step)
 
 
@@ -713,7 +719,11 @@ def _edit_loot_table(caller, raw_string, **kwargs):
         proto = parts[0]
         if proto.isdigit():
             vnum = int(proto)
-            if not vnum_registry.VNUM_RANGES["object"][0] <= vnum <= vnum_registry.VNUM_RANGES["object"][1]:
+            if (
+                not vnum_registry.VNUM_RANGES["object"][0]
+                <= vnum
+                <= vnum_registry.VNUM_RANGES["object"][1]
+            ):
                 caller.msg("Invalid object VNUM.")
                 return "menunode_loot_table"
             if not load_prototype("object", vnum):
@@ -1148,7 +1158,7 @@ def menunode_actflags(caller, raw_string="", **kwargs):
     if default:
         text += f" [default: {' '.join(default)}]"
     text += f"\nAvailable: {flags}"
-    text += "\nExample: |wsentinel wander aggressive assist call_for_help|n"
+    text += "\nExample: |wsentinel scavenger aggressive stay_area wander wimpy assist call_for_help noloot|n"
     text += "\n(back to go back, skip for default)"
     options = add_back_skip({"key": "_default", "goto": _set_actflags}, _set_actflags)
     return with_summary(caller, text), options


### PR DESCRIPTION
## Summary
- document NPC act flags
- list all act flags in mob builder example text

## Testing
- `black world/help_entries.py world/menus/mob_builder_menu.py`
- `pytest typeclasses/tests/test_bank_command.py::TestCmdBank::test_balance -q` *(fails: no such table)*

------
https://chatgpt.com/codex/tasks/task_e_6853709dd764832c8e2d8cb29c531582