### PR TITLE
Fix cleanup of combat target flags

### DIFF
--- a/combat/round_manager.py
+++ b/combat/round_manager.py
@@ -232,7 +232,8 @@ class CombatInstance:
 
         # Clean up fighter states
         if self.engine:
-            fighters = [p.actor for p in self.engine.participants]
+            fighters = set(self.combatants)
+            fighters.update(p.actor for p in self.engine.participants)
 
             for fighter in fighters:
                 if not fighter:


### PR DESCRIPTION
## Summary
- ensure end_combat clears flags for all fighters
- confirm room display checks combat state

## Testing
- `pytest typeclasses/tests/test_round_manager.py::TestCombatRoundManager::test_end_combat_clears_flags -q` *(fails: no such table)*

------
https://chatgpt.com/codex/tasks/task_e_6853a5f67b6c832c848bf52039d4d1e1