### PR TITLE
Add combat scripts for spells and skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,11 @@ Supports action queues, status effects, resistances
 
 Fully pluggable and extendable
 
+`combat.scripts` exposes helper functions like `queue_spell` and
+`queue_skill` for casting and using abilities. They automatically
+queue a `SpellAction` or `SkillAction` on the active combat engine or
+resolve the effect immediately when outside of combat.
+
 Running Tests
 Install test dependencies:
 ```bash

--- a/combat/scripts/__init__.py
+++ b/combat/scripts/__init__.py
@@ -1,0 +1,13 @@
+"""Helper functions for combat-related skill and spell usage."""
+
+from .skills import queue_skill, resolve_skill, get_skill
+from .spells import queue_spell, resolve_spell, get_spell
+
+__all__ = [
+    "queue_skill",
+    "resolve_skill",
+    "get_skill",
+    "queue_spell",
+    "resolve_spell",
+    "get_spell",
+]

--- a/combat/scripts/skills.py
+++ b/combat/scripts/skills.py
@@ -1,0 +1,46 @@
+"""Wrappers for using skills during combat."""
+
+from __future__ import annotations
+
+from typing import Optional, Union
+
+from ..combat_actions import SkillAction
+from ..combat_skills import SKILL_CLASSES, Skill
+from world.skills.utils import maybe_start_combat
+
+
+def get_skill(name: str) -> Optional[Skill]:
+    """Return a new instance of ``name`` if available."""
+    cls = SKILL_CLASSES.get(name)
+    return cls() if cls else None
+
+
+def queue_skill(
+    user: object,
+    skill: Union[str, Skill],
+    target: Optional[object] = None,
+    *,
+    engine: Optional[object] = None,
+    start_combat: bool = False,
+):
+    """Queue ``skill`` on ``engine`` or resolve immediately."""
+    if isinstance(skill, str):
+        skill_obj = get_skill(skill)
+    else:
+        skill_obj = skill
+    if not skill_obj:
+        return None
+    if start_combat and target:
+        maybe_start_combat(user, target)
+    if engine is None and hasattr(user, "ndb"):
+        engine = getattr(user.ndb, "combat_engine", None)
+    if engine:
+        engine.queue_action(user, SkillAction(user, skill_obj, target))
+        return None
+    action = SkillAction(user, skill_obj, target)
+    return action.resolve()
+
+
+def resolve_skill(user: object, skill: Union[str, Skill], target: Optional[object] = None):
+    """Resolve ``skill`` immediately."""
+    return queue_skill(user, skill, target, engine=None)

--- a/combat/scripts/spells.py
+++ b/combat/scripts/spells.py
@@ -1,0 +1,46 @@
+"""Helpers for casting spells in and out of combat."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from ..combat_actions import SpellAction
+from world.spells import SPELLS, Spell
+
+
+def get_spell(key: str) -> Optional[Spell]:
+    """Return the spell matching ``key``."""
+    return SPELLS.get(key)
+
+
+def queue_spell(
+    caster: object,
+    spell: str | Spell,
+    target: Optional[object] = None,
+    *,
+    engine: Optional[object] = None,
+):
+    """Queue ``spell`` on ``engine`` or resolve immediately."""
+    if isinstance(spell, Spell):
+        key = spell.key
+    else:
+        key = spell
+        spell = get_spell(key)
+    if not spell:
+        return None
+    if engine is None and hasattr(caster, "ndb"):
+        engine = getattr(caster.ndb, "combat_engine", None)
+    if engine:
+        engine.queue_action(caster, SpellAction(caster, key, target))
+        return None
+    cast = getattr(caster, "cast_spell", None)
+    if callable(cast):
+        cast(key, target)
+        return None
+    action = SpellAction(caster, key, target)
+    return action.resolve()
+
+
+def resolve_spell(caster: object, spell: str | Spell, target: Optional[object] = None):
+    """Resolve ``spell`` immediately."""
+    return queue_spell(caster, spell, target, engine=None)


### PR DESCRIPTION
## Summary
- add combat.scripts package exposing queue_skill/queue_spell helpers
- update ai_combat to use the new helpers
- update ability and spell commands to resolve skills/spells via combat.scripts
- document helpers in README

## Testing
- `pytest -q` *(fails: ImportError and functional test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6855a15a8938832c8c38530b5bdfc093