### PR TITLE
Update CONTRIBUTING.md test setup instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,10 +4,11 @@ Thank you for your interest in contributing!
 
 ## Running the Test Suite
 
-Tests are executed with [`pytest`](https://docs.pytest.org/). They depend on
+Tests are executed with [`pytest`](https://docs.pytest.org/). They rely on
 [Django](https://www.djangoproject.com/) and the [Evennia](https://www.evennia.com/) framework.
-A helper requirements file is provided to install compatible versions of these
-packages.
+If these packages are missing, `pytest` may report "found no collectors" or
+similar import errors. Install the required dependencies using the helper
+requirements file:
 
 ```bash
 python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary
- clarify that Evennia and Django must be installed before running `pytest`

## Testing
- `pip install -r requirements-test.txt` *(fails: Invalid requirement)*
- `pytest -q` *(fails: OperationalError: no such table `accounts_accountdb`)*

------
https://chatgpt.com/codex/tasks/task_e_6854f1faeca4832c839a66e6b86215a0