### PR TITLE
Implement bounty coin checks

### DIFF
--- a/commands/info.py
+++ b/commands/info.py
@@ -216,12 +216,13 @@ class CmdBounty(Command):
 
         wallet = self.caller.db.coins or {}
         if to_copper(wallet) < amount:
-            self.msg("You don't have that many coins.")
+            self.msg("You do not have enough coins to place this bounty.")
             return
+
         self.caller.db.coins = from_copper(to_copper(wallet) - amount)
         target.db.bounty = (target.db.bounty or 0) + amount
         self.msg(
-            f"You place a bounty of {amount} coins on {target.get_display_name(self.caller)}."
+            f"You place a bounty of {amount} gold on {target.get_display_name(self.caller)}."
         )
 
 

--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -477,11 +477,23 @@ class TestBountyLarge(EvenniaTest):
         self.char1.db.coins = from_copper(100)
         self.char2.db.coins = from_copper(0)
         self.char2.db.bounty = 0
+        self.char1.msg = MagicMock()
+        self.char2.msg = MagicMock()
 
     def test_bounty_place(self):
         self.char1.execute_cmd(f"bounty {self.char2.key} 30")
         self.assertEqual(to_copper(self.char1.db.coins), 70)
         self.assertEqual(self.char2.db.bounty, 30)
+        self.char1.msg.assert_any_call(
+            f"You place a bounty of 30 gold on {self.char2.get_display_name(self.char1)}."
+        )
+
+    def test_bounty_insufficient_funds(self):
+        self.char1.db.coins = from_copper(5)
+        self.char1.execute_cmd(f"bounty {self.char2.key} 10")
+        self.char1.msg.assert_any_call("You do not have enough coins to place this bounty.")
+        self.assertEqual(to_copper(self.char1.db.coins), 5)
+        self.assertEqual(self.char2.db.bounty, 0)
 
     def test_bounty_reward_on_defeat(self):
         self.char1.execute_cmd(f"bounty {self.char2.key} 10")


### PR DESCRIPTION
## Summary
- ensure bounty only deducts coins when player can afford it
- notify player when coins are insufficient
- confirm bounty success with clear messaging
- test bounty success and failure scenarios

## Testing
- `pytest -q` *(fails: IndentationError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68537805e010832cbc6bd18142197dac