### PR TITLE
Ensure engine round_time mirrors combat interval

### DIFF
--- a/combat/combat_manager.py
+++ b/combat/combat_manager.py
@@ -301,7 +301,7 @@ class CombatRoundManager:
         except ImportError as err:
             raise ImportError("Combat engine could not be imported") from err
 
-        engine = CombatEngine(fighters, round_time=None)
+        engine = CombatEngine(fighters, round_time=round_time or 2.0)
         if not engine:
             raise RuntimeError("CombatEngine failed to initialize")
 

--- a/docs/combat_loop_mapping.md
+++ b/docs/combat_loop_mapping.md
@@ -14,6 +14,8 @@ File: `combat/combat_manager.py`
 - Each `CombatInstance` schedules a tick every few seconds, much like ROM's
   `violence_update` that iterates over every character currently fighting.
 - Each tick triggers the associated `CombatEngine` to process a new round.
+- The `round_time` argument used when creating a combat sets this tick interval
+  and is forwarded to `CombatEngine` so its automatic round timer matches.
 - When `COMBAT_DEBUG_TICKS` is `True` in `server/conf/settings.py`, a debug log is emitted each tick.
 
 ## CombatInstance

--- a/typeclasses/tests/test_round_manager.py
+++ b/typeclasses/tests/test_round_manager.py
@@ -81,3 +81,11 @@ class TestCombatRoundManager(EvenniaTest):
         self.assertIs(self.manager.get_combatant_combat(self.char3), merged)
         self.assertTrue(extra.combat_ended)
 
+    def test_round_time_passed_to_engine(self):
+        with patch.object(CombatInstance, "start"):
+            inst = self.manager.create_combat(
+                combatants=[self.char1, self.char2], round_time=3.5
+            )
+        self.assertEqual(inst.round_time, 3.5)
+        self.assertEqual(inst.engine.round_time, 3.5)
+


### PR DESCRIPTION
## Summary
- forward `round_time` from `create_combat()` to `CombatEngine`
- document that `round_time` controls both tick scheduling and engine auto-rounds
- test that `CombatEngine` receives the configured `round_time`

## Testing
- `pytest -q typeclasses/tests/test_round_manager.py::TestCombatRoundManager::test_round_time_passed_to_engine` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6855d910ee0c832c9e14a013e5b24246