### PR TITLE
Add AI combat helper and update NPC AI references

### DIFF
--- a/combat/ai/aggressive.py
+++ b/combat/ai/aggressive.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from combat.ai import BaseAI, register_ai
-from combat.combat_ai.npc_logic import npc_take_turn
+from combat.ai_combat import queue_npc_action
 
 
 @register_ai("aggressive")
@@ -10,7 +10,7 @@ class AggressiveAI(BaseAI):
 
     def execute(self, npc):
         if npc.in_combat and npc.db.combat_target:
-            npc_take_turn(None, npc, npc.db.combat_target)
+            queue_npc_action(None, npc, npc.db.combat_target)
             return
         if not npc.location:
             return

--- a/combat/ai/defensive.py
+++ b/combat/ai/defensive.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from combat.ai import BaseAI, register_ai
-from combat.combat_ai.npc_logic import npc_take_turn
+from combat.ai_combat import queue_npc_action
 
 
 @register_ai("defensive")
@@ -10,4 +10,4 @@ class DefensiveAI(BaseAI):
 
     def execute(self, npc):
         if npc.in_combat and npc.db.combat_target:
-            npc_take_turn(None, npc, npc.db.combat_target)
+            queue_npc_action(None, npc, npc.db.combat_target)

--- a/combat/ai_combat.py
+++ b/combat/ai_combat.py
@@ -1,0 +1,19 @@
+"""Helpers for queuing NPC combat actions."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from combat.engine import CombatEngine
+from combat.combat_ai.npc_logic import npc_take_turn as _npc_take_turn
+
+
+def queue_npc_action(engine: CombatEngine | None, npc: Any, target: Any) -> None:
+    """Queue an action for ``npc`` on ``engine``.
+
+    This wraps :func:`combat.combat_ai.npc_logic.npc_take_turn` so that the
+    selected action is placed into ``engine``'s queue via
+    :meth:`CombatEngine.queue_action`.
+    """
+    _npc_take_turn(engine, npc, target)
+

--- a/typeclasses/tests/test_ai_combat.py
+++ b/typeclasses/tests/test_ai_combat.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import MagicMock
 
-from combat.combat_ai.npc_logic import npc_take_turn
+from combat.ai_combat import queue_npc_action
 from combat.combat_actions import SpellAction, SkillAction
 
 class DummyNPC:
@@ -28,20 +28,20 @@ class TestAICombat(unittest.TestCase):
         self.engine = MagicMock()
 
     def test_prefers_spell_over_skill(self):
-        npc_take_turn(self.engine, self.npc, self.target)
+        queue_npc_action(self.engine, self.npc, self.target)
         action = self.engine.queue_action.call_args[0][1]
         self.assertIsInstance(action, SpellAction)
 
     def test_uses_skill_when_no_mana(self):
         self.npc.traits.mana.current = 0
         self.engine.queue_action.reset_mock()
-        npc_take_turn(self.engine, self.npc, self.target)
+        queue_npc_action(self.engine, self.npc, self.target)
         action = self.engine.queue_action.call_args[0][1]
         self.assertIsInstance(action, SkillAction)
 
     def test_spell_order(self):
         self.npc.db.spells = ["fireball", "heal"]
-        npc_take_turn(self.engine, self.npc, self.target)
+        queue_npc_action(self.engine, self.npc, self.target)
         action = self.engine.queue_action.call_args[0][1]
         self.assertIsInstance(action, SpellAction)
         self.assertEqual(action.spell.key, "fireball")
@@ -50,7 +50,7 @@ class TestAICombat(unittest.TestCase):
         self.npc.db.spells = ["fireball", "heal"]
         self.npc.traits.mana.current = 8
         self.engine.queue_action.reset_mock()
-        npc_take_turn(self.engine, self.npc, self.target)
+        queue_npc_action(self.engine, self.npc, self.target)
         action = self.engine.queue_action.call_args[0][1]
         self.assertIsInstance(action, SpellAction)
         self.assertEqual(action.spell.key, "heal")
@@ -58,7 +58,7 @@ class TestAICombat(unittest.TestCase):
     def test_skill_order(self):
         self.npc.db.spells = []
         self.npc.db.skills = ["cleave", "shield bash"]
-        npc_take_turn(self.engine, self.npc, self.target)
+        queue_npc_action(self.engine, self.npc, self.target)
         action = self.engine.queue_action.call_args[0][1]
         self.assertIsInstance(action, SkillAction)
         self.assertEqual(action.skill.name, "cleave")
@@ -68,7 +68,7 @@ class TestAICombat(unittest.TestCase):
         self.npc.db.skills = ["cleave", "shield bash"]
         self.npc.traits.stamina.current = 15
         self.engine.queue_action.reset_mock()
-        npc_take_turn(self.engine, self.npc, self.target)
+        queue_npc_action(self.engine, self.npc, self.target)
         action = self.engine.queue_action.call_args[0][1]
         self.assertIsInstance(action, SkillAction)
         self.assertEqual(action.skill.name, "shield bash")

--- a/typeclasses/tests/test_combat_flow.py
+++ b/typeclasses/tests/test_combat_flow.py
@@ -11,7 +11,7 @@ from combat.combat_actions import (
 )
 from combat.combat_skills import ShieldBash
 from combat.damage_types import DamageType
-from combat.combat_ai.npc_logic import npc_take_turn
+from combat.ai_combat import queue_npc_action
 from typeclasses.gear import BareHand
 
 
@@ -300,7 +300,7 @@ class TestNPCBehaviors(unittest.TestCase):
         npc.traits.health.max = 10
         npc.on_low_hp = MagicMock()
         target = Dummy()
-        npc_take_turn(None, npc, target)
+        queue_npc_action(None, npc, target)
         npc.on_low_hp.assert_called()
 
 

--- a/world/npc_handlers/mob_ai.py
+++ b/world/npc_handlers/mob_ai.py
@@ -9,7 +9,7 @@ from random import choice, randint
 from evennia import DefaultObject
 from evennia.utils import logger
 from typeclasses.npcs import BaseNPC
-from combat.combat_ai.npc_logic import npc_take_turn
+from combat.ai_combat import queue_npc_action
 
 
 @dataclass
@@ -250,7 +250,7 @@ def process_mob_ai(npc: BaseNPC) -> None:
         return
 
     if npc.in_combat and npc.db.combat_target:
-        npc_take_turn(None, npc, npc.db.combat_target)
+        queue_npc_action(None, npc, npc.db.combat_target)
         return
 
     _scavenge(npc)


### PR DESCRIPTION
## Summary
- add `combat/ai_combat.py` wrapper around existing AI combat logic
- update mob AI and simple AI modules to use `queue_npc_action`
- update tests for new helper

## Testing
- `pytest -q` *(fails: django OperationalError - no such table)*

------
https://chatgpt.com/codex/tasks/task_e_6855c5c56f0c832c8d591620afa74253