### PR TITLE
Filter global NPC AI by tag

### DIFF
--- a/scripts/global_npc_ai.py
+++ b/scripts/global_npc_ai.py
@@ -16,7 +16,7 @@ class GlobalNPCAI(Script):
         self.persistent = True
 
     def at_repeat(self):
-        for npc in BaseNPC.objects.all():
+        for npc in BaseNPC.objects.filter(db_tags__db_key="npc_ai"):
             if not (npc.db.ai_type or npc.db.actflags):
                 continue
             try:

--- a/typeclasses/tests/test_npc_ai.py
+++ b/typeclasses/tests/test_npc_ai.py
@@ -19,6 +19,19 @@ class TestGlobalNPCAI(EvenniaTest):
             script.at_repeat()
             mock_proc.assert_called_with(npc)
 
+    def test_script_ignores_untagged_npc(self):
+        """NPCs without the npc_ai tag should not have their AI processed."""
+        from scripts.global_npc_ai import GlobalNPCAI
+        from typeclasses.npcs import BaseNPC
+
+        npc = create.create_object(BaseNPC, key="mob_no_tag", location=self.room1)
+        npc.db.ai_type = "aggressive"
+        script = GlobalNPCAI()
+
+        with patch("scripts.global_npc_ai.process_mob_ai") as mock_proc:
+            script.at_repeat()
+            mock_proc.assert_not_called()
+
     def test_base_npc_tagged_for_ai(self):
         from typeclasses.npcs import BaseNPC
 


### PR DESCRIPTION
## Summary
- restrict `GlobalNPCAI` to NPCs tagged `npc_ai`
- test that untagged NPCs are ignored by the global AI processor

## Testing
- `pytest -q` *(fails: OperationalError - no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68549533970c832c9c88875fef690d06