### PR TITLE
Deprecate round_manager module

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ Modular combat using a 2-second tick:
 from combat.combat_manager import CombatRoundManager
 CombatRoundManager.get().start_combat([fighter1, fighter2])
 ```
+The previous `combat.round_manager` module now simply re-exports these
+classes and is considered deprecated.
 
 Supports action queues, status effects, resistances
 

--- a/combat/round_manager.py
+++ b/combat/round_manager.py
@@ -1,6 +1,7 @@
 """Deprecated combat round management module.
 
-This file now re-exports classes from :mod:`combat.combat_manager`.
+``CombatRoundManager`` now lives in :mod:`combat.combat_manager`. This
+module simply re-exports the classes for backward compatibility.
 """
 
 from .combat_manager import CombatInstance, CombatRoundManager, leave_combat

--- a/docs/combat_loop_mapping.md
+++ b/docs/combat_loop_mapping.md
@@ -6,6 +6,9 @@ This project models its turn-based fighting system after the traditional combat 
 
 File: `combat/combat_manager.py`
 
+- The old `combat.round_manager` module has been deprecated and now
+  simply re-exports these classes for compatibility.
+
 - Maintains a registry of all active combat instances keyed by a unique combat id.
 - Tracks which combat each combatant belongs to for quick lookup.
 - Each `CombatInstance` schedules a tick every few seconds, much like ROM's


### PR DESCRIPTION
## Summary
- add deprecation note in `combat/round_manager`
- document round manager location in combat docs
- mention new module path in README

## Testing
- `pytest -q` *(fails: no such table accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6855ba37d5e0832c8fb8611b2cba336c