### PR TITLE
Add damage adjectives for high damage hits

### DIFF
--- a/combat/combat_utils.py
+++ b/combat/combat_utils.py
@@ -177,6 +177,26 @@ def check_distance(a, b, max_range: int) -> bool:
     return result
 
 
+def damage_adjective(actor, damage: int) -> str:
+    """Return a descriptive adjective for ``damage`` dealt by ``actor``."""
+
+    max_range = state_manager.get_effective_stat(actor, "attack_power")
+    if not max_range:
+        level = getattr(getattr(actor, "db", None), "level", 0) or 0
+        max_range = level * 5
+    max_range = max(max_range, 1)
+
+    if damage >= 0.9 * max_range:
+        return "legendary"
+    if damage >= 0.6 * max_range:
+        return "heavy"
+    if damage >= 0.3 * max_range:
+        return "solid"
+    if damage > 0:
+        return "light"
+    return ""
+
+
 def format_combat_message(
     actor,
     target,
@@ -185,6 +205,7 @@ def format_combat_message(
     *,
     crit: bool = False,
     miss: bool = False,
+    adjective: bool = False,
 ) -> str:
     """Return a standardized combat log message with color coding."""
 
@@ -195,6 +216,9 @@ def format_combat_message(
         return f"|C{a_name}'s {action} misses {t_name}!|n"
 
     if damage is not None:
+        if adjective:
+            adj = damage_adjective(actor, damage)
+            adj = f"{adj} " if adj else ""
         max_range = state_manager.get_effective_stat(actor, "attack_power")
         if not max_range:
             level = getattr(getattr(actor, "db", None), "level", 0) or 0
@@ -213,7 +237,7 @@ def format_combat_message(
             color = "|w"
 
         crit_text = " |y(critical)|n" if crit else ""
-        return f"{a_name} {action} {t_name} for {color}{damage}|n damage{crit_text}"
+        return f"{a_name} {action} {t_name} for {adj}{color}{damage}|n damage{crit_text}"
 
     return f"{a_name} {action} {t_name}!"
 

--- a/combat/engine/damage_processor.py
+++ b/combat/engine/damage_processor.py
@@ -40,7 +40,9 @@ class DamageProcessor:
     def dam_message(self, attacker, target, damage: int, *, crit: bool = False) -> None:
         if not attacker or not target or not attacker.location:
             return
-        msg = format_combat_message(attacker, target, "hits", damage, crit=crit)
+        msg = format_combat_message(
+            attacker, target, "hits", damage, crit=crit, adjective=True
+        )
         attacker.location.msg_contents(msg)
 
     def skill_message(self, actor, target, skill: str, success: bool = True) -> None:

--- a/utils/tests/test_combat_utils.py
+++ b/utils/tests/test_combat_utils.py
@@ -129,3 +129,28 @@ class TestCombatUtils(EvenniaTest):
         self.assertEqual(get_condition_msg(1, 10), "is in awful condition.")
         self.assertEqual(get_condition_msg(0, 10), "is dead.")
 
+    def test_damage_adjectives(self):
+        from combat import combat_utils
+
+        self.char1.db.level = 20
+        with patch("world.system.state_manager.get_effective_stat", return_value=0):
+            max_range = self.char1.db.level * 5
+            cases = [
+                (int(max_range * 0.95), "legendary"),
+                (int(max_range * 0.65), "heavy"),
+                (int(max_range * 0.35), "solid"),
+                (1, "light"),
+                (0, ""),
+            ]
+            for dmg, word in cases:
+                self.assertEqual(combat_utils.damage_adjective(self.char1, dmg), word)
+
+            msg = combat_utils.format_combat_message(
+                self.char1,
+                self.char2,
+                "hits",
+                damage=int(max_range * 0.95),
+                adjective=True,
+            )
+            self.assertIn("legendary", msg)
+


### PR DESCRIPTION
## Summary
- add damage_adjective helper and extend format_combat_message
- include adjective in DamageProcessor.dam_message
- test adjective helper and message output

## Testing
- `pytest -q` *(fails: django.db.utils.OperationalError: no such table: accounts_accountdb)*
- `pytest utils/tests/test_combat_utils.py::TestCombatUtils::test_damage_adjectives -q` *(fails: django.db.utils.OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6855da0ae13c832cb5800b5a67c5588f