### PR TITLE
Implement XP reward scaling

### DIFF
--- a/combat/engine/aggro_tracker.py
+++ b/combat/engine/aggro_tracker.py
@@ -39,6 +39,8 @@ class AggroTracker:
             level = getattr(getattr(victim, "db", None), "level", 1) or 1
             exp = level * 5
 
+        exp = state_manager.calculate_xp_reward(attacker, victim, exp)
+
         contributors = self.contributors(victim, active) or [attacker]
         award_xp(attacker, exp, contributors)
 

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -1127,7 +1127,14 @@ class NPC(Character):
         exp = int(exp_reward)
         if not attacker or not exp:
             return
+
+        exp = state_manager.calculate_xp_reward(attacker, self, exp)
+        if not exp:
+            return
+
         if hasattr(attacker, "msg"):
+            attacker.msg(f"You gain |Y{exp}|n experience points!")
+        state_manager.gain_xp(attacker, exp)
 
     def on_death(self, attacker):
         """Handle character death cleanup."""

--- a/world/system/state_manager.py
+++ b/world/system/state_manager.py
@@ -391,3 +391,28 @@ def gain_xp(chara, amount: int) -> None:
             chara.db.tnl -= excess
         else:
             chara.db.tnl = settings.XP_TO_LEVEL(int(chara.db.level or 1))
+
+
+def calculate_xp_reward(attacker, npc, base_xp: int) -> int:
+    """Return ``base_xp`` scaled by level difference between ``attacker`` and ``npc``."""
+
+    atk_lvl = getattr(getattr(attacker, "db", None), "level", 1) or 1
+    npc_lvl = getattr(getattr(npc, "db", None), "level", 1) or 1
+    diff = npc_lvl - atk_lvl
+
+    if diff >= 3:
+        scale = 1.5
+    elif diff == 2:
+        scale = 1.25
+    elif diff == 1:
+        scale = 1.1
+    elif diff == 0:
+        scale = 1.0
+    elif diff == -1:
+        scale = 0.8
+    elif diff == -2:
+        scale = 0.5
+    else:
+        scale = 0.0
+
+    return max(0, int(round(base_xp * scale)))

--- a/world/tests/test_xp_scaling.py
+++ b/world/tests/test_xp_scaling.py
@@ -1,0 +1,24 @@
+from evennia.utils.test_resources import EvenniaTest
+from world.system import state_manager
+
+
+class TestXpScaling(EvenniaTest):
+    def test_calculate_xp_reward(self):
+        base = 10
+        cases = [
+            (1, 4, 1.5),
+            (1, 3, 1.25),
+            (1, 2, 1.1),
+            (1, 1, 1.0),
+            (2, 1, 0.8),
+            (3, 1, 0.5),
+            (4, 1, 0.0),
+        ]
+
+        for atk_level, npc_level, mult in cases:
+            self.char1.db.level = atk_level
+            self.char2.db.level = npc_level
+            result = state_manager.calculate_xp_reward(self.char1, self.char2, base)
+            expected = max(0, int(round(base * mult)))
+            self.assertEqual(result, expected)
+


### PR DESCRIPTION
## Summary
- implement `state_manager.calculate_xp_reward`
- apply reward scaling in aggro tracker
- award scaled XP when a character dies
- test XP scaling for various level differences

## Testing
- `pytest world/tests/test_xp_scaling.py::TestXpScaling::test_calculate_xp_reward -q` *(fails: django.db.utils.OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68537d44efcc832cb2b812f1c8739edd