### PR TITLE
Ensure corpses spawn when NPCs exit combat

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -248,6 +248,7 @@ class Character(ObjectParent, ClothedCharacter):
         self.db.training_points = 0
         self.db.practice_sessions = 0
         from django.conf import settings
+
         self.db.level = 1
         self.db.experience = 0
         self.db.tnl = settings.XP_TO_LEVEL(1)
@@ -372,12 +373,17 @@ class Character(ObjectParent, ClothedCharacter):
         reduction = self.defense(damage_type)
         armor = max(0, reduction)
         if attacker:
-            armor = max(0, armor - state_manager.get_effective_stat(attacker, "piercing"))
+            armor = max(
+                0, armor - state_manager.get_effective_stat(attacker, "piercing")
+            )
         damage = int(max(0, round(damage * (1 - armor / 100))))
         if attacker:
             log = getattr(self.ndb, "damage_log", None) or {}
             log[attacker] = log.get(attacker, 0) + int(damage)
             self.ndb.damage_log = log
+            # track the most recent attacker so on_exit_combat can
+            # attribute loot drops correctly
+            self.ndb.last_attacker = attacker
 
         dt = None
         if damage_type:
@@ -396,13 +402,16 @@ class Character(ObjectParent, ClothedCharacter):
             damage = int(damage * get_damage_multiplier(resistances, dt))
 
         # magic resist mitigation
-        if dt and dt not in (DamageType.SLASHING, DamageType.PIERCING, DamageType.BLUDGEONING):
+        if dt and dt not in (
+            DamageType.SLASHING,
+            DamageType.PIERCING,
+            DamageType.BLUDGEONING,
+        ):
             mres = state_manager.get_effective_stat(self, "magic_resist")
             if attacker:
                 mres -= state_manager.get_effective_stat(attacker, "spell_penetration")
             if mres > 0:
                 damage = max(0, damage - mres)
-
 
         self.traits.health.current -= damage
         crit_prefix = "|rCritical!|n " if critical else ""
@@ -434,6 +443,7 @@ class Character(ObjectParent, ClothedCharacter):
             self.traits.health.rate = 0
             if not self.in_combat and not self.attributes.get("_dead"):
                 from combat.round_manager import leave_combat
+
                 leave_combat(self)
                 if bounty := self.db.bounty:
                     wallet = attacker.db.coins or {}
@@ -442,6 +452,7 @@ class Character(ObjectParent, ClothedCharacter):
                 if utils.inherits_from(self, PlayerCharacter):
                     self.on_death(attacker)
         return damage
+
     def at_emote(self, message, **kwargs):
         """
         Execute a room emote as ourself.
@@ -605,6 +616,7 @@ class Character(ObjectParent, ClothedCharacter):
         Attempt to use a skill, applying any stat bonus as necessary.
         """
         from world.system import state_manager
+
         target = kwargs.get("target")
 
         # using an active combat skill if a target is provided
@@ -613,17 +625,26 @@ class Character(ObjectParent, ClothedCharacter):
 
             skill_cls = SKILL_CLASSES.get(skill_name)
             if not skill_cls:
-                return CombatResult(actor=self, target=target, message="Nothing happens.")
+                return CombatResult(
+                    actor=self, target=target, message="Nothing happens."
+                )
             skill = skill_cls()
             if not self.cooldowns.ready(skill.name):
-                return CombatResult(actor=self, target=self, message="Still recovering.")
+                return CombatResult(
+                    actor=self, target=self, message="Still recovering."
+                )
             if self.traits.stamina.current < skill.stamina_cost:
                 return CombatResult(actor=self, target=self, message="Too exhausted.")
             self.traits.stamina.current -= skill.stamina_cost
             state_manager.add_cooldown(self, skill.name, skill.cooldown)
             from utils.hit_chance import calculate_hit_success
-            if not calculate_hit_success(self, skill.name, getattr(skill, "support_skill", None)):
-                return CombatResult(actor=self, target=target, message="You miss your strike.")
+
+            if not calculate_hit_success(
+                self, skill.name, getattr(skill, "support_skill", None)
+            ):
+                return CombatResult(
+                    actor=self, target=target, message="You miss your strike."
+                )
             result = skill.resolve(self, target)
             for eff in getattr(skill, "effects", []):
                 state_manager.add_status_effect(target, eff.key, eff.duration)
@@ -668,7 +689,10 @@ class Character(ObjectParent, ClothedCharacter):
         self.traits.mana.current -= spell.mana_cost
         state_manager.add_cooldown(self, spell.key, spell.cooldown)
         from utils.hit_chance import calculate_hit_success
-        if not calculate_hit_success(self, spell.key, getattr(spell, "support_skill", None)):
+
+        if not calculate_hit_success(
+            self, spell.key, getattr(spell, "support_skill", None)
+        ):
             self.msg("You fail to cast the spell.")
             return False
         colored = colorize_spell(spell.key)
@@ -828,6 +852,7 @@ class Character(ObjectParent, ClothedCharacter):
         if getattr(self.db, "natural_weapon", None):
             return self.db.natural_weapon
         from typeclasses.gear import BareHand
+
         return BareHand()
 
     def attack(self, target, weapon, **kwargs):
@@ -845,7 +870,9 @@ class Character(ObjectParent, ClothedCharacter):
                 self.msg("You don't see your target.")
             return
 
-        if not getattr(target, "traits", None) or not callable(getattr(target, "at_damage", None)):
+        if not getattr(target, "traits", None) or not callable(
+            getattr(target, "at_damage", None)
+        ):
             if self.sessions.count():
                 self.msg("You can't attack that.")
             return
@@ -867,7 +894,6 @@ class Character(ObjectParent, ClothedCharacter):
 
         if hasattr(self, "check_triggers"):
             self.check_triggers("on_attack", target=target, weapon=weapon)
-
 
     def revive(self, reviver, **kwargs):
         """
@@ -909,7 +935,9 @@ class PlayerCharacter(Character):
         return f"|g{name}|n"
 
     def at_damage(self, attacker, damage, damage_type=None, critical=False):
-        dmg = super().at_damage(attacker, damage, damage_type=damage_type, critical=critical)
+        dmg = super().at_damage(
+            attacker, damage, damage_type=damage_type, critical=critical
+        )
         if self.traits.health.value < 50 and self.sessions.count():
             self.refresh_prompt()
         return dmg
@@ -921,6 +949,7 @@ class PlayerCharacter(Character):
 
         # remove from combat if engaged
         from combat.round_manager import leave_combat
+
         leave_combat(self)
         # create a corpse object and reuse shared logic
         corpse = make_corpse(self)
@@ -983,7 +1012,6 @@ class PlayerCharacter(Character):
             self.traits.stamina.rate = 0.0
         self.msg(prompt=self.get_display_status(self))
 
-
     def respawn(self):
         """
         Resets the character back to the spawn point with full health.
@@ -1009,7 +1037,9 @@ class PlayerCharacter(Character):
         for slot, item in self.equipment.items():
             if not item:
                 continue
-            if not item.access(looker, "view") or not item.access(looker, "search", default=True):
+            if not item.access(looker, "view") or not item.access(
+                looker, "search", default=True
+            ):
                 continue
             if hasattr(looker, "can_see") and not looker.can_see(item):
                 continue
@@ -1049,6 +1079,17 @@ class NPC(Character):
             self.db.triggers = {}
         self.trigger_manager.start_random_triggers()
 
+    def on_exit_combat(self):
+        """Handle cleanup when this NPC leaves combat."""
+        if self.traits.health.current <= 0 and not getattr(
+            self.ndb, "_corpse_spawned", False
+        ):
+            attacker = getattr(self.ndb, "last_attacker", None)
+            try:
+                self.drop_loot(attacker)
+            finally:
+                self.ndb._corpse_spawned = True
+
     def check_triggers(self, event, **kwargs):
         """Evaluate stored triggers for a given event."""
         self.trigger_manager.check(event, **kwargs)
@@ -1079,7 +1120,7 @@ class NPC(Character):
                 chance = int(entry.get("chance", 100))
                 guaranteed = entry.get("guaranteed_after")
                 count = entry.get("_count", 0)
-                
+
                 roll = randint(1, 100)
                 if roll <= chance or (
                     guaranteed is not None and count >= int(guaranteed)
@@ -1095,7 +1136,9 @@ class NPC(Character):
                             amt = int(amount)
                         coin_loot[proto.lower()] = coin_loot.get(proto.lower(), 0) + amt
                     else:
-                        if isinstance(proto, int) or (isinstance(proto, str) and proto.isdigit()):
+                        if isinstance(proto, int) or (
+                            isinstance(proto, str) and proto.isdigit()
+                        ):
                             proto_data = load_prototype("object", int(proto))
                             if proto_data:
                                 drops.append(proto_data)
@@ -1146,6 +1189,7 @@ class NPC(Character):
     def award_xp_to(self, attacker):
         """Grant experience reward to ``attacker``."""
         from world.system import state_manager
+
         exp_reward = getattr(self.db, "exp_reward", 0)
         if exp_reward is None:
             exp_reward = 0
@@ -1183,10 +1227,12 @@ class NPC(Character):
         leave_combat(self)
 
         corpse = None
-        try:
-            corpse = self.drop_loot(attacker)
-        except Exception as err:  # pragma: no cover - log errors
-            logger.log_err(f"Loot drop error on {self}: {err}")
+        if not getattr(self.ndb, "_corpse_spawned", False):
+            try:
+                corpse = self.drop_loot(attacker)
+                self.ndb._corpse_spawned = True
+            except Exception as err:  # pragma: no cover - log errors
+                logger.log_err(f"Loot drop error on {self}: {err}")
 
         if corpse:
             if getattr(self.db, "vnum", None) is not None:
@@ -1294,7 +1340,9 @@ class NPC(Character):
         """
         Apply damage, after taking into account damage resistances.
         """
-        dmg = super().at_damage(attacker, damage, damage_type=damage_type, critical=critical)
+        dmg = super().at_damage(
+            attacker, damage, damage_type=damage_type, critical=critical
+        )
         self.check_triggers("on_attack", attacker=attacker, damage=dmg)
 
         if self.traits.health.value <= 0:
@@ -1307,6 +1355,7 @@ class NPC(Character):
             self.at_emote("flees!")
             self.db.fleeing = True
             from combat.round_manager import leave_combat
+
             leave_combat(self)
             # there's a 50/50 chance the object will escape forever
             if randint(0, 1):
@@ -1327,6 +1376,7 @@ class NPC(Character):
         else:
             self.db.combat_target = attacker
         return dmg
+
     def enter_combat(self, target, **kwargs):
         """
         initiate combat against another character
@@ -1355,6 +1405,7 @@ class NPC(Character):
 
         if engine:
             from combat.combat_actions import AttackAction
+
             engine.queue_action(self, AttackAction(self, target))
         else:
             self.attack(target, weapon)
@@ -1376,7 +1427,9 @@ class NPC(Character):
         """
         attack with your natural weapon
         """
-        if not getattr(target, "traits", None) or not callable(getattr(target, "at_damage", None)):
+        if not getattr(target, "traits", None) or not callable(
+            getattr(target, "at_damage", None)
+        ):
             if hasattr(wielder, "msg"):
                 wielder.msg("You can't attack that.")
             return

--- a/typeclasses/tests/test_combat_engine.py
+++ b/typeclasses/tests/test_combat_engine.py
@@ -80,7 +80,7 @@ class TestCombatEngine(unittest.TestCase):
     def test_enter_and_exit_callbacks(self):
         a = Dummy()
         b = Dummy()
-        with patch('world.system.state_manager.apply_regen'):
+        with patch("world.system.state_manager.apply_regen"):
             engine = CombatEngine([a, b], round_time=0)
             a.on_enter_combat.assert_called()
             b.on_enter_combat.assert_called()
@@ -93,7 +93,10 @@ class TestCombatEngine(unittest.TestCase):
         a = Dummy(init=10)
         b = Dummy(init=1)
         engine = CombatEngine([a, b], round_time=0)
-        with patch('world.system.state_manager.apply_regen') as mock_regen, patch('random.randint', return_value=0):
+        with (
+            patch("world.system.state_manager.apply_regen") as mock_regen,
+            patch("random.randint", return_value=0),
+        ):
             engine.start_round()
             self.assertEqual(engine.queue[0].actor, a)
             self.assertEqual(mock_regen.call_count, 2)
@@ -101,7 +104,7 @@ class TestCombatEngine(unittest.TestCase):
     def test_aggro_tracking(self):
         a = Dummy()
         b = Dummy()
-        with patch('world.system.state_manager.apply_regen'):
+        with patch("world.system.state_manager.apply_regen"):
             engine = CombatEngine([a, b], round_time=0)
             engine.queue_action(a, KillAction(a, b))
             engine.start_round()
@@ -113,9 +116,11 @@ class TestCombatEngine(unittest.TestCase):
         attacker.db.experience = 0
         victim = Dummy()
         victim.db.exp_reward = 10
-        with patch('world.system.state_manager.apply_regen'), \
-             patch('world.system.state_manager.check_level_up'), \
-             patch.object(attacker, 'msg') as mock_msg:
+        with (
+            patch("world.system.state_manager.apply_regen"),
+            patch("world.system.state_manager.check_level_up"),
+            patch.object(attacker, "msg") as mock_msg,
+        ):
             engine = CombatEngine([attacker, victim], round_time=0)
             engine.queue_action(attacker, KillAction(attacker, victim))
             engine.start_round()
@@ -130,9 +135,12 @@ class TestCombatEngine(unittest.TestCase):
             obj.db.experience = 0
         victim = Dummy()
         victim.db.exp_reward = 9
-        with patch('world.system.state_manager.apply_regen'), \
-             patch('world.system.state_manager.check_level_up'), \
-             patch.object(a, 'msg') as msg_a, patch.object(b, 'msg') as msg_b:
+        with (
+            patch("world.system.state_manager.apply_regen"),
+            patch("world.system.state_manager.check_level_up"),
+            patch.object(a, "msg") as msg_a,
+            patch.object(b, "msg") as msg_b,
+        ):
             engine = CombatEngine([a, b, victim], round_time=0)
             engine.aggro[victim] = {a: 1, b: 1}
             engine.queue_action(a, KillAction(a, victim))
@@ -149,8 +157,10 @@ class TestCombatEngine(unittest.TestCase):
             m.db.experience = 0
         victim = Dummy()
         victim.db.exp_reward = 100
-        with patch('world.system.state_manager.apply_regen'), \
-             patch('world.system.state_manager.check_level_up'):
+        with (
+            patch("world.system.state_manager.apply_regen"),
+            patch("world.system.state_manager.check_level_up"),
+        ):
             engine = CombatEngine(members + [victim], round_time=0)
             engine.aggro[victim] = {m: 1 for m in members}
             engine.queue_action(members[0], KillAction(members[0], victim))
@@ -165,9 +175,11 @@ class TestCombatEngine(unittest.TestCase):
         a.traits.health = MagicMock(value=a.hp)
         a.key = "dummy"
         a.tags = MagicMock()
-        with patch('world.system.state_manager.apply_regen'), \
-             patch('combat.engine.damage_processor.delay') as mock_delay, \
-             patch('random.randint', return_value=0):
+        with (
+            patch("world.system.state_manager.apply_regen"),
+            patch("combat.engine.damage_processor.delay") as mock_delay,
+            patch("random.randint", return_value=0),
+        ):
             engine = CombatEngine([a], round_time=0)
             engine.queue_action(a, KillAction(a, a))
             engine.start_round()
@@ -178,10 +190,12 @@ class TestCombatEngine(unittest.TestCase):
     def test_schedules_next_round(self):
         a = Dummy()
         b = Dummy()
-        with patch('world.system.state_manager.apply_regen'), \
-             patch('world.system.state_manager.get_effective_stat', return_value=0), \
-             patch('combat.engine.damage_processor.delay') as mock_delay, \
-             patch('random.randint', return_value=0):
+        with (
+            patch("world.system.state_manager.apply_regen"),
+            patch("world.system.state_manager.get_effective_stat", return_value=0),
+            patch("combat.engine.damage_processor.delay") as mock_delay,
+            patch("random.randint", return_value=0),
+        ):
             engine = CombatEngine([a, b], round_time=0)
             engine.start_round()
             engine.process_round()
@@ -205,10 +219,12 @@ class TestCombatEngine(unittest.TestCase):
             room = MagicMock()
             a.location = b.location = room
 
-            with patch('world.system.state_manager.apply_regen'), \
-                 patch('world.system.state_manager.get_effective_stat', return_value=0), \
-                 patch('random.randint', return_value=0), \
-                 patch('combat.engine.damage_processor.delay'):
+            with (
+                patch("world.system.state_manager.apply_regen"),
+                patch("world.system.state_manager.get_effective_stat", return_value=0),
+                patch("random.randint", return_value=0),
+                patch("combat.engine.damage_processor.delay"),
+            ):
                 engine = CombatEngine([a, b], round_time=0)
                 engine.queue_action(a, act_cls(a, b))
                 engine.start_round()
@@ -232,10 +248,12 @@ class TestCombatEngine(unittest.TestCase):
         room = MagicMock()
         a.location = b.location = room
 
-        with patch('world.system.state_manager.apply_regen'), \
-             patch('world.system.state_manager.get_effective_stat', return_value=0), \
-             patch('random.randint', return_value=0), \
-             patch('combat.engine.damage_processor.delay'):
+        with (
+            patch("world.system.state_manager.apply_regen"),
+            patch("world.system.state_manager.get_effective_stat", return_value=0),
+            patch("random.randint", return_value=0),
+            patch("combat.engine.damage_processor.delay"),
+        ):
             engine = CombatEngine([a, b], round_time=0)
             engine.queue_action(a, DamageAction(a, b))
             engine.start_round()
@@ -250,8 +268,10 @@ class TestCombatEngine(unittest.TestCase):
         a.db.combat_target = b
         b.db.combat_target = a
 
-        with patch('world.system.state_manager.apply_regen'), \
-             patch('random.randint', return_value=0):
+        with (
+            patch("world.system.state_manager.apply_regen"),
+            patch("random.randint", return_value=0),
+        ):
             engine = CombatEngine([a, b], round_time=0)
             engine.start_round()
             engine.process_round()
@@ -287,22 +307,27 @@ class TestCombatDeath(EvenniaTest):
         npc.db.exp_reward = 5
         npc.db.coin_drop = {"silver": 3}
         self.char1.db.coins = from_copper(0)
-        item = create.create_object("typeclasses.objects.Object", key="loot", location=npc)
+        item = create.create_object(
+            "typeclasses.objects.Object", key="loot", location=npc
+        )
         weapon = create.create_object("typeclasses.objects.Object", key="sword")
         weapon.tags.add("equipment", category="flag")
         weapon.tags.add("identified", category="flag")
         npc.db.equipment = {"mainhand": weapon}
         weapon.location = None
 
-        with patch('world.system.state_manager.apply_regen'), \
-             patch('world.system.state_manager.check_level_up'):
+        with (
+            patch("world.system.state_manager.apply_regen"),
+            patch("world.system.state_manager.check_level_up"),
+        ):
             npc.on_death(player)
 
         self.assertEqual(player.db.experience, 5)
         self.assertEqual(to_copper(player.db.coins), to_copper({"silver": 3}))
         corpse = next(
-            obj for obj in self.room1.contents
-            if obj.is_typeclass('typeclasses.objects.Corpse', exact=False)
+            obj
+            for obj in self.room1.contents
+            if obj.is_typeclass("typeclasses.objects.Corpse", exact=False)
         )
         self.assertEqual(corpse.db.corpse_of, npc.key)
         self.assertEqual(corpse.db.desc, f"The corpse of {npc.key} lies here.")
@@ -330,6 +355,34 @@ class TestCombatDeath(EvenniaTest):
             if obj.is_typeclass("typeclasses.objects.Corpse", exact=False)
         ]
         self.assertEqual(len(corpses), 1)
+
+    def test_on_exit_combat_creates_corpse_once(self):
+        """NPCs leaving combat should drop loot exactly once."""
+        from evennia.utils import create
+        from typeclasses.characters import NPC
+
+        player = self.char1
+        npc = create.create_object(NPC, key="mob", location=self.room1)
+        npc.db.drops = []
+
+        engine = CombatEngine([player, npc], round_time=0)
+        engine.queue_action(player, KillAction(player, npc))
+
+        with (
+            patch("world.system.state_manager.apply_regen"),
+            patch("world.system.state_manager.check_level_up"),
+            patch.object(npc, "drop_loot", wraps=npc.drop_loot) as mock_drop,
+        ):
+            engine.start_round()
+            engine.process_round()
+
+        mock_drop.assert_called_once()
+        corpse = next(
+            obj
+            for obj in self.room1.contents
+            if obj.is_typeclass("typeclasses.objects.Corpse", exact=False)
+        )
+        self.assertEqual(corpse.db.corpse_of, npc.key)
 
     def test_same_key_npcs_create_multiple_corpses(self):
         """Killing NPCs with the same key should spawn separate corpses."""
@@ -385,6 +438,7 @@ class TestCombatDeath(EvenniaTest):
         npc.db.drops = []
 
         from combat.round_manager import CombatRoundManager
+
         manager = CombatRoundManager.get()
         instance = manager.start_combat([player, npc])
         manager.remove_combat(instance.combat_id)
@@ -409,7 +463,7 @@ class TestCombatDeath(EvenniaTest):
         npc.db.drops = []
         npc.db.exp_reward = 7
 
-        with patch('world.system.state_manager.check_level_up'):
+        with patch("world.system.state_manager.check_level_up"):
             npc.at_damage(player, npc.traits.health.current + 1)
 
         self.assertEqual(player.db.experience, 7)
@@ -429,7 +483,7 @@ class TestCombatDeath(EvenniaTest):
         expected = (npc.db.level or 1) * settings.DEFAULT_XP_PER_LEVEL
         self.assertEqual(npc.db.exp_reward, expected)
 
-        with patch('world.system.state_manager.check_level_up'):
+        with patch("world.system.state_manager.check_level_up"):
             npc.at_damage(player, npc.traits.health.current + 1)
 
         self.assertEqual(player.db.experience, expected)
@@ -465,15 +519,17 @@ class TestCombatDeath(EvenniaTest):
         npc.db.exp_reward = 2
         npc.pk = None
 
-        with patch('world.system.state_manager.apply_regen'), \
-             patch('world.system.state_manager.check_level_up'):
+        with (
+            patch("world.system.state_manager.apply_regen"),
+            patch("world.system.state_manager.check_level_up"),
+        ):
             npc.on_death(player)
 
         self.assertEqual(player.db.experience, 2)
         corpse = next(
             obj
             for obj in self.room1.contents
-            if obj.is_typeclass('typeclasses.objects.Corpse', exact=False)
+            if obj.is_typeclass("typeclasses.objects.Corpse", exact=False)
         )
         self.assertEqual(corpse.db.corpse_of, npc.key)
 
@@ -491,8 +547,10 @@ class TestCombatDeath(EvenniaTest):
         self.room1.msg_contents = MagicMock()
         player.msg = MagicMock()
 
-        with patch('world.system.state_manager.apply_regen'), \
-             patch('world.system.state_manager.check_level_up'):
+        with (
+            patch("world.system.state_manager.apply_regen"),
+            patch("world.system.state_manager.check_level_up"),
+        ):
             npc.on_death(player)
 
         calls = [c.args[0] for c in self.room1.msg_contents.call_args_list]
@@ -511,9 +569,11 @@ class TestCombatDeath(EvenniaTest):
         engine = CombatEngine([player, npc], round_time=0)
         engine.queue_action(player, KillAction(player, npc))
 
-        with patch('world.system.state_manager.apply_regen'), \
-             patch('world.system.state_manager.check_level_up'), \
-             patch.object(engine, 'award_experience') as mock_award:
+        with (
+            patch("world.system.state_manager.apply_regen"),
+            patch("world.system.state_manager.check_level_up"),
+            patch.object(engine, "award_experience") as mock_award,
+        ):
             engine.start_round()
             engine.process_round()
 
@@ -529,14 +589,16 @@ class TestCombatDeath(EvenniaTest):
         npc.db.vnum = 42
         npc.db.drops = []
 
-        with patch('world.system.state_manager.apply_regen'), \
-             patch('world.system.state_manager.check_level_up'):
+        with (
+            patch("world.system.state_manager.apply_regen"),
+            patch("world.system.state_manager.check_level_up"),
+        ):
             npc.on_death(player)
 
         corpse = next(
             obj
             for obj in self.room1.contents
-            if obj.is_typeclass('typeclasses.objects.Corpse', exact=False)
+            if obj.is_typeclass("typeclasses.objects.Corpse", exact=False)
         )
         self.assertEqual(corpse.db.npc_vnum, npc.db.vnum)
         self.assertNotIn(npc, self.room1.contents)
@@ -556,15 +618,21 @@ class TestCombatNPCTurn(EvenniaTest):
 
         engine = CombatEngine([npc, target], round_time=0)
 
-        with patch('world.system.state_manager.apply_regen'), \
-             patch('world.system.state_manager.get_effective_stat', return_value=0), \
-             patch('random.randint', return_value=0), \
-             patch('combat.engine.damage_processor.delay'), \
-             patch.object(engine, 'queue_action', wraps=engine.queue_action) as mock_queue:
+        with (
+            patch("world.system.state_manager.apply_regen"),
+            patch("world.system.state_manager.get_effective_stat", return_value=0),
+            patch("random.randint", return_value=0),
+            patch("combat.engine.damage_processor.delay"),
+            patch.object(
+                engine, "queue_action", wraps=engine.queue_action
+            ) as mock_queue,
+        ):
             engine.start_round()
             engine.process_round()
 
-        self.assertTrue(any(isinstance(c.args[1], AttackAction) for c in mock_queue.call_args_list))
+        self.assertTrue(
+            any(isinstance(c.args[1], AttackAction) for c in mock_queue.call_args_list)
+        )
 
 
 class TestMultipleActions(unittest.TestCase):
@@ -588,7 +656,10 @@ class TestMultipleActions(unittest.TestCase):
         engine.queue_action(a, RecordAction(a, b, "first", priority=1))
         engine.queue_action(a, RecordAction(a, b, "second", priority=5))
 
-        with patch("world.system.state_manager.apply_regen"), patch("random.randint", return_value=0):
+        with (
+            patch("world.system.state_manager.apply_regen"),
+            patch("random.randint", return_value=0),
+        ):
             engine.start_round()
             engine.process_round()
 
@@ -609,9 +680,11 @@ class TestMultipleActions(unittest.TestCase):
         engine.queue_action(a, first)
         engine.queue_action(a, second)
 
-        with patch("world.system.state_manager.apply_regen"), \
-             patch("random.randint", return_value=0), \
-             patch.object(engine, "track_aggro", side_effect=Exception("stop")):
+        with (
+            patch("world.system.state_manager.apply_regen"),
+            patch("random.randint", return_value=0),
+            patch.object(engine, "track_aggro", side_effect=Exception("stop")),
+        ):
             engine.start_round()
             with self.assertRaises(Exception):
                 engine.process_round()
@@ -628,9 +701,11 @@ def test_no_recovery_message_after_target_cleared():
     engine = CombatEngine([player, mob], round_time=0)
     engine.queue_action(player, KillAction(player, mob))
 
-    with patch("world.system.state_manager.apply_regen"), \
-         patch("combat.engine.damage_processor.delay"), \
-         patch("random.randint", return_value=0):
+    with (
+        patch("world.system.state_manager.apply_regen"),
+        patch("combat.engine.damage_processor.delay"),
+        patch("random.randint", return_value=0),
+    ):
         engine.start_round()
         engine.process_round()
 
@@ -651,11 +726,13 @@ class TestUnsavedPrototypeCombat(unittest.TestCase):
         engine = CombatEngine([player, npc], round_time=0)
         engine.queue_action(player, KillAction(player, npc))
 
-        with patch("world.system.state_manager.apply_regen"), \
-             patch("world.system.state_manager.check_level_up"), \
-             patch("world.system.state_manager.get_effective_stat", return_value=0), \
-             patch("random.randint", return_value=0), \
-             patch("combat.engine.damage_processor.delay"):
+        with (
+            patch("world.system.state_manager.apply_regen"),
+            patch("world.system.state_manager.check_level_up"),
+            patch("world.system.state_manager.get_effective_stat", return_value=0),
+            patch("random.randint", return_value=0),
+            patch("combat.engine.damage_processor.delay"),
+        ):
             engine.start_round()
             engine.process_round()
 
@@ -704,8 +781,10 @@ def test_attacker_target_cleared_on_defeat():
     engine = CombatEngine([attacker, defender], round_time=0)
     engine.queue_action(attacker, KillAction(attacker, defender))
 
-    with patch("world.system.state_manager.apply_regen"), \
-         patch("random.randint", return_value=0):
+    with (
+        patch("world.system.state_manager.apply_regen"),
+        patch("random.randint", return_value=0),
+    ):
         engine.start_round()
         engine.process_round()
 
@@ -721,9 +800,11 @@ def test_clearing_target_leaves_combat():
 
     engine = CombatEngine([player, mob], round_time=0)
 
-    with patch("world.system.state_manager.apply_regen"), \
-         patch("combat.engine.damage_processor.delay"), \
-         patch("random.randint", return_value=0):
+    with (
+        patch("world.system.state_manager.apply_regen"),
+        patch("combat.engine.damage_processor.delay"),
+        patch("random.randint", return_value=0),
+    ):
         engine.start_round()
         engine.process_round()
 
@@ -745,7 +826,10 @@ def test_retarget_after_defeat():
     engine = CombatEngine([a, b1, b2], round_time=0)
     engine.queue_action(a, KillAction(a, b1))
 
-    with patch("world.system.state_manager.apply_regen"), patch("random.randint", return_value=0):
+    with (
+        patch("world.system.state_manager.apply_regen"),
+        patch("random.randint", return_value=0),
+    ):
         engine.start_round()
         engine.process_round()
 
@@ -769,8 +853,9 @@ def test_remaining_combatants_continue_after_kill():
     engine = CombatEngine([player, mob1, mob2], round_time=0)
     engine.queue_action(player, KillAction(player, mob1))
 
-    with patch("world.system.state_manager.apply_regen"), patch(
-        "random.randint", return_value=0
+    with (
+        patch("world.system.state_manager.apply_regen"),
+        patch("random.randint", return_value=0),
     ):
         engine.start_round()
         engine.process_round()
@@ -793,8 +878,9 @@ def test_dead_actor_action_skipped():
     engine.queue_action(player, KillAction(player, mob1))
     engine.queue_action(mob1, AttackAction(mob1, player))
 
-    with patch("world.system.state_manager.apply_regen"), patch(
-        "random.randint", return_value=0
+    with (
+        patch("world.system.state_manager.apply_regen"),
+        patch("random.randint", return_value=0),
     ):
         engine.start_round()
         engine.process_round()
@@ -818,6 +904,7 @@ def test_queue_pruned_after_defeat():
 
     engine = CombatEngine([player, mob1, mob2], round_time=0)
     engine.queue_action(player, KillAction(player, mob1))
+
     class MarkAction(Action):
         def resolve(self):
             return CombatResult(self.actor, self.target, "mark")
@@ -827,17 +914,18 @@ def test_queue_pruned_after_defeat():
     def _dummy_attack(self):
         return CombatResult(self.actor, self.target, "atk")
 
-    with patch("world.system.state_manager.apply_regen"), patch(
-        "world.system.state_manager.get_effective_stat", return_value=0
-    ), patch(
-        "combat.combat_actions.AttackAction.resolve", _dummy_attack
-    ), patch(
-        "random.randint", return_value=0
+    with (
+        patch("world.system.state_manager.apply_regen"),
+        patch("world.system.state_manager.get_effective_stat", return_value=0),
+        patch("combat.combat_actions.AttackAction.resolve", _dummy_attack),
+        patch("random.randint", return_value=0),
     ):
         engine.start_round()
         engine.process_round()
         participant = next(p for p in engine.participants if p.actor is player)
-        assert not any(getattr(a, "target", None) is mob1 for a in participant.next_action)
+        assert not any(
+            getattr(a, "target", None) is mob1 for a in participant.next_action
+        )
         engine.queue_action(player, MarkAction(player, mob2))
         engine.process_round()
 
@@ -866,8 +954,9 @@ def test_hostile_joins_after_midround_kill():
     engine = inst.engine
     engine.queue_action(player, KillAction(player, mob1))
 
-    with patch("world.system.state_manager.apply_regen"), patch(
-        "random.randint", return_value=0
+    with (
+        patch("world.system.state_manager.apply_regen"),
+        patch("random.randint", return_value=0),
     ):
         inst.process_round()
         inst.process_round()
@@ -895,8 +984,9 @@ def test_multi_combat_until_one_remains():
 
     engine = CombatEngine([player] + mobs, round_time=0)
 
-    with patch("world.system.state_manager.apply_regen"), patch(
-        "random.randint", return_value=0
+    with (
+        patch("world.system.state_manager.apply_regen"),
+        patch("random.randint", return_value=0),
     ):
         engine.start_round()
 


### PR DESCRIPTION
## Summary
- track last attacker in `Character.at_damage`
- create an `on_exit_combat` hook for NPCs that drops loot when dead
- avoid duplicate corpse creation in `on_death`
- test that corpses are created exactly once when combat ends

## Testing
- `black typeclasses/characters.py typeclasses/tests/test_combat_engine.py`
- `pytest typeclasses/tests/test_combat_engine.py::TestCombatDeath::test_on_exit_combat_creates_corpse_once -q` *(fails: found no collectors)*

------
https://chatgpt.com/codex/tasks/task_e_6854e4309ae0832cbddd460a3ed2afd1