### PR TITLE
Add npc_vnum attr on corpses

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -1060,7 +1060,11 @@ class NPC(Character):
     # death handling -----------------------------------------------------
 
     def drop_loot(self, killer=None):
-        """Create a corpse and deposit any drops and coins."""
+        """Create a corpse and deposit any drops and coins.
+
+        The returned corpse will include ``npc_vnum`` if this NPC has a
+        ``vnum`` Attribute.
+        """
         from utils.currency import COIN_VALUES
         from utils.prototype_manager import load_prototype
         from utils.dice import roll_dice_string
@@ -1158,7 +1162,11 @@ class NPC(Character):
         state_manager.gain_xp(attacker, exp)
 
     def on_death(self, attacker):
-        """Handle character death cleanup."""
+        """Handle character death cleanup.
+
+        The corpse created during this process stores this NPC's ``vnum``
+        as ``npc_vnum`` when available.
+        """
         if not self.location or self.attributes.get("_dead"):
             return
         self.db._dead = True
@@ -1181,6 +1189,8 @@ class NPC(Character):
             logger.log_err(f"Loot drop error on {self}: {err}")
 
         if corpse:
+            if getattr(self.db, "vnum", None) is not None:
+                corpse.db.npc_vnum = self.db.vnum
             corpse.location = self.location
 
         self.at_death(attacker)

--- a/typeclasses/tests/test_combat_engine.py
+++ b/typeclasses/tests/test_combat_engine.py
@@ -443,9 +443,16 @@ class TestCombatDeath(EvenniaTest):
 
         npc = create.create_object(NPC, key="mob", location=self.room1)
         npc.db.drops = []
+        npc.db.vnum = 77
 
         with patch.object(npc, "delete") as mock_delete:
             npc.on_death(self.char1)
+            corpse = next(
+                obj
+                for obj in self.room1.contents
+                if obj.is_typeclass("typeclasses.objects.Corpse", exact=False)
+            )
+            self.assertEqual(corpse.db.npc_vnum, 77)
             self.assertTrue(npc.db.is_dead)
             self.assertIsNone(npc.location)
             mock_delete.assert_called_once()

--- a/utils/mob_utils.py
+++ b/utils/mob_utils.py
@@ -85,7 +85,11 @@ def mobprogs_to_triggers(mobprogs: list[dict]) -> Dict[str, list[dict]]:
 
 
 def make_corpse(npc):
-    """Create a corpse object for ``npc`` and transfer belongings."""
+    """Create a corpse object for ``npc`` and transfer belongings.
+
+    If ``npc.db.vnum`` is defined, it will be copied to the corpse as the
+    ``npc_vnum`` Attribute.
+    """
 
     from evennia import create_object
     from world.mob_constants import ACTFLAGS
@@ -104,6 +108,8 @@ def make_corpse(npc):
         return existing[0]
 
     attrs = [("corpse_of", npc.key), ("corpse_of_id", npc.dbref), ("is_corpse", True)]
+    if getattr(npc.db, "vnum", None) is not None:
+        attrs.append(("npc_vnum", npc.db.vnum))
     decay = getattr(npc.db, "corpse_decay_time", None)
     if decay is None:
         from django.conf import settings

--- a/utils/tests/test_mob_utils.py
+++ b/utils/tests/test_mob_utils.py
@@ -66,3 +66,13 @@ class TestMobUtils(EvenniaTest):
         self.assertFalse(corpse.contents)
         self.assertEqual(inv_item.location, npc)
         self.assertEqual(eq_item.location, npc)
+
+    def test_make_corpse_includes_vnum(self):
+        from evennia.utils import create
+        from typeclasses.characters import NPC
+
+        npc = create.create_object(NPC, key="mob", location=self.room1)
+        npc.db.vnum = 123
+
+        corpse = make_corpse(npc)
+        self.assertEqual(corpse.db.npc_vnum, 123)


### PR DESCRIPTION
## Summary
- include npc_vnum when generating a corpse
- document npc_vnum behaviour in drop_loot and on_death
- ensure on_death stores npc_vnum on the corpse
- test coverage for new attribute

## Testing
- `pytest -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6854e0c6a9ac832c8b35628d47615495