### PR TITLE
Move spells module to combat package

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,8 @@ Supports action queues, status effects, resistances
 
 Fully pluggable and extendable
 
+The available spells and the ``Spell`` dataclass now live in ``combat.spells``.
+
 `combat.scripts` exposes helper functions like `queue_spell` and
 `queue_skill` for casting and using abilities. They automatically
 queue a `SpellAction` or `SkillAction` on the active combat engine or

--- a/combat/combat_actions.py
+++ b/combat/combat_actions.py
@@ -239,7 +239,7 @@ class SpellAction(Action):
             Optional spell target.
         """
         super().__init__(actor, target)
-        from world.spells import SPELLS
+        from combat.spells import SPELLS
 
         self.spell = SPELLS.get(spell_key)
         if self.spell:
@@ -254,7 +254,7 @@ class SpellAction(Action):
         success = getattr(self.actor, "cast_spell", None)
         if callable(success):
             success(self.spell.key, self.target)
-        from world.spells import colorize_spell
+        from combat.spells import colorize_spell
 
         colored = colorize_spell(self.spell.key)
         result = CombatResult(

--- a/combat/scripts/spells.py
+++ b/combat/scripts/spells.py
@@ -7,7 +7,7 @@ from typing import Optional
 from world.skills.utils import maybe_start_combat
 
 from ..combat_actions import SpellAction
-from world.spells import SPELLS, Spell
+from combat.spells import SPELLS, Spell
 
 
 def get_spell(key: str) -> Optional[Spell]:

--- a/combat/spells.py
+++ b/combat/spells.py
@@ -1,0 +1,53 @@
+from dataclasses import dataclass
+from typing import Dict
+
+@dataclass
+class Spell:
+    """Data describing a castable spell."""
+
+    key: str
+    stat: str
+    mana_cost: int
+    desc: str = ""
+    cooldown: int = 0
+    # Optional skill providing a proficiency bonus to casting success
+    support_skill: str | None = None
+
+
+SPELLS: Dict[str, Spell] = {
+    "fireball": Spell(
+        "fireball",
+        "INT",
+        10,
+        "Hurl a ball of fire at your target.",
+        cooldown=5,
+        support_skill="spellcasting",
+    ),
+    "heal": Spell(
+        "heal",
+        "WIS",
+        8,
+        "Restore a small amount of health.",
+        cooldown=3,
+        support_skill="spellcasting",
+    ),
+}
+
+
+def colorize_spell(name: str) -> str:
+    """Return ``name`` wrapped in an ANSI color based on keywords."""
+
+    lname = name.lower()
+    if any(key in lname for key in ("fire", "flame", "burn")):
+        color = "|r"
+    elif any(key in lname for key in ("ice", "frost", "cold")):
+        color = "|c"
+    elif any(key in lname for key in ("nature", "druid", "plant")):
+        color = "|g"
+    elif any(key in lname for key in ("necrom", "shadow")):
+        color = "|m"
+    elif any(key in lname for key in ("holy", "heal", "light")):
+        color = "|w"
+    else:
+        color = "|M"
+    return f"{color}{name}|n"

--- a/commands/spells.py
+++ b/commands/spells.py
@@ -2,7 +2,7 @@ from evennia import CmdSet
 from evennia.utils.evtable import EvTable
 from .command import Command
 from combat.scripts import get_spell, queue_spell
-from world.spells import Spell, colorize_spell
+from combat.spells import Spell, colorize_spell
 
 
 class CmdSpellbook(Command):

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -18,7 +18,7 @@ from utils.slots import SLOT_ORDER
 from collections.abc import Mapping
 import math
 from world.triggers import TriggerManager
-from world.spells import Spell
+from combat.spells import Spell
 from combat.combat_actions import CombatResult
 from world.combat import get_health_description
 from combat import combat_utils
@@ -647,7 +647,7 @@ class Character(ObjectParent, ClothedCharacter):
 
     def cast_spell(self, spell_key, target=None):
         """Cast a known spell, spending mana."""
-        from world.spells import SPELLS, colorize_spell
+        from combat.spells import SPELLS, colorize_spell
         from world.system import state_manager
 
         spell = SPELLS.get(spell_key)

--- a/typeclasses/tests/test_skill_spell_usage.py
+++ b/typeclasses/tests/test_skill_spell_usage.py
@@ -1,7 +1,7 @@
 from unittest.mock import patch, MagicMock
 from evennia.utils.test_resources import EvenniaTest
 from combat.combat_skills import SKILL_CLASSES
-from world.spells import SPELLS
+from combat.spells import SPELLS
 
 class TestSkillAndSpellUsage(EvenniaTest):
     def setUp(self):

--- a/typeclasses/tests/test_spellbook_command.py
+++ b/typeclasses/tests/test_spellbook_command.py
@@ -1,7 +1,7 @@
 from unittest.mock import MagicMock
 from evennia.utils.test_resources import EvenniaTest
 from commands.spells import CmdSpellbook
-from world.spells import Spell
+from combat.spells import Spell
 
 class TestSpellbook(EvenniaTest):
     def setUp(self):

--- a/world/spells.py
+++ b/world/spells.py
@@ -1,52 +1,5 @@
-from dataclasses import dataclass
-from typing import Dict
+"""Backward compatibility wrapper for spell definitions."""
 
-@dataclass
-class Spell:
-    key: str
-    stat: str
-    mana_cost: int
-    desc: str = ""
-    cooldown: int = 0
-    # Optional skill providing a proficiency bonus to casting success
-    support_skill: str | None = None
+from combat.spells import Spell, SPELLS, colorize_spell
 
-
-SPELLS: Dict[str, Spell] = {
-    "fireball": Spell(
-        "fireball",
-        "INT",
-        10,
-        "Hurl a ball of fire at your target.",
-        cooldown=5,
-        support_skill="spellcasting",
-    ),
-    "heal": Spell(
-        "heal",
-        "WIS",
-        8,
-        "Restore a small amount of health.",
-        cooldown=3,
-        support_skill="spellcasting",
-    ),
-}
-
-
-def colorize_spell(name: str) -> str:
-    """Return ``name`` wrapped in an ANSI color based on keywords."""
-
-    lname = name.lower()
-    if any(key in lname for key in ("fire", "flame", "burn")):
-        color = "|r"
-    elif any(key in lname for key in ("ice", "frost", "cold")):
-        color = "|c"
-    elif any(key in lname for key in ("nature", "druid", "plant")):
-        color = "|g"
-    elif any(key in lname for key in ("necrom", "shadow")):
-        color = "|m"
-    elif any(key in lname for key in ("holy", "heal", "light")):
-        color = "|w"
-    else:
-        color = "|M"
-    return f"{color}{name}|n"
-
+__all__ = ["Spell", "SPELLS", "colorize_spell"]

--- a/world/tests/test_spell_colorization.py
+++ b/world/tests/test_spell_colorization.py
@@ -1,5 +1,5 @@
 from evennia.utils.test_resources import EvenniaTest
-from world.spells import colorize_spell
+from combat.spells import colorize_spell
 
 class TestSpellColor(EvenniaTest):
     def test_fire_spell_color(self):


### PR DESCRIPTION
## Summary
- move Spell dataclass and helpers to `combat.spells`
- update imports to use `combat.spells`
- make `world.spells` a compatibility wrapper
- mention new module in README

## Testing
- `pytest -q` *(fails: OperationalError - no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6855ef0f8944832c9910f9569ee4d03e