### PR TITLE
Add debug logging for spawn manager

### DIFF
--- a/world/tests/test_spawn_manager.py
+++ b/world/tests/test_spawn_manager.py
@@ -188,14 +188,19 @@ class TestSpawnManager(EvenniaTest):
             },
         ]
         with mock.patch.object(self.script, "_spawn") as m_spawn, \
-             mock.patch("scripts.spawn_manager.time.time", return_value=10):
+             mock.patch("scripts.spawn_manager.time.time", return_value=10), \
+             mock.patch("evennia.utils.logger.log_debug") as m_debug:
             self.script.at_repeat()
             m_spawn.assert_called_once()
+            m_debug.assert_called_once()
 
         m_spawn.reset_mock()
-        with mock.patch("scripts.spawn_manager.time.time", return_value=10):
+        with mock.patch.object(self.script, "_spawn", m_spawn), \
+             mock.patch("scripts.spawn_manager.time.time", return_value=10), \
+             mock.patch("evennia.utils.logger.log_debug") as m_debug:
             self.script.at_repeat()
             m_spawn.assert_called_once()
+            m_debug.assert_called_once()
 
     def test_get_room_falls_back_to_room_id_when_dbref_not_room(self):
         dummy = create_object("typeclasses.objects.Object", key="dummy")


### PR DESCRIPTION
## Summary
- log when spawns are loaded
- add debug info during spawn processing
- verify debug logging in spawn manager test

## Testing
- `pytest -q world/tests/test_spawn_manager.py::TestSpawnManager::test_batch_processing_spawns_by_tick -q`

------
https://chatgpt.com/codex/tasks/task_e_6854641a2ccc832cbf42035aca447c94