### PR TITLE
Fix combat imports

### DIFF
--- a/combat/aggro_tracker.py
+++ b/combat/aggro_tracker.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Dict, Iterable, List
 
 from world.system import state_manager
-from .combat_utils import award_xp
+from combat.combat_utils import award_xp
 
 
 class AggroTracker:

--- a/combat/ai_combat.py
+++ b/combat/ai_combat.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import Any
 
-from combat.engine import CombatEngine
 from combat.combat_ai.npc_logic import npc_take_turn as _npc_take_turn
 
 

--- a/combat/combat_actions.py
+++ b/combat/combat_actions.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import Optional, Iterable
 import logging
 
-from .engine.combat_math import CombatMath
+from combat.engine.combat_math import CombatMath
 from world.system import state_manager
 
 logger = logging.getLogger(__name__)

--- a/combat/combat_manager.py
+++ b/combat/combat_manager.py
@@ -1,6 +1,6 @@
 """Deprecated alias to :mod:`combat.round_manager`.
 Import from :mod:`combat.round_manager` instead."""
 
-from .round_manager import CombatInstance, CombatRoundManager, leave_combat
+from combat.round_manager import CombatInstance, CombatRoundManager, leave_combat
 
 __all__ = ["CombatInstance", "CombatRoundManager", "leave_combat"]

--- a/combat/combat_skills.py
+++ b/combat/combat_skills.py
@@ -14,9 +14,9 @@ class SkillCategory(str, Enum):
     RANGED = "ranged"
     MAGIC = "magic"
 
-from .combat_actions import CombatResult
-from .combat_utils import roll_damage, roll_evade
-from .effects import StatusEffect
+from combat.combat_actions import CombatResult
+from combat.combat_utils import roll_damage, roll_evade
+from combat.effects import StatusEffect
 from world.system import stat_manager
 from world.skills.kick import Kick
 from world.skills.disarm import Disarm

--- a/combat/damage_processor.py
+++ b/combat/damage_processor.py
@@ -6,12 +6,12 @@ from typing import Dict, List
 from evennia.utils import delay
 from django.conf import settings
 
-from .combatants import CombatParticipant, _current_hp
-from .combat_utils import format_combat_message
-from .corpse_creation import spawn_corpse
-from .engine.turn_manager import TurnManager
-from .aggro_tracker import AggroTracker
-from .damage_types import DamageType
+from combat.combatants import CombatParticipant, _current_hp
+from combat.combat_utils import format_combat_message
+from combat.corpse_creation import spawn_corpse
+from combat.engine.turn_manager import TurnManager
+from combat.aggro_tracker import AggroTracker
+from combat.damage_types import DamageType
 from world.system import state_manager
 
 

--- a/combat/round_manager.py
+++ b/combat/round_manager.py
@@ -11,7 +11,7 @@ from typing import Dict, List, Optional, Set
 
 from evennia.utils import delay
 from evennia.utils.logger import log_trace
-from .combatants import _current_hp
+from combat.combatants import _current_hp
 
 
 @dataclass
@@ -300,7 +300,7 @@ class CombatRoundManager:
         fighters = combatants or []
 
         try:
-            from .engine import CombatEngine
+            from combat.engine import CombatEngine
         except ImportError as err:
             raise ImportError("Combat engine could not be imported") from err
 

--- a/combat/scripts/skills.py
+++ b/combat/scripts/skills.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from typing import Optional, Union
 
-from ..combat_actions import SkillAction
-from ..combat_skills import SKILL_CLASSES, Skill
+from combat.combat_actions import SkillAction
+from combat.combat_skills import SKILL_CLASSES, Skill
 from world.skills.utils import maybe_start_combat
 
 


### PR DESCRIPTION
## Summary
- use absolute imports across combat modules
- drop unused CombatEngine import in ai_combat

## Testing
- `python -m compileall -q combat`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6855f1640090832ca9e240202d588673