### PR TITLE
Add combatants helpers

### DIFF
--- a/combat/combat_manager.py
+++ b/combat/combat_manager.py
@@ -8,7 +8,7 @@ from typing import Dict, List, Optional, Set
 
 from evennia.utils import delay
 from evennia.utils.logger import log_trace
-from .engine import _current_hp
+from .combatants import _current_hp
 
 
 @dataclass

--- a/combat/combatants.py
+++ b/combat/combatants.py
@@ -1,0 +1,63 @@
+"""Utilities for working with combat participants."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, List
+
+
+@dataclass
+class CombatParticipant:
+    """Representation of a combatant in combat."""
+
+    actor: object
+    initiative: int = 0
+    next_action: List[object] = field(default_factory=list)
+
+
+def _current_hp(obj):
+    """Return the current health of ``obj`` as an integer."""
+    if hasattr(obj, "hp"):
+        try:
+            return int(obj.hp)
+        except Exception as err:  # pragma: no cover - safety
+            raise ValueError(f"invalid hp value on {obj!r}") from err
+
+    hp_trait = getattr(getattr(obj, "traits", None), "health", None)
+    if hp_trait is not None:
+        try:
+            return int(hp_trait.current)
+        except Exception as err:  # pragma: no cover - safety
+            raise ValueError(f"invalid health trait on {obj!r}") from err
+
+    raise AttributeError(f"{obj!r} lacks a health trait or hp attribute")
+
+
+# ---------------------------------------------------------------------------
+# participant list helpers
+# ---------------------------------------------------------------------------
+
+def _assemble(*groups: Iterable[object] | object) -> List[object]:
+    """Flatten one or more fighter groups into a participant list."""
+    fighters: List[object] = []
+    for grp in groups:
+        if isinstance(grp, Iterable) and not isinstance(grp, (str, bytes)):
+            fighters.extend(list(grp))
+        else:
+            fighters.append(grp)
+    return fighters
+
+
+def setup_1v1(a: object, b: object) -> List[object]:
+    """Return a participant list for a one-on-one fight."""
+    return _assemble(a, b)
+
+
+def setup_1vN(a: object, opponents: Iterable[object]) -> List[object]:
+    """Return a participant list for a one-versus-many fight."""
+    return _assemble(a, opponents)
+
+
+def setup_NvN(group_a: Iterable[object], group_b: Iterable[object]) -> List[object]:
+    """Return a participant list for a group-vs-group fight."""
+    return _assemble(group_a, group_b)

--- a/combat/engine/__init__.py
+++ b/combat/engine/__init__.py
@@ -1,6 +1,6 @@
 """Engine subpackage for combat components."""
 
-from .common import _current_hp, CombatParticipant
+from ..combatants import _current_hp, CombatParticipant
 from .turn_manager import TurnManager
 from .aggro_tracker import AggroTracker
 from .damage_processor import DamageProcessor

--- a/combat/engine/common.py
+++ b/combat/engine/common.py
@@ -1,41 +1,10 @@
-"""Common utilities for the combat engine."""
+"""Shared constants for the combat engine."""
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import List
-
-from world.system import state_manager
 
 # For every ``HASTE_PER_EXTRA_ATTACK`` haste, an actor gains one additional
 # attack in a round (up to ``MAX_ATTACKS_PER_ROUND`` total).
 HASTE_PER_EXTRA_ATTACK = 50
 MAX_ATTACKS_PER_ROUND = 6
-
-
-@dataclass
-class CombatParticipant:
-    """Representation of a combatant in combat."""
-
-    actor: object
-    initiative: int = 0
-    next_action: List[object] = field(default_factory=list)
-
-
-def _current_hp(obj):
-    """Return the current health of ``obj`` as an integer."""
-    if hasattr(obj, "hp"):
-        try:
-            return int(obj.hp)
-        except Exception as err:
-            raise ValueError(f"invalid hp value on {obj!r}") from err
-
-    hp_trait = getattr(getattr(obj, "traits", None), "health", None)
-    if hp_trait is not None:
-        try:
-            return int(hp_trait.current)
-        except Exception as err:
-            raise ValueError(f"invalid health trait on {obj!r}") from err
-
-    raise AttributeError(f"{obj!r} lacks a health trait or hp attribute")
 

--- a/combat/engine/damage_processor.py
+++ b/combat/engine/damage_processor.py
@@ -6,7 +6,7 @@ from typing import Dict, List
 from evennia.utils import delay
 from django.conf import settings
 
-from .common import CombatParticipant, _current_hp
+from ..combatants import CombatParticipant, _current_hp
 from ..combat_utils import format_combat_message
 from .turn_manager import TurnManager
 from .aggro_tracker import AggroTracker

--- a/combat/engine/turn_manager.py
+++ b/combat/engine/turn_manager.py
@@ -6,7 +6,8 @@ from typing import Iterable, List
 
 from world.system import state_manager
 
-from .common import CombatParticipant, _current_hp, HASTE_PER_EXTRA_ATTACK, MAX_ATTACKS_PER_ROUND
+from .common import HASTE_PER_EXTRA_ATTACK, MAX_ATTACKS_PER_ROUND
+from ..combatants import CombatParticipant, _current_hp
 from ..combat_actions import AttackAction, Action
 from ..combat_utils import calculate_initiative
 


### PR DESCRIPTION
## Summary
- introduce `combatants.py` with combatant dataclass and participant setup helpers
- move `_current_hp` utility here and simplify engine `common.py`
- update engine modules and combat manager to import from the new file

## Testing
- `pytest -q` *(fails: 671 failed, 47 passed, 2 warnings, 2 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68559f7160d4832c8cd38307222c9aeb