### PR TITLE
Add CorpseSpawner script and refactor death logic

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -13,6 +13,7 @@ from evennia.prototypes.spawner import spawn
 from utils.currency import to_copper, from_copper, format_wallet
 from utils import normalize_slot
 from utils.mob_utils import make_corpse
+from typeclasses.scripts import CorpseSpawner
 from utils.slots import SLOT_ORDER
 from collections.abc import Mapping
 import math
@@ -23,7 +24,6 @@ from world.combat import get_health_description
 from combat import combat_utils
 
 from .objects import ObjectParent
-from world.mob_constants import BODYPARTS
 
 _IMMOBILE = ("sitting", "lying down", "unconscious", "sleeping")
 
@@ -922,29 +922,11 @@ class PlayerCharacter(Character):
         # remove from combat if engaged
         from combat.round_manager import leave_combat
         leave_combat(self)
-        # create a corpse object and reuse shared logic
-        corpse = make_corpse(self)
+        corpse = CorpseSpawner.spawn_for(self)
         if not corpse:
             return
-        # ensure expected attributes exist
         corpse.db.corpse_of = self.key
         corpse.db.corpse_of_id = self.dbref
-        from world import prototypes
-
-        for part in BODYPARTS:
-            # randomly decide if this body part should spawn for the player
-            if randint(1, 100) <= 50:
-                proto_name = f"{part.name}_PART"
-                proto = getattr(prototypes, proto_name, None)
-                if proto:
-                    obj = spawn(proto)[0]
-                    obj.location = corpse
-                else:
-                    create_object(
-                        "typeclasses.objects.Object",
-                        key=part.value,
-                        location=corpse,
-                    )
         self.at_death(attacker)
         if attacker:
             self.msg(f"You are slain by {attacker.get_display_name(self)}!")
@@ -1182,12 +1164,7 @@ class NPC(Character):
         # remove from combat if engaged
         leave_combat(self)
 
-        corpse = None
-        try:
-            corpse = self.drop_loot(attacker)
-        except Exception as err:  # pragma: no cover - log errors
-            logger.log_err(f"Loot drop error on {self}: {err}")
-
+        corpse = CorpseSpawner.spawn_for(self, attacker)
         if corpse:
             if getattr(self.db, "vnum", None) is not None:
                 corpse.db.npc_vnum = self.db.vnum

--- a/typeclasses/scripts.py
+++ b/typeclasses/scripts.py
@@ -128,3 +128,46 @@ class DecayScript(Script):
 
         obj.delete()
         self.stop()
+
+
+class CorpseSpawner(Script):
+    """Spawn a corpse for a defeated character."""
+
+    @classmethod
+    def spawn_for(cls, char, killer=None):
+        """Create and return a corpse for ``char``.
+
+        If ``char`` is a :class:`PlayerCharacter` random body part objects may be
+        spawned on the corpse.  For NPCs, ``drop_loot`` is invoked to handle any
+        loot tables and coin rewards.
+        """
+        from utils.mob_utils import make_corpse
+        from evennia import create_object
+        corpse = make_corpse(char)
+
+        from typeclasses.characters import PlayerCharacter, NPC
+
+        if inherits_from(char, PlayerCharacter):
+            from world import prototypes
+            from world.mob_constants import BODYPARTS
+
+            for part in BODYPARTS:
+                if randint(1, 100) <= 50:
+                    proto = getattr(prototypes, f"{part.name}_PART", None)
+                    if proto:
+                        spawned = spawn(proto)[0]
+                        spawned.location = corpse
+                    else:
+                        create_object(
+                            "typeclasses.objects.Object", key=part.value, location=corpse
+                        )
+            return corpse
+
+        if inherits_from(char, NPC):
+            try:
+                corpse = char.drop_loot(killer)
+            except Exception as err:  # pragma: no cover - log errors
+                logger.log_err(f"Loot drop error on {char}: {err}")
+            return corpse
+
+        return corpse

--- a/typeclasses/tests/test_combat_engine.py
+++ b/typeclasses/tests/test_combat_engine.py
@@ -570,123 +570,123 @@ class TestCombatDeath(EvenniaTest):
         self.assertNotIn(npc, [p.actor for p in engine.participants])
         self.assertEqual(corpse.db.corpse_of, npc.key)
 
-  def test_player_kills_multiple_npcs_creates_multiple_corpses_and_awards_xp(self):
-      """Killing two NPCs should produce two corpses, loot, and combined XP."""
-      from evennia.utils import create
-      from typeclasses.characters import NPC
+    def test_player_kills_multiple_npcs_creates_multiple_corpses_and_awards_xp(self):
+        """Killing two NPCs should produce two corpses, loot, and combined XP."""
+        from evennia.utils import create
+        from typeclasses.characters import NPC
 
-      player = self.char1
-      player.db.experience = 0
-      npc1 = create.create_object(NPC, key="mob1", location=self.room1)
-      npc2 = create.create_object(NPC, key="mob2", location=self.room1)
+        player = self.char1
+        player.db.experience = 0
+        npc1 = create.create_object(NPC, key="mob1", location=self.room1)
+        npc2 = create.create_object(NPC, key="mob2", location=self.room1)
 
-      for npc in (npc1, npc2):
-          npc.db.drops = []
-      npc1.db.exp_reward = 5
-      npc2.db.exp_reward = 7
+        for npc in (npc1, npc2):
+            npc.db.drops = []
+        npc1.db.exp_reward = 5
+        npc2.db.exp_reward = 7
 
-      loot1 = create.create_object("typeclasses.objects.Object", key="loot1", location=npc1)
-      loot2 = create.create_object("typeclasses.objects.Object", key="loot2", location=npc2)
+        loot1 = create.create_object("typeclasses.objects.Object", key="loot1", location=npc1)
+        loot2 = create.create_object("typeclasses.objects.Object", key="loot2", location=npc2)
 
-      engine = CombatEngine([player, npc1, npc2], round_time=0)
+        engine = CombatEngine([player, npc1, npc2], round_time=0)
 
-      # Kill first NPC
-      engine.queue_action(player, KillAction(player, npc1))
-      with patch("world.system.state_manager.apply_regen"), patch(
-          "world.system.state_manager.check_level_up"
-      ), patch("random.randint", return_value=0):
-          engine.start_round()
-          engine.process_round()
+        # Kill first NPC
+        engine.queue_action(player, KillAction(player, npc1))
+        with patch("world.system.state_manager.apply_regen"), patch(
+            "world.system.state_manager.check_level_up"
+        ), patch("random.randint", return_value=0):
+            engine.start_round()
+            engine.process_round()
 
-      # Kill second NPC
-      engine.queue_action(player, KillAction(player, npc2))
-      with patch("world.system.state_manager.apply_regen"), patch(
-          "world.system.state_manager.check_level_up"
-      ), patch("random.randint", return_value=0):
-          engine.process_round()
+        # Kill second NPC
+        engine.queue_action(player, KillAction(player, npc2))
+        with patch("world.system.state_manager.apply_regen"), patch(
+            "world.system.state_manager.check_level_up"
+        ), patch("random.randint", return_value=0):
+            engine.process_round()
 
-      # Verify two corpses were created
-      corpses = [
-          obj
-          for obj in self.room1.contents
-          if obj.is_typeclass("typeclasses.objects.Corpse", exact=False)
-      ]
-      self.assertEqual(len(corpses), 2)
+        # Verify two corpses were created
+        corpses = [
+            obj
+            for obj in self.room1.contents
+            if obj.is_typeclass("typeclasses.objects.Corpse", exact=False)
+        ]
+        self.assertEqual(len(corpses), 2)
 
-      # Verify correct corpse mapping
-      corpse1 = next(c for c in corpses if c.db.corpse_of == npc1.key)
-      corpse2 = next(c for c in corpses if c.db.corpse_of == npc2.key)
+        # Verify correct corpse mapping
+        corpse1 = next(c for c in corpses if c.db.corpse_of == npc1.key)
+        corpse2 = next(c for c in corpses if c.db.corpse_of == npc2.key)
 
-      # Verify loot transfer
-      self.assertIn(loot1, corpse1.contents)
-      self.assertIn(loot2, corpse2.contents)
+        # Verify loot transfer
+        self.assertIn(loot1, corpse1.contents)
+        self.assertIn(loot2, corpse2.contents)
 
-      # Verify combined XP award
-      total_xp = npc1.db.exp_reward + npc2.db.exp_reward
-      self.assertEqual(player.db.experience, total_xp)
+        # Verify combined XP award
+        total_xp = npc1.db.exp_reward + npc2.db.exp_reward
+        self.assertEqual(player.db.experience, total_xp)
 
-  def test_manual_death_when_flagged_in_combat_creates_corpse(self):
-      """Setting hp to 0 outside the engine should still create a corpse."""
-      from evennia.utils import create
-      from typeclasses.characters import NPC
+    def test_manual_death_when_flagged_in_combat_creates_corpse(self):
+        """Setting hp to 0 outside the engine should still create a corpse."""
+        from evennia.utils import create
+        from typeclasses.characters import NPC
 
-      npc = create.create_object(NPC, key="mob", location=self.room1)
-      npc.db.drops = []
-      npc.db.in_combat = True
-      npc.traits.health.current = 0
+        npc = create.create_object(NPC, key="mob", location=self.room1)
+        npc.db.drops = []
+        npc.db.in_combat = True
+        npc.traits.health.current = 0
 
-      corpse = create.create_object('typeclasses.objects.Object', key='corpse', location=None)
+        corpse = create.create_object('typeclasses.objects.Object', key='corpse', location=None)
 
-      with patch('world.system.state_manager.check_level_up'), \
-           patch('typeclasses.characters.make_corpse', return_value=corpse) as mock_make:
-          npc.at_damage(self.char1, 0)
+        with patch('world.system.state_manager.check_level_up'), \
+             patch('typeclasses.scripts.CorpseSpawner.spawn_for', return_value=corpse) as mock_spawn:
+            npc.at_damage(self.char1, 0)
 
-      mock_make.assert_called_once_with(npc)
-      self.assertIs(corpse.location, self.room1)
+        mock_spawn.assert_called_once_with(npc, self.char1)
+        self.assertIs(corpse.location, self.room1)
 
-  def test_multi_target_kill_spawns_corpses_and_awards_xp(self):
-      """Killing two NPCs at once should create two corpses and grant XP."""
-      from evennia.utils import create
-      from typeclasses.characters import NPC
+    def test_multi_target_kill_spawns_corpses_and_awards_xp(self):
+        """Killing two NPCs at once should create two corpses and grant XP."""
+        from evennia.utils import create
+        from typeclasses.characters import NPC
 
-      player = self.char1
-      player.db.experience = 0
-      npc1 = create.create_object(NPC, key="mob1", location=self.room1)
-      npc2 = create.create_object(NPC, key="mob2", location=self.room1)
+        player = self.char1
+        player.db.experience = 0
+        npc1 = create.create_object(NPC, key="mob1", location=self.room1)
+        npc2 = create.create_object(NPC, key="mob2", location=self.room1)
 
-      for npc in (npc1, npc2):
-          npc.db.drops = []
-          npc.db.exp_reward = 3
-          npc.ndb.damage_log = {player: 5}
+        for npc in (npc1, npc2):
+            npc.db.drops = []
+            npc.db.exp_reward = 3
+            npc.ndb.damage_log = {player: 5}
 
-      class KillBoth(Action):
-          def __init__(self, actor, target, other):
-              super().__init__(actor, target)
-              self.other = other
+        class KillBoth(Action):
+            def __init__(self, actor, target, other):
+                super().__init__(actor, target)
+                self.other = other
 
-          def resolve(self):
-              npc1.traits.health.current = 0
-              npc2.traits.health.current = 0
-              return CombatResult(self.actor, npc1, "boom")
+            def resolve(self):
+                npc1.traits.health.current = 0
+                npc2.traits.health.current = 0
+                return CombatResult(self.actor, npc1, "boom")
 
-      engine = CombatEngine([player, npc1, npc2], round_time=0)
-      engine.queue_action(player, KillBoth(player, npc1, npc2))
+        engine = CombatEngine([player, npc1, npc2], round_time=0)
+        engine.queue_action(player, KillBoth(player, npc1, npc2))
 
-      with patch("world.system.state_manager.apply_regen"), patch(
-          "world.system.state_manager.check_level_up"
-      ), patch("random.randint", return_value=0):
-          engine.start_round()
-          engine.process_round()
+        with patch("world.system.state_manager.apply_regen"), patch(
+            "world.system.state_manager.check_level_up"
+        ), patch("random.randint", return_value=0):
+            engine.start_round()
+            engine.process_round()
 
-      corpses = [
-          obj
-          for obj in self.room1.contents
-          if obj.is_typeclass("typeclasses.objects.Corpse", exact=False)
-      ]
-      self.assertEqual(len(corpses), 2)
-      self.assertIn(npc1.key, [c.db.corpse_of for c in corpses])
-      self.assertIn(npc2.key, [c.db.corpse_of for c in corpses])
-      self.assertEqual(player.db.experience, npc1.db.exp_reward + npc2.db.exp_reward)
+        corpses = [
+            obj
+            for obj in self.room1.contents
+            if obj.is_typeclass("typeclasses.objects.Corpse", exact=False)
+        ]
+        self.assertEqual(len(corpses), 2)
+        self.assertIn(npc1.key, [c.db.corpse_of for c in corpses])
+        self.assertIn(npc2.key, [c.db.corpse_of for c in corpses])
+        self.assertEqual(player.db.experience, npc1.db.exp_reward + npc2.db.exp_reward)
 
 
 class TestCombatNPCTurn(EvenniaTest):


### PR DESCRIPTION
## Summary
- create `CorpseSpawner` script to centralize corpse creation
- update `PlayerCharacter` and `NPC` to use the new script
- adjust combat tests to patch `CorpseSpawner`

## Testing
- `pytest -q` *(fails: OperationalError - no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68558e8c6d24832c929c720d442e4dcd