### PR TITLE
Implement XP gain announcements

### DIFF
--- a/commands/quests.py
+++ b/commands/quests.py
@@ -398,7 +398,7 @@ class CmdCompleteQuest(Command):
         if quest.xp_reward:
             from world.system import state_manager
 
-            state_manager.gain_xp(caller, quest.xp_reward)
+            state_manager.gain_xp(caller, quest.xp_reward, announce=True)
             rewards.append(f"{quest.xp_reward} XP")
 
         from utils.currency import to_copper, from_copper, format_wallet

--- a/commands/shops.py
+++ b/commands/shops.py
@@ -290,7 +290,7 @@ class CmdDonate(Command):
             obj.delete()
 
         from world.system import state_manager
-        state_manager.gain_xp(self.caller, total)
+        state_manager.gain_xp(self.caller, total, announce=True)
 
         self.msg(f"You exchange {obj_name} for {total} experience.")
 

--- a/typeclasses/tests/test_xp_messages.py
+++ b/typeclasses/tests/test_xp_messages.py
@@ -1,0 +1,62 @@
+from unittest.mock import MagicMock, patch
+from evennia.utils.test_resources import EvenniaTest
+from evennia.utils import create
+from django.conf import settings
+
+from world.quests import Quest, QuestManager
+from world.recipes import smithing
+from commands.shops import CmdDonate
+
+
+class TestExperienceAnnouncements(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.char1.msg = MagicMock()
+        if "world.prototypes" not in settings.PROTOTYPE_MODULES:
+            settings.PROTOTYPE_MODULES.append("world.prototypes")
+        # ensure crafting skill
+        self.char1.traits.add("smithing", trait_type="counter", min=0, max=100)
+        self.char1.traits.smithing.base = 5
+
+    @patch("evennia.contrib.game_systems.crafting.crafting.CraftingRecipe.craft", return_value=[])
+    @patch("world.recipes.base.randint", return_value=1)
+    def test_crafting_announces_xp(self, mock_rand, mock_super):
+        recipe = smithing.SmeltIronRecipe()
+        recipe.crafter = self.char1
+        recipe.msg = MagicMock()
+        recipe.craft()
+        messages = [call.args[0] for call in self.char1.msg.call_args_list]
+        assert "You gain |Y1|n experience points!" in messages
+
+    def test_quest_complete_announces_xp(self):
+        quest = Quest(quest_key="testquest", title="Q", goal_type="kill", amount=1, xp_reward=5)
+        QuestManager.save(quest)
+        self.char1.db.active_quests = {"testquest": {"progress": 1}}
+        self.char1.execute_cmd("complete testquest")
+        messages = [call.args[0] for call in self.char1.msg.call_args_list]
+        assert "You gain |Y5|n experience points!" in messages
+
+    def test_donate_announces_xp(self):
+        from typeclasses.rooms import XYGridShop
+
+        shop = create.create_object(XYGridShop, key="shop")
+        shop.db.donation_tags = ["ore"]
+        item = create.create_object("typeclasses.objects.Object", key="ore", location=self.char1)
+        item.tags.add("ore", category="crafting_material")
+        item.db.value = 10
+
+        cmd = CmdDonate()
+        cmd.caller = self.char1
+        cmd.obj = shop
+        cmd.args = "ore"
+        cmd.count = 1
+        cmd.parse()
+        self.char1.search = MagicMock(return_value=item)
+        gen = cmd.func()
+        next(gen)
+        try:
+            gen.send("yes")
+        except StopIteration:
+            pass
+        messages = [call.args[0] for call in self.char1.msg.call_args_list]
+        assert "You gain |Y5|n experience points!" in messages

--- a/world/recipes/base.py
+++ b/world/recipes/base.py
@@ -52,7 +52,7 @@ class SkillRecipe(CraftingRecipe):
         # you should get the experience reward regardless of success
         if self.exp_gain:
             from world.system import state_manager
-            state_manager.gain_xp(crafter, self.exp_gain)
+            state_manager.gain_xp(crafter, self.exp_gain, announce=True)
         # implement some randomness - the higher the difference, the lower the chance of failure
         if not randint(0, success_rate):
             self.msg("It doesn't seem to work out. Maybe you should try again?")

--- a/world/system/state_manager.py
+++ b/world/system/state_manager.py
@@ -373,8 +373,12 @@ def level_up(chara, excess: int = 0) -> None:
     stat_manager.refresh_stats(chara)
 
 
-def gain_xp(chara, amount: int) -> None:
-    """Increase ``chara.db.experience`` and check for leveling."""
+def gain_xp(chara, amount: int, announce: bool = False) -> None:
+    """Increase ``chara.db.experience`` and check for leveling.
+
+    If ``announce`` is ``True`` and ``chara`` has a ``msg`` method, the
+    character will be notified of the experience gained.
+    """
 
     if not chara or not amount:
         return
@@ -383,6 +387,9 @@ def gain_xp(chara, amount: int) -> None:
     current_level = int(chara.db.level or 1)
     chara.db.experience = (chara.db.experience or 0) + amt
     chara.db.tnl = (chara.db.tnl or settings.XP_TO_LEVEL(current_level)) - amt
+
+    if announce and hasattr(chara, "msg"):
+        chara.msg(f"You gain |Y{amt}|n experience points!")
 
     while chara.db.tnl <= 0 and (chara.db.level or 1) < MAX_LEVEL:
         excess = -chara.db.tnl


### PR DESCRIPTION
## Summary
- add `announce` flag to `gain_xp`
- broadcast XP gain when `announce=True`
- notify players for XP from crafting, quests and shop donations
- test XP messages on those actions

## Testing
- `pytest typeclasses/tests/test_xp_messages.py::TestExperienceAnnouncements::test_crafting_announces_xp -q` *(fails: django.db.utils.OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6854acf0e0d4832caca057f94acbeeb3