### PR TITLE
Fix aggro cleanup after XP award

### DIFF
--- a/combat/engine/aggro_tracker.py
+++ b/combat/engine/aggro_tracker.py
@@ -43,4 +43,5 @@ class AggroTracker:
 
         contributors = self.contributors(victim, active) or [attacker]
         award_xp(attacker, exp, contributors)
+        self.table.pop(victim, None)
 

--- a/world/tests/test_aggro_tracker.py
+++ b/world/tests/test_aggro_tracker.py
@@ -1,0 +1,25 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from combat.engine.aggro_tracker import AggroTracker
+
+
+class TestAggroTracker(unittest.TestCase):
+    def test_award_experience_removes_victim(self):
+        tracker = AggroTracker()
+        attacker = MagicMock(pk=1)
+        victim = MagicMock(pk=2)
+        active = [attacker]
+
+        with patch("combat.engine.aggro_tracker.state_manager.get_effective_stat", return_value=0), \
+             patch("combat.engine.aggro_tracker.state_manager.calculate_xp_reward", return_value=5), \
+             patch("combat.engine.aggro_tracker.award_xp"):
+            tracker.track(victim, attacker)
+            assert victim in tracker.table
+            tracker.award_experience(attacker, victim, active)
+
+        assert victim not in tracker.table
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- clear aggro entry for defeated victim when experience is awarded
- test AggroTracker XP award removes the defeated victim

## Testing
- `pytest -q world/tests/test_aggro_tracker.py`
- `pytest -q` *(fails: 336 failed, 16 passed, 2 warnings, 1 error)*

------
https://chatgpt.com/codex/tasks/task_e_6854d3cc4bec832cadecce882aeecc38