### PR TITLE
Add death broadcast for player

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -952,6 +952,13 @@ class PlayerCharacter(Character):
                     location=corpse,
                 )
         self.at_death(attacker)
+        if self.location:
+            if attacker:
+                self.location.msg_contents(
+                    f"{self.key} is |Rslain|n by |C{attacker.key}|n!"
+                )
+            else:
+                self.location.msg_contents(f"{self.key} dies.")
         self.award_xp_to(attacker)
 
 

--- a/typeclasses/tests/test_characters.py
+++ b/typeclasses/tests/test_characters.py
@@ -447,3 +447,16 @@ class TestPlayerDeath(EvenniaTest):
         self.assertEqual(part_names, expected)
         self.assertIn(item, player.contents)
         self.assertEqual(player.db.coins.get("gold"), 2)
+
+    def test_player_death_broadcasts_room_message(self):
+        player = self.char1
+        attacker = self.char2
+        self.room1.msg_contents = MagicMock()
+
+        player.traits.health.current = 1
+        player.at_damage(attacker, 2)
+
+        calls = [c.args[0] for c in self.room1.msg_contents.call_args_list]
+        self.assertTrue(
+            any("is slain" in msg or "dies." in msg for msg in calls)
+        )


### PR DESCRIPTION
## Summary
- announce player kills like NPCs
- test that death messages broadcast to room

## Testing
- `pytest -q` *(fails: world/tests/test_rdel_command.py::TestRDelCommand::test_rdel_deletes_room_and_proto, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6854777c6d78832ca649375b61d1a24d