### PR TITLE
Fix defeat XP flow

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -940,7 +940,6 @@ class PlayerCharacter(Character):
                 )
             else:
                 self.location.msg_contents(f"{self.key} dies.")
-        self.award_xp_to(attacker)
 
         # determine recall destination just like the recall command
         dest = self.db.recall_location
@@ -1181,14 +1180,8 @@ class NPC(Character):
             else:
                 self.location.msg_contents(f"{self.key} dies.")
 
-        # award experience using the combat engine if available
-        if engine:
-            try:
-                engine.award_experience(attacker, self)
-            except Exception:  # pragma: no cover - safety
-                logger.log_err("XP award failed via engine", exc_info=True)
-        else:
-            # fallback if no active engine
+        # award experience if no engine is managing combat
+        if not engine:
             self.award_xp_to(attacker)
 
         if attacker and getattr(attacker.db, "combat_target", None) is self:


### PR DESCRIPTION
## Summary
- award experience from the combat engine after `on_death`
- ensure a corpse spawns for any defeated character
- remove XP awards from `PlayerCharacter.on_death`
- keep NPC XP fallback when no combat engine is used

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6855c31f8628832ca5e223265f0ba2a9