### PR TITLE
Fix XP awarding via combat engine

### DIFF
--- a/combat/engine/damage_processor.py
+++ b/combat/engine/damage_processor.py
@@ -110,6 +110,7 @@ class DamageProcessor:
 
         if hasattr(target, "on_death"):
             target.on_death(attacker)
+        self.engine.award_experience(attacker, target)
 
         if getattr(target, "pk", None) is not None:
             self.update_pos(target)

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -1167,7 +1167,8 @@ class NPC(Character):
                 self.location.msg_contents(f"{self.key} dies.")
 
         # award experience to the attacker before removing the NPC
-        self.award_xp_to(attacker)
+        if not (attacker and getattr(getattr(attacker, "db", None), "in_combat", False)):
+            self.award_xp_to(attacker)
 
         if attacker and getattr(attacker.db, "combat_target", None) is self:
             attacker.db.combat_target = None

--- a/typeclasses/tests/test_combat_engine.py
+++ b/typeclasses/tests/test_combat_engine.py
@@ -297,9 +297,12 @@ class TestCombatDeath(EvenniaTest):
         engine.queue_action(player, KillAction(player, npc))
 
         with patch('world.system.state_manager.apply_regen'), \
-             patch('world.system.state_manager.check_level_up'):
+             patch('world.system.state_manager.check_level_up'), \
+             patch.object(npc, 'award_xp_to', wraps=npc.award_xp_to) as mock_xp:
             engine.start_round()
             engine.process_round()
+
+        mock_xp.assert_not_called()
 
         self.assertEqual(player.db.experience, 5)
         self.assertEqual(to_copper(player.db.coins), to_copper({"silver": 3}))


### PR DESCRIPTION
## Summary
- trigger experience awarding in the combat damage processor
- prevent NPC.on_death from double awarding XP
- ensure XP awarding happens only via the engine in combat tests

## Testing
- `pytest typeclasses/tests/test_combat_engine.py::TestCombatDeath::test_npc_death_creates_corpse_and_awards_xp -q` *(fails: django.db.utils.OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6854c21ec108832c98f12fe2c5f2f7c4