### PR TITLE
Refactor combat AI modules

### DIFF
--- a/combat/ai/aggressive.py
+++ b/combat/ai/aggressive.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from combat.ai import BaseAI, register_ai
-from combat.ai_combat import npc_take_turn
+from combat.combat_ai.npc_logic import npc_take_turn
 
 
 @register_ai("aggressive")

--- a/combat/ai/defensive.py
+++ b/combat/ai/defensive.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from combat.ai import BaseAI, register_ai
-from combat.ai_combat import npc_take_turn
+from combat.combat_ai.npc_logic import npc_take_turn
 
 
 @register_ai("defensive")

--- a/combat/combat_ai/__init__.py
+++ b/combat/combat_ai/__init__.py
@@ -1,0 +1,6 @@
+"""Combat AI helpers."""
+
+from .ai_controller import Behavior, run_behaviors
+from .npc_logic import npc_take_turn
+
+__all__ = ["Behavior", "run_behaviors", "npc_take_turn"]

--- a/combat/combat_ai/ai_controller.py
+++ b/combat/combat_ai/ai_controller.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Iterable
+
+from ..engine import CombatEngine
+
+
+@dataclass(order=True)
+class Behavior:
+    """A prioritized behavior condition/action pair."""
+
+    priority: int
+    check: Callable[[CombatEngine | None, object, object], bool] = field(compare=False)
+    act: Callable[[CombatEngine | None, object, object], None] = field(compare=False)
+
+
+def run_behaviors(
+    engine: CombatEngine | None,
+    npc: object,
+    target: object,
+    behaviors: Iterable[Behavior],
+) -> None:
+    """Execute the first valid behavior from ``behaviors``."""
+
+    for beh in sorted(list(behaviors), reverse=True):
+        if beh.check(engine, npc, target):
+            beh.act(engine, npc, target)
+            break

--- a/typeclasses/tests/test_ai_combat.py
+++ b/typeclasses/tests/test_ai_combat.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import MagicMock
 
-from combat.ai_combat import npc_take_turn
+from combat.combat_ai.npc_logic import npc_take_turn
 from combat.combat_actions import SpellAction, SkillAction
 
 class DummyNPC:

--- a/typeclasses/tests/test_combat_flow.py
+++ b/typeclasses/tests/test_combat_flow.py
@@ -11,7 +11,7 @@ from combat.combat_actions import (
 )
 from combat.combat_skills import ShieldBash
 from combat.damage_types import DamageType
-from combat.ai_combat import npc_take_turn
+from combat.combat_ai.npc_logic import npc_take_turn
 from typeclasses.gear import BareHand
 
 

--- a/world/npc_handlers/mob_ai.py
+++ b/world/npc_handlers/mob_ai.py
@@ -9,7 +9,7 @@ from random import choice, randint
 from evennia import DefaultObject
 from evennia.utils import logger
 from typeclasses.npcs import BaseNPC
-from combat.ai_combat import npc_take_turn
+from combat.combat_ai.npc_logic import npc_take_turn
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- split `combat/ai_combat.py` into new `combat/combat_ai` package
- move `npc_take_turn` into `npc_logic.py`
- add `Behavior` dataclass and runner in `ai_controller.py`
- update imports to reference new locations
- adjust tests to use new modules

## Testing
- `pytest typeclasses/tests/test_ai_combat.py::TestAICombat::test_prefers_spell_over_skill -q`
- `pytest typeclasses/tests/test_npc_ai.py::TestAIBehaviors::test_wander_ai_moves -q` *(fails: OperationalError: no such table)*

------
https://chatgpt.com/codex/tasks/task_e_6855a9860bd8832ca32a5a2f487b9de8