### PR TITLE
Fix combat defeat hook duplication

### DIFF
--- a/combat/engine/damage_processor.py
+++ b/combat/engine/damage_processor.py
@@ -102,9 +102,6 @@ class DamageProcessor:
         return 0
 
     def handle_defeat(self, target, attacker) -> None:
-        if hasattr(target, "on_exit_combat"):
-            target.on_exit_combat()
-
         if hasattr(target, "at_defeat"):
             target.at_defeat(attacker)
 

--- a/typeclasses/tests/test_combat_engine.py
+++ b/typeclasses/tests/test_combat_engine.py
@@ -89,6 +89,18 @@ class TestCombatEngine(unittest.TestCase):
             engine.process_round()
             b.on_exit_combat.assert_called()
 
+    def test_exit_hook_called_once_on_defeat(self):
+        a = Dummy()
+        b = Dummy()
+        with patch('world.system.state_manager.apply_regen'), \
+             patch('world.system.state_manager.get_effective_stat', return_value=0):
+            engine = CombatEngine([a, b], round_time=0)
+            b.on_exit_combat.reset_mock()
+            engine.queue_action(a, KillAction(a, b))
+            engine.start_round()
+            engine.process_round()
+            assert b.on_exit_combat.call_count == 1
+
     def test_initiative_and_regen(self):
         a = Dummy(init=10)
         b = Dummy(init=1)


### PR DESCRIPTION
## Summary
- remove direct `on_exit_combat` call from `DamageProcessor.handle_defeat`
- rely on `TurnManager.remove_participant` to trigger exit hooks
- add regression test ensuring `on_exit_combat` fires only once on defeat

## Testing
- `pytest typeclasses/tests/test_combat_engine.py::TestCombatEngine::test_exit_hook_called_once_on_defeat -q`

------
https://chatgpt.com/codex/tasks/task_e_6854d3c03dc8832c80ffc389e29c3107