### PR TITLE
Enable spells to start combat

### DIFF
--- a/combat/scripts/spells.py
+++ b/combat/scripts/spells.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Optional
 
+from world.skills.utils import maybe_start_combat
+
 from ..combat_actions import SpellAction
 from world.spells import SPELLS, Spell
 
@@ -19,6 +21,7 @@ def queue_spell(
     target: Optional[object] = None,
     *,
     engine: Optional[object] = None,
+    start_combat: bool = False,
 ):
     """Queue ``spell`` on ``engine`` or resolve immediately."""
     if isinstance(spell, Spell):
@@ -28,6 +31,8 @@ def queue_spell(
         spell = get_spell(key)
     if not spell:
         return None
+    if start_combat and target:
+        maybe_start_combat(caster, target)
     if engine is None and hasattr(caster, "ndb"):
         engine = getattr(caster.ndb, "combat_engine", None)
     if engine:

--- a/commands/spells.py
+++ b/commands/spells.py
@@ -111,7 +111,10 @@ class CmdCast(Command):
             target = self.caller.search(self.target)
             if not target:
                 return
-        result = queue_spell(self.caller, spell, target)
+        if target:
+            result = queue_spell(self.caller, spell, target, start_combat=True)
+        else:
+            result = queue_spell(self.caller, spell, target)
         if result and result.message and self.caller.location:
             self.caller.location.msg_contents(result.message)
 


### PR DESCRIPTION
## Summary
- allow queue_spell to optionally start combat
- start combat when casting a targeted spell

## Testing
- `pytest -q` *(fails: django.db errors and many failed tests)*

------
https://chatgpt.com/codex/tasks/task_e_6855c1b9d97c832cb2168920036fa4af