### PR TITLE
Ensure fighters cleared when removed

### DIFF
--- a/combat/engine/turn_manager.py
+++ b/combat/engine/turn_manager.py
@@ -43,8 +43,10 @@ class TurnManager:
 
         if hasattr(actor, "db") and getattr(actor, "pk", None) is not None:
             actor.db.in_combat = False
+            actor.db.combat_target = None
         else:
             setattr(actor, "in_combat", False)
+            setattr(actor, "combat_target", None)
         if hasattr(actor, "on_exit_combat"):
             actor.on_exit_combat()
         if hasattr(actor, "ndb") and hasattr(actor.ndb, "combat_engine"):

--- a/combat/round_manager.py
+++ b/combat/round_manager.py
@@ -235,11 +235,14 @@ class CombatInstance:
             fighters = [p.actor for p in self.engine.participants]
 
             for fighter in fighters:
-                if fighter:
-                    if hasattr(fighter, "db") and getattr(fighter, "pk", None) is not None:
-                        fighter.db.in_combat = False
-                    else:
-                        setattr(fighter, "in_combat", False)
+                if not fighter:
+                    continue
+                if hasattr(fighter, "db") and getattr(fighter, "pk", None) is not None:
+                    fighter.db.in_combat = False
+                    fighter.db.combat_target = None
+                else:
+                    setattr(fighter, "in_combat", False)
+                    setattr(fighter, "combat_target", None)
 
         if reason:
             log_trace(f"Combat ended: {reason}")

--- a/typeclasses/tests/test_combat_engine.py
+++ b/typeclasses/tests/test_combat_engine.py
@@ -269,6 +269,7 @@ class TestCombatEngine(unittest.TestCase):
         engine.remove_participant(a)
 
         self.assertFalse(a.db.in_combat)
+        self.assertIsNone(getattr(a.db, "combat_target", None))
         a.on_exit_combat.assert_called()
         self.assertNotIn(a, [p.actor for p in engine.participants])
 

--- a/typeclasses/tests/test_round_manager.py
+++ b/typeclasses/tests/test_round_manager.py
@@ -55,3 +55,14 @@ class TestCombatRoundManager(EvenniaTest):
         self.assertIn("Combat Manager Status:", info)
         self.assertIn("Active Instances:", info)
 
+    def test_end_combat_clears_flags(self):
+        self.char1.db.combat_target = self.char2
+        self.char2.db.combat_target = self.char1
+
+        self.instance.end_combat("done")
+
+        self.assertFalse(self.char1.db.in_combat)
+        self.assertIsNone(getattr(self.char1.db, "combat_target", None))
+        self.assertFalse(self.char2.db.in_combat)
+        self.assertIsNone(getattr(self.char2.db, "combat_target", None))
+


### PR DESCRIPTION
## Summary
- reset `combat_target` when removing combat participants
- clear `combat_target` for all fighters when a combat instance ends
- test removal updates both `in_combat` and `combat_target`
- test `CombatInstance.end_combat` clears combat status

## Testing
- `pytest typeclasses/tests/test_round_manager.py::TestCombatRoundManager::test_end_combat_clears_flags -q` *(fails: django.db.utils.OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6853a0d2b20c832cbca9b8a631e3edd1