### PR TITLE
Fix target checks in combat defeat handling

### DIFF
--- a/combat/engine/damage_processor.py
+++ b/combat/engine/damage_processor.py
@@ -141,7 +141,11 @@ class DamageProcessor:
             if combatant is target:
                 continue
             current = getattr(getattr(combatant, "db", None), "combat_target", None)
-            needs_new = current is target or _current_hp(current) <= 0
+            has_hp = current and (
+                hasattr(current, "hp")
+                or getattr(getattr(current, "traits", None), "health", None) is not None
+            )
+            needs_new = current is target or not has_hp or (has_hp and _current_hp(current) <= 0)
             if needs_new:
                 remaining = [c for c in survivors if c is not combatant]
                 new_target = remaining[0] if remaining else None
@@ -164,6 +168,11 @@ class DamageProcessor:
             room = getattr(target, "location", None)
             if room:
                 for obj in room.contents:
+                    has_hp = hasattr(obj, "hp") or getattr(
+                        getattr(obj, "traits", None), "health", None
+                    ) is not None
+                    if not has_hp:
+                        continue
                     if obj in inst.combatants:
                         continue
                     if _current_hp(obj) <= 0:


### PR DESCRIPTION
## Summary
- avoid AttributeError if a combatant's target has no health trait
- ignore non-combat objects in room when looking for new combatants
- test that defeat works with missing targets and with items in the room

## Testing
- `pytest typeclasses/tests/test_combat_flow.py::TestCombatVictory::test_handle_defeat_with_missing_targets typeclasses/tests/test_combat_flow.py::TestCombatVictory::test_handle_defeat_ignores_items_in_room -q`

------
https://chatgpt.com/codex/tasks/task_e_6854d3b9a4a4832c8b32bafa63726b87