### PR TITLE
Add Disarm skill with tests

### DIFF
--- a/combat/combat_skills.py
+++ b/combat/combat_skills.py
@@ -19,6 +19,7 @@ from .combat_utils import roll_damage, roll_evade
 from .combat_states import CombatState
 from world.system import stat_manager
 from world.skills.kick import Kick
+from world.skills.disarm import Disarm
 
 
 @dataclass
@@ -103,4 +104,5 @@ SKILL_CLASSES: Dict[str, type[Skill]] = {
     "shield bash": ShieldBash,
     "cleave": Cleave,
     "kick": Kick,
+    "disarm": Disarm,
 }

--- a/typeclasses/tests/test_disarm_skill.py
+++ b/typeclasses/tests/test_disarm_skill.py
@@ -1,0 +1,51 @@
+from unittest.mock import MagicMock, patch
+from django.test import override_settings
+from evennia.utils.test_resources import EvenniaTest
+from evennia.utils import create
+from combat.engine import CombatEngine
+from combat.combat_actions import SkillAction
+from world.skills.disarm import Disarm
+from world.system import stat_manager
+
+
+@override_settings(DEFAULT_HOME=None)
+class TestDisarmSkill(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.room1.msg_contents = MagicMock()
+        self.char1.location = self.room1
+        self.char2.location = self.room1
+        self.char1.msg = MagicMock()
+        self.char2.msg = MagicMock()
+
+        self.char2.attributes.add("_wielded", {"right": None, "left": None})
+        self.weapon = create.create_object(
+            "typeclasses.gear.MeleeWeapon", key="sword", location=self.char2
+        )
+        self.weapon.tags.add("equipment", category="flag")
+        self.weapon.tags.add("identified", category="flag")
+        self.char2.at_wield(self.weapon)
+
+    def _run_skill(self, hit=True, evade=False, parry=False):
+        engine = CombatEngine([self.char1, self.char2], round_time=0)
+        engine.queue_action(self.char1, SkillAction(self.char1, Disarm(), self.char2))
+        with patch("world.system.state_manager.apply_regen"), \
+             patch.object(stat_manager, "check_hit", return_value=hit), \
+             patch("combat.combat_utils.roll_evade", return_value=evade), \
+             patch("combat.combat_utils.roll_parry", return_value=parry), \
+             patch("world.skills.skill.random", return_value=0), \
+             patch("random.randint", return_value=0):
+            engine.start_round()
+            engine.process_round()
+
+    def test_disarm_success(self):
+        self._run_skill()
+        self.assertNotIn(self.weapon, self.char2.wielding)
+        calls = [c.args[0] for c in self.room1.msg_contents.call_args_list]
+        self.assertTrue(any("disarm" in msg.lower() for msg in calls))
+
+    def test_disarm_failure(self):
+        self._run_skill(hit=False)
+        self.assertIn(self.weapon, self.char2.wielding)
+        calls = [c.args[0] for c in self.room1.msg_contents.call_args_list]
+        self.assertTrue(any("fails" in msg or "misses" in msg for msg in calls))

--- a/world/skills/__init__.py
+++ b/world/skills/__init__.py
@@ -1,6 +1,7 @@
 from .skill import Skill
 from .kick import Kick
+from .disarm import Disarm
 from .unarmed_passive import Unarmed
 from .hand_to_hand import HandToHand
 
-__all__ = ["Skill", "Kick", "Unarmed", "HandToHand"]
+__all__ = ["Skill", "Kick", "Disarm", "Unarmed", "HandToHand"]

--- a/world/skills/disarm.py
+++ b/world/skills/disarm.py
@@ -1,0 +1,39 @@
+from combat.combat_actions import CombatResult
+from combat.combat_utils import roll_evade, roll_parry
+from world.system import stat_manager
+from .skill import Skill
+
+
+class Disarm(Skill):
+    """Attempt to knock the target's weapon from their hands."""
+
+    name = "disarm"
+    cooldown = 5
+    stamina_cost = 5
+
+    def resolve(self, user, target):
+        """Try to disarm ``target``."""
+        self.improve(user)
+        weapon = target.wielding[0] if getattr(target, "wielding", []) else None
+        if not weapon:
+            return CombatResult(
+                actor=user,
+                target=target,
+                message=f"{target.key} isn't wielding anything.",
+            )
+        if (
+            not stat_manager.check_hit(user, target)
+            or roll_evade(user, target)
+            or roll_parry(user, target)
+        ):
+            return CombatResult(
+                actor=user,
+                target=target,
+                message=f"{user.key}'s disarm attempt fails against {target.key}.",
+            )
+        target.at_unwield(weapon)
+        return CombatResult(
+            actor=user,
+            target=target,
+            message=f"$You() disarm(s) {target.key}, knocking {weapon.key} away!",
+        )


### PR DESCRIPTION
## Summary
- add a Disarm skill implementation
- expose Disarm through skill registry
- test disarm success/failure scenarios

## Testing
- `pytest -k disarm_skill -q` *(fails: OperationalError no such table)*

------
https://chatgpt.com/codex/tasks/task_e_6855e3189930832ca8525567af75724f