### PR TITLE
Move aggro modules

### DIFF
--- a/combat/aggro_tracker.py
+++ b/combat/aggro_tracker.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Dict, Iterable, List
 
 from world.system import state_manager
-from ..combat_utils import award_xp
+from .combat_utils import award_xp
 
 
 class AggroTracker:

--- a/combat/damage_processor.py
+++ b/combat/damage_processor.py
@@ -6,12 +6,12 @@ from typing import Dict, List
 from evennia.utils import delay
 from django.conf import settings
 
-from ..combatants import CombatParticipant, _current_hp
-from ..combat_utils import format_combat_message
-from combat.corpse_creation import spawn_corpse
-from .turn_manager import TurnManager
+from .combatants import CombatParticipant, _current_hp
+from .combat_utils import format_combat_message
+from .corpse_creation import spawn_corpse
+from .engine.turn_manager import TurnManager
 from .aggro_tracker import AggroTracker
-from ..damage_types import DamageType
+from .damage_types import DamageType
 from world.system import state_manager
 
 

--- a/combat/engine/__init__.py
+++ b/combat/engine/__init__.py
@@ -2,8 +2,8 @@
 
 from ..combatants import _current_hp, CombatParticipant
 from .turn_manager import TurnManager
-from .aggro_tracker import AggroTracker
-from .damage_processor import DamageProcessor
+from ..aggro_tracker import AggroTracker
+from ..damage_processor import DamageProcessor
 from .combat_math import CombatMath
 from .combat_engine import CombatEngine
 

--- a/combat/engine/combat_engine.py
+++ b/combat/engine/combat_engine.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from typing import Iterable
 
 from .turn_manager import TurnManager
-from .aggro_tracker import AggroTracker
-from .damage_processor import DamageProcessor
+from ..aggro_tracker import AggroTracker
+from ..damage_processor import DamageProcessor
 from evennia.utils.logger import log_trace
 
 

--- a/world/tests/test_aggro_tracker.py
+++ b/world/tests/test_aggro_tracker.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-from combat.engine.aggro_tracker import AggroTracker
+from combat.aggro_tracker import AggroTracker
 
 
 class TestAggroTracker(unittest.TestCase):
@@ -11,9 +11,9 @@ class TestAggroTracker(unittest.TestCase):
         victim = MagicMock(pk=2)
         active = [attacker]
 
-        with patch("combat.engine.aggro_tracker.state_manager.get_effective_stat", return_value=0), \
-             patch("combat.engine.aggro_tracker.state_manager.calculate_xp_reward", return_value=5), \
-             patch("combat.engine.aggro_tracker.award_xp"):
+        with patch("combat.aggro_tracker.state_manager.get_effective_stat", return_value=0), \
+             patch("combat.aggro_tracker.state_manager.calculate_xp_reward", return_value=5), \
+             patch("combat.aggro_tracker.award_xp"):
             tracker.track(victim, attacker)
             assert victim in tracker.table
             tracker.award_experience(attacker, victim, active)

--- a/world/tests/test_combat_engine_minimal.py
+++ b/world/tests/test_combat_engine_minimal.py
@@ -61,7 +61,7 @@ class TestCombatEngineMinimal(unittest.TestCase):
         engine.queue_action(defender, NoOpAction(defender))
         engine.queue_action(attacker, DamageAction(attacker, defender))
         with patch("world.system.state_manager.apply_regen"), patch(
-            "combat.engine.damage_processor.delay"
+            "combat.damage_processor.delay"
         ), patch("random.randint", return_value=0):
             engine.start_round()
             engine.process_round()
@@ -76,7 +76,7 @@ class TestCombatEngineMinimal(unittest.TestCase):
         engine.queue_action(defender, NoOpAction(defender))
         engine.queue_action(attacker, KillAction(attacker, defender))
         with patch("world.system.state_manager.apply_regen"), patch(
-            "combat.engine.damage_processor.delay"
+            "combat.damage_processor.delay"
         ), patch("random.randint", return_value=0):
             engine.start_round()
             engine.process_round()
@@ -92,7 +92,7 @@ class TestCombatEngineMinimal(unittest.TestCase):
         engine = CombatEngine([attacker, defender], round_time=0)
         engine.queue_action(attacker, DamageAction(attacker, defender))
         with patch("world.system.state_manager.apply_regen"), patch(
-            "combat.engine.damage_processor.delay"
+            "combat.damage_processor.delay"
         ), patch("random.randint", return_value=0):
             engine.start_round()
             engine.process_round()
@@ -125,7 +125,7 @@ class TestCombatEngineMinimal(unittest.TestCase):
         engine.queue_action(defender, NoOpAction(defender))
         engine.queue_action(attacker, KillAction(attacker, defender))
         with patch("world.system.state_manager.apply_regen"), patch(
-            "combat.engine.damage_processor.delay"
+            "combat.damage_processor.delay"
         ), patch("random.randint", return_value=0), patch.object(
             engine, "award_experience"
         ) as mock_xp:
@@ -163,7 +163,7 @@ class TestCombatEngineMinimal(unittest.TestCase):
         engine.queue_action(defender, NoOpAction(defender))
         engine.queue_action(attacker, KillAction(attacker, defender))
         with patch("world.system.state_manager.apply_regen"), patch(
-            "combat.engine.damage_processor.delay"
+            "combat.damage_processor.delay"
         ), patch("random.randint", return_value=0):
             engine.start_round()
             engine.process_round()
@@ -182,7 +182,7 @@ class TestCombatEngineMinimal(unittest.TestCase):
         engine.queue_action(defender, NoOpAction(defender))
         engine.queue_action(attacker, KillAction(attacker, defender))
         with patch("world.system.state_manager.apply_regen"), patch(
-            "combat.engine.damage_processor.delay"
+            "combat.damage_processor.delay"
         ), patch("random.randint", return_value=0):
             engine.start_round()
             engine.process_round()


### PR DESCRIPTION
## Summary
- move `aggro_tracker` and `damage_processor` out of the engine package
- update imports and tests
- re-export from `engine.__init__`

## Testing
- `pytest -q` *(fails: django and evennia not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6855ea3ad1f4832cb613c890c69faec4