### PR TITLE
Add newline after combat round output

### DIFF
--- a/combat/engine/damage_processor.py
+++ b/combat/engine/damage_processor.py
@@ -237,19 +237,24 @@ class DamageProcessor:
             self.round_output.extend(summary_lines)
 
     def _broadcast_round_output(self) -> None:
-        if not self.round_output:
-            return
         msg = "\n".join(self.round_output)
         room = None
         if self.turn_manager.participants:
             room = getattr(self.turn_manager.participants[0].actor, "location", None)
         if room:
-            room.msg_contents(msg)
+            if msg:
+                room.msg_contents(msg)
+            room.msg_contents("\n")
         else:
             for participant in self.turn_manager.participants:
                 actor = participant.actor
                 if hasattr(actor, "msg"):
-                    actor.msg(msg)
+                    if msg:
+                        actor.msg(msg)
+            for participant in self.turn_manager.participants:
+                actor = participant.actor
+                if hasattr(actor, "msg"):
+                    actor.msg("\n")
 
     def process_round(self) -> None:
         self.turn_manager.start_round()

--- a/typeclasses/tests/test_combat_flow.py
+++ b/typeclasses/tests/test_combat_flow.py
@@ -352,3 +352,22 @@ def test_npc_damage_dice_fallback_to_2d6():
     assert defender.hp == 8
     mock_roll.assert_called_with("2d6")
 
+
+def test_round_output_blank_line():
+    attacker = Dummy()
+    defender = Dummy()
+    attacker.location = defender.location
+    attacker.db.combat_target = defender
+    defender.db.combat_target = attacker
+
+    engine = CombatEngine([attacker, defender], round_time=0)
+    engine.queue_action(attacker, AttackAction(attacker, defender))
+
+    with patch("world.system.state_manager.apply_regen"), \
+         patch("random.randint", return_value=0):
+        engine.start_round()
+        engine.process_round()
+
+    calls = [c.args[0] for c in attacker.location.msg_contents.call_args_list]
+    assert calls[-1] == "\n"
+

--- a/typeclasses/tests/test_new_skills.py
+++ b/typeclasses/tests/test_new_skills.py
@@ -161,5 +161,5 @@ class TestKickSkill(EvenniaTest):
             engine.process_round()
 
         self.assertFalse(self.char1.msg.called)
-        self.assertEqual(len(self.room1.msg_contents.call_args_list), 1)
+        self.assertEqual(len(self.room1.msg_contents.call_args_list), 2)
 


### PR DESCRIPTION
## Summary
- broadcast a blank line after each combat round
- test newline in combat round output
- update skill test for new newline output

## Testing
- `pytest typeclasses/tests/test_combat_flow.py::test_round_output_blank_line -q`
- `pytest typeclasses/tests/test_new_skills.py::TestKickSkill::test_kick_engine_single_message -q` *(fails: no such table)*

------
https://chatgpt.com/codex/tasks/task_e_685380c053b4832c97464c857e1c6121