### PR TITLE
Fix peace command to end combat cleanly

### DIFF
--- a/commands/admin/__init__.py
+++ b/commands/admin/__init__.py
@@ -455,9 +455,13 @@ class CmdPeace(Command):
             caller.msg("There is no fighting here.")
             return
 
-        for p in list(instance.engine.participants):
-            leave_combat(p.actor)
-        manager.remove_combat(instance.combat_id)
+        # remove each combatant using the helper so state gets cleaned up
+        for combatant in list(instance.combatants):
+            leave_combat(combatant)
+
+        # fully end the combat instance now that everyone left
+        instance.end_combat("Force ended by peace command")
+
         location.msg_contents("Peace falls over the area.")
 
 

--- a/typeclasses/tests/test_admin_commands.py
+++ b/typeclasses/tests/test_admin_commands.py
@@ -539,6 +539,31 @@ class TestAdminCommands(EvenniaTest):
         from combat.round_manager import CombatRoundManager
         self.assertFalse(CombatRoundManager.get().combats)
 
+    def test_peace_clears_room_combat_tags(self):
+        """After using peace, room occupants should no longer show fighting tags."""
+
+        from commands.combat import CombatCmdSet
+        from commands.admin import CmdPeace
+
+        self.char1.cmdset.add_default(CombatCmdSet)
+        self.char2.cmdset.add_default(CombatCmdSet)
+
+        # mock attack to avoid full combat loop
+        self.char1.attack = MagicMock()
+
+        # start combat and verify tag appears
+        self.char1.execute_cmd(f"attack {self.char2.key}")
+        out = self.room1.return_appearance(self.char1)
+        self.assertIn(f"[fighting {self.char2.get_display_name(self.char1)}]", out)
+
+        cmd = CmdPeace()
+        cmd.caller = self.char1
+        cmd.func()
+
+        # combat ended - tags should be gone
+        out = self.room1.return_appearance(self.char1)
+        self.assertNotIn("[fighting", out)
+
     def test_force_mob_report(self):
         from commands.admin import CmdForceMobReport
 


### PR DESCRIPTION
## Summary
- use `leave_combat` helper for all combatants
- call `end_combat` to fully terminate the instance
- test that `peace` removes `[fighting X]` tags

## Testing
- `pytest typeclasses/tests/test_admin_commands.py::TestAdminCommands::test_peace_clears_room_combat_tags -q` *(fails: no such table: accounts_accountdb)*
- `./scripts/setup_test_env.sh` *(fails to install dependencies due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6853a50900b4832c8e0256cd39ee78d4