### PR TITLE
Implement formatted bounty output

### DIFF
--- a/commands/info.py
+++ b/commands/info.py
@@ -167,7 +167,7 @@ class CmdFinger(Command):
 
         bounty = target.attributes.get("bounty", 0)
         if bounty:
-            lines.append(f"Bounty: {format_wallet(bounty)}")
+            lines.append(f"Bounty: {format_wallet(bounty, show_zero=True)}")
         else:
             lines.append("No bounty.")
 
@@ -232,7 +232,7 @@ class CmdBounty(Command):
         self.caller.db.coins = from_copper(to_copper(wallet) - amount_copper)
         target.db.bounty = (target.db.bounty or 0) + amount_copper
         self.msg(
-            f"You place a bounty of {amount} {coin} on {target.get_display_name(self.caller)}."
+            f"You place a bounty of {format_wallet(amount_copper, show_zero=True)} on {target.get_display_name(self.caller)}."
         )
 
 

--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -71,6 +71,12 @@ class TestInfoCommands(EvenniaTest):
         self.assertIn("Guild Points: 20", output)
         self.assertIn("Bounty: 10 Copper", output)
 
+    def test_finger_bounty_with_intermediate_zero(self):
+        self.char2.attributes.add("bounty", 3050)
+        self.char1.execute_cmd(f"finger {self.char2.key}")
+        output = self.char1.msg.call_args[0][0]
+        self.assertIn("Bounty: 3 Platinum, 0 Gold, 5 Silver", output)
+
     def test_score(self):
         self.char1.db.title = "Tester"
         self.char1.db.copper = 10

--- a/utils/currency.py
+++ b/utils/currency.py
@@ -41,19 +41,41 @@ def from_copper(amount: int) -> dict:
     return wallet
 
 
-def format_wallet(wallet) -> str:
-    """Return a human-readable currency string."""
+def format_wallet(wallet, *, show_zero: bool = False) -> str:
+    """Return a human-readable currency string.
+
+    Args:
+        wallet: Mapping of coin names to amounts or an integer copper value.
+        show_zero: When ``True``, include zero-valued denominations between the
+            highest and lowest non-zero coins.
+    """
     if wallet is None:
         wallet = {}
     if isinstance(wallet, int):
         wallet = from_copper(wallet)
-    parts = []
-    for coin in ["platinum", "gold", "silver", "copper"]:
-        count = int(wallet.get(coin, 0))
-        if count:
-            parts.append(f"{count} {coin.capitalize()}")
-    if not parts:
+
+    coins = ["platinum", "gold", "silver", "copper"]
+    counts = [int(wallet.get(c, 0)) for c in coins]
+
+    if not any(counts):
         return "0 Copper"
+
+    if not show_zero:
+        parts = [
+            f"{count} {coin.capitalize()}"
+            for coin, count in zip(coins, counts)
+            if count
+        ]
+        return ", ".join(parts)
+
+    # determine range from highest to lowest non-zero denomination
+    first = next(i for i, c in enumerate(counts) if c)
+    last = len(coins) - 1 - next(i for i, c in enumerate(reversed(counts)) if c)
+
+    parts = [
+        f"{counts[i]} {coins[i].capitalize()}"
+        for i in range(first, last + 1)
+    ]
     return ", ".join(parts)
 
 


### PR DESCRIPTION
## Summary
- show zero denominations in `format_wallet`
- display bounties with zero coins in CmdBounty and finger command
- test bounty formatting for complex copper amounts

## Testing
- `pytest -q` *(fails: Could not run full test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68539bee16c0832c912ed1877511c00b