### PR TITLE
Add admin debug helper and logging

### DIFF
--- a/combat/combat_manager.py
+++ b/combat/combat_manager.py
@@ -8,6 +8,7 @@ from typing import Dict, List, Optional, Set
 
 from evennia.utils import delay
 from evennia.utils.logger import log_trace
+from utils.debug import admin_debug
 from .combatants import _current_hp
 
 
@@ -58,6 +59,8 @@ class CombatInstance:
 
     def start(self) -> None:
         """Begin automatic round processing."""
+        names = ", ".join(getattr(c, "key", str(c)) for c in self.combatants)
+        admin_debug(f"Combat {self.combat_id} starting with: {names}")
         self._schedule_tick()
 
     def _schedule_tick(self) -> None:
@@ -78,6 +81,7 @@ class CombatInstance:
     def _tick(self) -> None:
         """Process a round and schedule the next one."""
         self.tick_handle = None
+        admin_debug(f"Combat {self.combat_id} tick at round {self.round_number}")
         if not self.is_valid():
             self.end_combat("Invalid combat instance")
             return
@@ -228,6 +232,8 @@ class CombatInstance:
         """Mark this instance as ended and clean up fighter states."""
         if self.combat_ended:
             return
+
+        admin_debug(f"Combat {self.combat_id} ending: {reason}")
 
         room = getattr(self, "room", None)
         try:

--- a/combat/corpse_creation.py
+++ b/combat/corpse_creation.py
@@ -1,6 +1,7 @@
 from random import randint
 from evennia.utils import logger, inherits_from
 from utils.mob_utils import make_corpse
+from utils.debug import admin_debug
 
 from evennia.prototypes.spawner import spawn
 from evennia import create_object
@@ -12,6 +13,7 @@ def spawn_corpse(char, killer=None):
     Player characters receive random body part objects while NPCs
     trigger their loot handling via ``drop_loot``.
     """
+    admin_debug(f"Spawning corpse for {getattr(char, 'key', char)}")
     corpse = make_corpse(char)
     if not corpse:
         return None
@@ -37,6 +39,7 @@ def spawn_corpse(char, killer=None):
 
     if inherits_from(char, NPC):
         try:
+            admin_debug(f"{getattr(char, 'key', char)} dropping loot")
             corpse = char.drop_loot(killer)
         except Exception as err:  # pragma: no cover - log errors
             logger.log_err(f"Loot drop error on {char}: {err}")

--- a/combat/engine/combat_engine.py
+++ b/combat/engine/combat_engine.py
@@ -8,6 +8,7 @@ from .turn_manager import TurnManager
 from .aggro_tracker import AggroTracker
 from .damage_processor import DamageProcessor
 from evennia.utils.logger import log_trace
+from utils.debug import admin_debug
 
 
 class CombatEngine:
@@ -47,7 +48,7 @@ class CombatEngine:
         combatant_keys = ", ".join(
             getattr(p.actor, "key", str(p.actor)) for p in self.turn_manager.participants
         )
-        log_trace(f"Processing combat round {self.round} | Combatants: {combatant_keys}")
+        admin_debug(f"Processing combat round {self.round} | Combatants: {combatant_keys}")
         self.processor.process_round()
 
     # Convenience wrappers for processor functionality

--- a/combat/engine/damage_processor.py
+++ b/combat/engine/damage_processor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Dict, List
 from evennia.utils import delay
 from django.conf import settings
+from utils.debug import admin_debug
 
 from ..combatants import CombatParticipant, _current_hp
 from ..combat_utils import format_combat_message
@@ -326,6 +327,13 @@ class DamageProcessor:
         damage_totals: Dict[object, int] = {}
 
         actions = self.turn_manager.gather_actions()
+        action_summary = [
+            f"{getattr(p.actor, 'key', p.actor)}->{getattr(a, '__class__').__name__}"
+            for _, _, _, p, a in actions
+        ]
+        admin_debug(
+            f"Round {self.engine.round}: queued actions: {', '.join(action_summary)}"
+        )
         prev = None
         for _, _, _, participant, action in actions:
             if prev is not participant and prev is not None:

--- a/server/conf/settings.py
+++ b/server/conf/settings.py
@@ -97,6 +97,8 @@ VNUM_REGISTRY_FILE = Path(GAME_DIR) / "world" / "vnum_registry.json"
 COMBAT_DEBUG_TICKS = False
 # When True, include a damage summary at the end of each combat round
 COMBAT_DEBUG_SUMMARY = False
+# Send combat debug messages to connected admins when True
+COMBAT_ADMIN_DEBUG = False
 
 # Clothing - https://www.evennia.com/docs/latest/Contribs/Contrib-Clothing.html#configuration
 CLOTHING_WEARSTYLE_MAXLENGTH = 40

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -4,6 +4,7 @@ from .roles import has_role, is_guildmaster, is_receptionist
 from .slots import VALID_SLOTS, normalize_slot
 from .ansi_utils import format_ansi_title
 from .menu_utils import add_back_skip
+from .debug import admin_debug
 try:  # optional during early initialization
     from .mob_utils import (
         assign_next_vnum,

--- a/utils/debug.py
+++ b/utils/debug.py
@@ -1,0 +1,16 @@
+from django.conf import settings
+from evennia.accounts.models import AccountDB
+from evennia.utils import logger
+
+
+def admin_debug(msg: str) -> None:
+    """Send a debug ``msg`` to connected admins and log it."""
+    logger.log_debug(msg)
+    if not getattr(settings, "COMBAT_ADMIN_DEBUG", False):
+        return
+    for account in AccountDB.objects.filter(is_superuser=True):
+        try:
+            if account.is_connected:
+                account.msg(msg)
+        except Exception:
+            pass

--- a/utils/mob_utils.py
+++ b/utils/mob_utils.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Dict
 
 from utils import vnum_registry
+from utils.debug import admin_debug
 from utils.stats_utils import normalize_stat_key
 from world.scripts.mob_db import get_mobdb
 from world.system import stat_manager
@@ -97,6 +98,8 @@ def make_corpse(npc):
     if not npc or not npc.location:
         return None
 
+    admin_debug(f"Creating corpse for {getattr(npc, 'key', npc)}")
+
     # avoid multiple corpses if on_death is called repeatedly for the same npc
     existing = [
         obj
@@ -126,6 +129,7 @@ def make_corpse(npc):
         location=npc.location,
         attributes=attrs,
     )
+    admin_debug(f"Corpse object {corpse.key} created at {getattr(npc.location, 'key', npc.location)}")
     # store the vnum of the NPC on the corpse for bookkeeping
     if hasattr(npc.db, "vnum"):
         corpse.db.npc_vnum = npc.db.vnum


### PR DESCRIPTION
## Summary
- add `utils.debug.admin_debug` to notify connected admins
- log combat events to admins through `admin_debug`
- provide `COMBAT_ADMIN_DEBUG` setting

## Testing
- `python -m pytest -q --maxfail=1` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6855d0ee8df0832c87c1a8c02250d2da