### PR TITLE
Fix spawn manager typeclass path

### DIFF
--- a/scripts/spawn_manager.py
+++ b/scripts/spawn_manager.py
@@ -202,7 +202,7 @@ class SpawnManager(Script):
                 if isinstance(base_cls, str):
                     module, clsname = base_cls.rsplit(".", 1)
                     base_cls = getattr(__import__(module, fromlist=[clsname]), clsname)
-                data["typeclass"] = base_cls
+                data["typeclass"] = f"{base_cls.__module__}.{base_cls.__name__}"
                 npc = spawner.spawn(data)[0]
                 npc.location = room
                 npc.db.prototype_key = proto


### PR DESCRIPTION
## Summary
- always store the resolved typeclass path string in `SpawnManager._spawn`

## Testing
- `pytest world/tests/test_spawn_manager.py -q` *(fails: OperationalError - no such table)*

------
https://chatgpt.com/codex/tasks/task_e_685439d57cc0832c80c3515ec0d79300