### PR TITLE
Fix NPC death handling while flagged in combat

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -1297,10 +1297,9 @@ class NPC(Character):
         dmg = super().at_damage(attacker, damage, damage_type=damage_type, critical=critical)
         self.check_triggers("on_attack", attacker=attacker, damage=dmg)
 
-        if self.traits.health.value <= 0:
+        if self.traits.health.value <= 0 and not self.attributes.get("_dead"):
             # we've been defeated!
-            if not self.attributes.get("_dead") and not self.in_combat:
-                self.on_death(attacker)
+            self.on_death(attacker)
             return dmg
 
         if "timid" in self.attributes.get("react_as", ""):


### PR DESCRIPTION
## Summary
- adjust NPC death check so `_dead` bypasses the combat check
- add regression test for NPC HP dropping to zero while flagged `in_combat`

## Testing
- `pytest typeclasses/tests/test_combat_engine.py::TestCombatDeath::test_manual_death_when_flagged_in_combat_creates_corpse -q`

------
https://chatgpt.com/codex/tasks/task_e_6854fc8ab4d0832c9ec428697e613ad8