### PR TITLE
Handle negative bounty values

### DIFF
--- a/commands/bank.py
+++ b/commands/bank.py
@@ -56,10 +56,14 @@ class CmdBank(Command):
                 caller.msg(f"Usage: bank {sub} <amount [coin]>")
                 return
             amount_parts = rest.split()
-            if not amount_parts[0].isdigit():
+            amount_str = amount_parts[0]
+            if not amount_str.lstrip('-').isdigit():
                 caller.msg(f"Usage: bank {sub} <amount [coin]>")
                 return
-            amt = int(amount_parts[0])
+            amt = int(amount_str)
+            if amt <= 0:
+                caller.msg("Amount must be positive.")
+                return
             coin = amount_parts[1].lower() if len(amount_parts) > 1 else "copper"
             if coin not in COIN_VALUES:
                 caller.msg(f"Unknown coin type: {coin}.")
@@ -86,10 +90,14 @@ class CmdBank(Command):
             if len(parts) < 2:
                 caller.msg("Usage: bank transfer <amount [coin]> <target>")
                 return
-            if not parts[0].isdigit():
+            amount_str = parts[0]
+            if not amount_str.lstrip('-').isdigit():
                 caller.msg("Usage: bank transfer <amount [coin]> <target>")
                 return
-            amt = int(parts[0])
+            amt = int(amount_str)
+            if amt <= 0:
+                caller.msg("Amount must be positive.")
+                return
             if len(parts) == 2:
                 coin = "copper"
                 target_name = parts[1]

--- a/commands/info.py
+++ b/commands/info.py
@@ -202,12 +202,16 @@ class CmdBounty(Command):
             return
 
         parts = self.args.split(None, 2)
-        if len(parts) < 2 or not parts[1].isdigit():
+        if len(parts) < 2:
+            self.msg("Usage: bounty <target> <amount> [coin]")
+            return
+
+        amount_str = parts[1]
+        if not amount_str.lstrip("-").isdigit():
             self.msg("Usage: bounty <target> <amount> [coin]")
             return
 
         target_name = parts[0]
-        amount_str = parts[1]
         coin = parts[2].lower() if len(parts) > 2 else "copper"
 
         if coin not in COIN_VALUES:

--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -550,6 +550,12 @@ class TestBountyLarge(EvenniaTest):
         self.assertEqual(to_copper(self.char1.db.coins), COIN_VALUES["gold"] + 200)
         self.assertEqual(self.char2.db.bounty, 0)
 
+    def test_bounty_negative_amount(self):
+        self.char1.execute_cmd(f"bounty {self.char2.key} -10 gold")
+        self.char1.msg.assert_any_call("Amount must be positive.")
+        self.assertEqual(to_copper(self.char1.db.coins), 100)
+        self.assertEqual(self.char2.db.bounty, 0)
+
 
 class TestCommandPrompt(EvenniaTest):
     def setUp(self):


### PR DESCRIPTION
## Summary
- handle signed amounts for `bounty` and `bank`
- warn when the supplied amount is non-positive
- test negative bounty amount

## Testing
- `pytest -q` *(fails: no such table `accounts_accountdb`)*

------
https://chatgpt.com/codex/tasks/task_e_68539db9f6dc832c81caff1a4f7fde2c