### PR TITLE
Add corpse vnum test

### DIFF
--- a/utils/mob_utils.py
+++ b/utils/mob_utils.py
@@ -120,6 +120,9 @@ def make_corpse(npc):
         location=npc.location,
         attributes=attrs,
     )
+    # store the vnum of the NPC on the corpse for bookkeeping
+    if hasattr(npc.db, "vnum"):
+        corpse.db.npc_vnum = npc.db.vnum
 
     no_loot = ACTFLAGS.NOLOOT.value in (npc.db.actflags or [])
 


### PR DESCRIPTION
## Summary
- ensure corpses record the NPC vnum when an NPC dies

## Testing
- `pytest -q typeclasses/tests/test_combat_engine.py::TestCombatDeath::test_corpse_stores_vnum_and_npc_removed -q` *(fails: StopIteration)*

------
https://chatgpt.com/codex/tasks/task_e_6854e0cc95b4832ca60fe4fccaed5ada