### PR TITLE
Add debug_combat command

### DIFF
--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -1157,6 +1157,33 @@ Notes:
     - Ends combat for everyone present.
 
 Related:
+        help ansi
+""",
+    },
+    {
+        "key": "@debug_combat",
+        "category": "Admin",
+        "text": """
+Help for @debug_combat
+
+Display combat debug information for a target.
+
+Usage:
+    @debug_combat <target>
+
+Switches:
+    None
+
+Arguments:
+    target - character or object to inspect
+
+Examples:
+    @debug_combat Bob
+
+Notes:
+    - Shows persistent and non-persistent combat flags for the target.
+
+Related:
     help ansi
 """,
     },


### PR DESCRIPTION
## Summary
- add `@debug_combat` command for developers
- expose command in the Admin command set
- document the command in file-based help entries

## Testing
- `pytest -q` *(fails: ImportError and many test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6853a79cb274832c8e6108585279e16c