### PR TITLE
Fix multi-target combat freeze

### DIFF
--- a/combat/engine/damage_processor.py
+++ b/combat/engine/damage_processor.py
@@ -196,6 +196,10 @@ class DamageProcessor:
     # -------------------------------------------------------------
     def _execute_action(self, participant: CombatParticipant, action, damage_totals: Dict[object, int]) -> None:
         actor = participant.actor
+        if _current_hp(actor) <= 0:
+            if action in participant.next_action:
+                participant.next_action.remove(action)
+            return
         target = getattr(action, "target", None)
         if target and _current_hp(target) <= 0:
             if action in participant.next_action:


### PR DESCRIPTION
## Summary
- avoid executing actions for defeated combatants
- add regression test

## Testing
- `pytest -k test_dead_actor_action_skipped -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685387e97190832cb763616ccee52c86