### PR TITLE
Add death message to PlayerCharacter

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -952,6 +952,10 @@ class PlayerCharacter(Character):
                     location=corpse,
                 )
         self.at_death(attacker)
+        if attacker:
+            self.msg(f"You are slain by {attacker.get_display_name(self)}!")
+        else:
+            self.msg("You have died.")
         if self.location:
             if attacker:
                 self.location.msg_contents(

--- a/typeclasses/tests/test_characters.py
+++ b/typeclasses/tests/test_characters.py
@@ -460,3 +460,15 @@ class TestPlayerDeath(EvenniaTest):
         self.assertTrue(
             any("is slain" in msg or "dies." in msg for msg in calls)
         )
+
+    def test_player_receives_death_message(self):
+        player = self.char1
+        attacker = self.char2
+        player.msg = MagicMock()
+
+        player.traits.health.current = 1
+        player.at_damage(attacker, 2)
+
+        player.msg.assert_any_call(
+            f"You are slain by {attacker.get_display_name(player)}!"
+        )


### PR DESCRIPTION
## Summary
- message player when killed
- test that death message is sent

## Testing
- `pytest typeclasses/tests/test_characters.py::TestPlayerDeath::test_player_receives_death_message -q`


------
https://chatgpt.com/codex/tasks/task_e_6854aefdf618832c872ef64311254916