### PR TITLE
Add corpse_creation utility

### DIFF
--- a/corpse_creation.py
+++ b/corpse_creation.py
@@ -1,0 +1,45 @@
+from random import randint
+from evennia.utils import logger, inherits_from
+from utils.mob_utils import make_corpse
+
+from evennia.prototypes.spawner import spawn
+from evennia import create_object
+
+
+def spawn_corpse(char, killer=None):
+    """Create and return a corpse for ``char``.
+
+    Player characters receive random body part objects while NPCs
+    trigger their loot handling via ``drop_loot``.
+    """
+    corpse = make_corpse(char)
+    if not corpse:
+        return None
+
+    from typeclasses.characters import PlayerCharacter, NPC
+    if inherits_from(char, PlayerCharacter):
+        from world import prototypes
+        from world.mob_constants import BODYPARTS
+
+        for part in BODYPARTS:
+            if randint(1, 100) <= 50:
+                proto = getattr(prototypes, f"{part.name}_PART", None)
+                if proto:
+                    spawned = spawn(proto)[0]
+                    spawned.location = corpse
+                else:
+                    create_object(
+                        "typeclasses.objects.Object",
+                        key=part.value,
+                        location=corpse,
+                    )
+        return corpse
+
+    if inherits_from(char, NPC):
+        try:
+            corpse = char.drop_loot(killer)
+        except Exception as err:  # pragma: no cover - log errors
+            logger.log_err(f"Loot drop error on {char}: {err}")
+        return corpse
+
+    return corpse

--- a/typeclasses/tests/test_combat_engine.py
+++ b/typeclasses/tests/test_combat_engine.py
@@ -570,7 +570,7 @@ class TestCombatDeath(EvenniaTest):
         self.assertNotIn(npc, [p.actor for p in engine.participants])
         self.assertEqual(corpse.db.corpse_of, npc.key)
 
-  def test_player_kills_multiple_npcs_creates_multiple_corpses_and_awards_xp(self):
+    def test_player_kills_multiple_npcs_creates_multiple_corpses_and_awards_xp(self):
       """Killing two NPCs should produce two corpses, loot, and combined XP."""
       from evennia.utils import create
       from typeclasses.characters import NPC
@@ -625,68 +625,68 @@ class TestCombatDeath(EvenniaTest):
       total_xp = npc1.db.exp_reward + npc2.db.exp_reward
       self.assertEqual(player.db.experience, total_xp)
 
-  def test_manual_death_when_flagged_in_combat_creates_corpse(self):
-      """Setting hp to 0 outside the engine should still create a corpse."""
-      from evennia.utils import create
-      from typeclasses.characters import NPC
+    def test_manual_death_when_flagged_in_combat_creates_corpse(self):
+        """Setting hp to 0 outside the engine should still create a corpse."""
+        from evennia.utils import create
+        from typeclasses.characters import NPC
 
-      npc = create.create_object(NPC, key="mob", location=self.room1)
-      npc.db.drops = []
-      npc.db.in_combat = True
-      npc.traits.health.current = 0
+        npc = create.create_object(NPC, key="mob", location=self.room1)
+        npc.db.drops = []
+        npc.db.in_combat = True
+        npc.traits.health.current = 0
 
-      corpse = create.create_object('typeclasses.objects.Object', key='corpse', location=None)
+        corpse = create.create_object('typeclasses.objects.Object', key='corpse', location=None)
 
-      with patch('world.system.state_manager.check_level_up'), \
-           patch('typeclasses.characters.make_corpse', return_value=corpse) as mock_make:
-          npc.at_damage(self.char1, 0)
+        with patch('world.system.state_manager.check_level_up'), \
+             patch('typeclasses.characters.spawn_corpse', return_value=corpse) as mock_spawn:
+            npc.at_damage(self.char1, 0)
 
-      mock_make.assert_called_once_with(npc)
-      self.assertIs(corpse.location, self.room1)
+        mock_spawn.assert_called_once_with(npc, self.char1)
+        self.assertIs(corpse.location, self.room1)
 
-  def test_multi_target_kill_spawns_corpses_and_awards_xp(self):
-      """Killing two NPCs at once should create two corpses and grant XP."""
-      from evennia.utils import create
-      from typeclasses.characters import NPC
+    def test_multi_target_kill_spawns_corpses_and_awards_xp(self):
+        """Killing two NPCs at once should create two corpses and grant XP."""
+        from evennia.utils import create
+        from typeclasses.characters import NPC
 
-      player = self.char1
-      player.db.experience = 0
-      npc1 = create.create_object(NPC, key="mob1", location=self.room1)
-      npc2 = create.create_object(NPC, key="mob2", location=self.room1)
+        player = self.char1
+        player.db.experience = 0
+        npc1 = create.create_object(NPC, key="mob1", location=self.room1)
+        npc2 = create.create_object(NPC, key="mob2", location=self.room1)
 
-      for npc in (npc1, npc2):
-          npc.db.drops = []
-          npc.db.exp_reward = 3
-          npc.ndb.damage_log = {player: 5}
+        for npc in (npc1, npc2):
+            npc.db.drops = []
+            npc.db.exp_reward = 3
+            npc.ndb.damage_log = {player: 5}
 
-      class KillBoth(Action):
-          def __init__(self, actor, target, other):
-              super().__init__(actor, target)
-              self.other = other
+        class KillBoth(Action):
+            def __init__(self, actor, target, other):
+                super().__init__(actor, target)
+                self.other = other
 
-          def resolve(self):
-              npc1.traits.health.current = 0
-              npc2.traits.health.current = 0
-              return CombatResult(self.actor, npc1, "boom")
+            def resolve(self):
+                npc1.traits.health.current = 0
+                npc2.traits.health.current = 0
+                return CombatResult(self.actor, npc1, "boom")
 
-      engine = CombatEngine([player, npc1, npc2], round_time=0)
-      engine.queue_action(player, KillBoth(player, npc1, npc2))
+        engine = CombatEngine([player, npc1, npc2], round_time=0)
+        engine.queue_action(player, KillBoth(player, npc1, npc2))
 
-      with patch("world.system.state_manager.apply_regen"), patch(
-          "world.system.state_manager.check_level_up"
-      ), patch("random.randint", return_value=0):
-          engine.start_round()
-          engine.process_round()
+        with patch("world.system.state_manager.apply_regen"), patch(
+            "world.system.state_manager.check_level_up"
+        ), patch("random.randint", return_value=0):
+            engine.start_round()
+            engine.process_round()
 
-      corpses = [
-          obj
-          for obj in self.room1.contents
-          if obj.is_typeclass("typeclasses.objects.Corpse", exact=False)
-      ]
-      self.assertEqual(len(corpses), 2)
-      self.assertIn(npc1.key, [c.db.corpse_of for c in corpses])
-      self.assertIn(npc2.key, [c.db.corpse_of for c in corpses])
-      self.assertEqual(player.db.experience, npc1.db.exp_reward + npc2.db.exp_reward)
+        corpses = [
+            obj
+            for obj in self.room1.contents
+            if obj.is_typeclass("typeclasses.objects.Corpse", exact=False)
+        ]
+        self.assertEqual(len(corpses), 2)
+        self.assertIn(npc1.key, [c.db.corpse_of for c in corpses])
+        self.assertIn(npc2.key, [c.db.corpse_of for c in corpses])
+        self.assertEqual(player.db.experience, npc1.db.exp_reward + npc2.db.exp_reward)
 
 
 class TestCombatNPCTurn(EvenniaTest):

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -11,6 +11,7 @@ try:  # optional during early initialization
         auto_calc,
         auto_calc_secondary,
         make_corpse,
+        spawn_corpse,
     )
 except Exception:  # pragma: no cover - may fail before Django setup
     pass


### PR DESCRIPTION
## Summary
- add corpse_creation module containing spawn_corpse
- use spawn_corpse in Character death handling
- update combat engine test for new function
- expose spawn_corpse via utils package

## Testing
- `pytest typeclasses/tests/test_combat_engine.py::TestCombatDeath::test_manual_death_when_flagged_in_combat_creates_corpse -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68559a7f9b5c832c81b60564fde69040