### PR TITLE
Avoid duplicate death announcements

### DIFF
--- a/combat/engine/damage_processor.py
+++ b/combat/engine/damage_processor.py
@@ -173,10 +173,12 @@ class DamageProcessor:
                         inst.add_combatant(obj)
             inst.sync_participants()
 
-        if attacker and attacker.location:
-            attacker.location.msg_contents(
-                f"{target.key} is defeated by {attacker.key}!"
-            )
+        # Death notifications are handled by ``on_death`` on the defeated
+        # character, so we avoid broadcasting here to prevent duplicates.
+        # if attacker and attacker.location:
+        #     attacker.location.msg_contents(
+        #         f"{target.key} is defeated by {attacker.key}!"
+        #     )
 
         self.turn_manager.remove_participant(target)
 


### PR DESCRIPTION
## Summary
- comment out defeat broadcast in `handle_defeat`
- rely on `on_death` to announce a death

## Testing
- `pytest -q` *(fails: fixture self not found, hundreds of test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68547512f1a0832caf578521eb9bcc3f