### PR TITLE
Fix combat target clearing

### DIFF
--- a/combat/engine/combat_engine.py
+++ b/combat/engine/combat_engine.py
@@ -44,7 +44,10 @@ class CombatEngine:
         self.turn_manager.start_round()
 
     def process_round(self) -> None:
-        log_trace(f"Processing combat round {self.round}")
+        combatant_keys = ", ".join(
+            getattr(p.actor, "key", str(p.actor)) for p in self.turn_manager.participants
+        )
+        log_trace(f"Processing combat round {self.round} | Combatants: {combatant_keys}")
         self.processor.process_round()
 
     # Convenience wrappers for processor functionality


### PR DESCRIPTION
## Summary
- prevent clearing combat target when enemies remain
- update removal logic when combat_target is `None`
- log combatants at start of each round
- adjust combat engine tests for new behaviour

## Testing
- `pytest -q` *(fails: IndentationError in `typeclasses/characters.py`)*

------
https://chatgpt.com/codex/tasks/task_e_68537be26034832cb98aedf2a733cd06