### PR TITLE
Add wimpy flee tests and document dodge/parry

### DIFF
--- a/docs/combat_loop_mapping.md
+++ b/docs/combat_loop_mapping.md
@@ -107,3 +107,15 @@ from combat.engine import CombatEngine, TurnManager, AggroTracker, DamageProcess
   participant = CombatParticipant(actor)
   ```
 
+## Additional Mechanics
+
+- **Parry and Dodge** – `CombatMath.check_hit` mirrors ROM's `check_dodge` and
+  `check_parry` functions. After verifying a hit, it rolls
+  `roll_evade`, `roll_parry` and `roll_block` to allow the defender a chance to
+  avoid damage based on their `evasion`, `parry_rate` and `block_rate` stats.
+
+- **Wimpy Fleeing** – NPCs with the `wimpy` flag run away when their HP drops
+  below a threshold. The `_check_wimpy` helper in `world/npc_handlers/mob_ai.py`
+  compares the mob's current HP against `flee_at` (defaulting to 25% of maximum)
+  and issues the `flee` command when triggered.
+

--- a/typeclasses/tests/test_mob_ai.py
+++ b/typeclasses/tests/test_mob_ai.py
@@ -214,3 +214,41 @@ class TestMobAIBehaviors(EvenniaTest):
         mob_ai.process_mob_ai(npc)
 
         npc.execute_cmd.assert_called_with("flee")
+
+    def test_wimpy_uses_custom_threshold(self):
+        """NPC flees when HP is below its custom ``flee_at`` value."""
+        from typeclasses.npcs import BaseNPC
+        from combat.combat_manager import CombatRoundManager
+
+        npc = create.create_object(BaseNPC, key="scared", location=self.room1)
+        npc.db.actflags = ["wimpy"]
+        npc.db.flee_at = 50
+        npc.hp = 40
+        npc.max_hp = 100
+        manager = CombatRoundManager.get()
+        manager.start_combat([npc, self.char1])
+
+        npc.execute_cmd = MagicMock()
+
+        mob_ai.process_mob_ai(npc)
+
+        npc.execute_cmd.assert_called_with("flee")
+
+    def test_wimpy_stays_above_custom_threshold(self):
+        """NPC does not flee if current HP is above ``flee_at``."""
+        from typeclasses.npcs import BaseNPC
+        from combat.combat_manager import CombatRoundManager
+
+        npc = create.create_object(BaseNPC, key="brave", location=self.room1)
+        npc.db.actflags = ["wimpy"]
+        npc.db.flee_at = 50
+        npc.hp = 80
+        npc.max_hp = 100
+        manager = CombatRoundManager.get()
+        manager.start_combat([npc, self.char1])
+
+        npc.execute_cmd = MagicMock()
+
+        mob_ai.process_mob_ai(npc)
+
+        npc.execute_cmd.assert_not_called()


### PR DESCRIPTION
## Summary
- document new dodge/parry and wimpy fleeing mechanics
- test custom wimpy flee threshold

## Testing
- `pytest typeclasses/tests/test_mob_ai.py::TestMobAIBehaviors::test_wimpy_uses_custom_threshold -q`


------
https://chatgpt.com/codex/tasks/task_e_6855e5471bfc832c808de6ba5e4fdc73