### PR TITLE
Fix HP check for actors without health attribute

### DIFF
--- a/combat/engine/common.py
+++ b/combat/engine/common.py
@@ -27,13 +27,15 @@ def _current_hp(obj):
     if hasattr(obj, "hp"):
         try:
             return int(obj.hp)
-        except Exception:
-            pass
+        except Exception as err:
+            raise ValueError(f"invalid hp value on {obj!r}") from err
+
     hp_trait = getattr(getattr(obj, "traits", None), "health", None)
     if hp_trait is not None:
         try:
             return int(hp_trait.value)
-        except Exception:
-            return 0
-    return 0
+        except Exception as err:
+            raise ValueError(f"invalid health trait on {obj!r}") from err
+
+    raise AttributeError(f"{obj!r} lacks a health trait or hp attribute")
 


### PR DESCRIPTION
## Summary
- avoid treating objects without health traits as dead by raising an error in `_current_hp`

## Testing
- `pytest -q` *(fails: 654 failed, 40 passed, 2 warnings, 2 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68543d0998e8832c9b438869051d953c