### PR TITLE
Handle defeat cleanup with killer detection

### DIFF
--- a/combat/engine/damage_processor.py
+++ b/combat/engine/damage_processor.py
@@ -229,6 +229,13 @@ class DamageProcessor:
                 or (target is None and not participant.next_action and not hostiles)
             )
             if should_remove:
+                if hp <= 0 and not getattr(getattr(actor, "db", None), "is_dead", False):
+                    killer = None
+                    log = getattr(getattr(actor, "ndb", None), "damage_log", None)
+                    if log:
+                        killer = max(log, key=log.get)
+                    self.handle_defeat(actor, killer)
+
                 self.turn_manager.remove_participant(actor)
                 from combat.round_manager import CombatRoundManager
                 inst = CombatRoundManager.get().get_combatant_combat(actor)


### PR DESCRIPTION
## Summary
- determine killer from `damage_log` when cleaning up dead combatants
- trigger `handle_defeat` in cleanup to spawn corpses/award XP
- test off-target defeat XP and corpse spawning

## Testing
- `pytest -q` *(fails: OperationalError - no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6854fc821e04832ca11cf9067aa97a74