### PR TITLE
Ensure redit stores vnum in prototypes

### DIFF
--- a/commands/redit.py
+++ b/commands/redit.py
@@ -508,6 +508,8 @@ def menunode_done(caller, raw_string="", **kwargs):
             data["exits"] = proto.get("exits") or {}
         if "spawns" in proto:
             data["spawns"] = proto.get("spawns") or []
+        data["vnum"] = proto.get("vnum", vnum)
+        proto["vnum"] = data["vnum"]
         save_prototype("room", data, vnum=vnum)
 
         idx, area = find_area(area_key)
@@ -740,6 +742,7 @@ class CmdREdit(Command):
                 "key": room.key,
                 "desc": room.db.desc or "",
                 "exits": {},
+                "vnum": vnum,
             }
             if area_name:
                 proto["area"] = area_name
@@ -830,6 +833,7 @@ class CmdREdit(Command):
                 "key": f"Room {vnum}",
                 "desc": "",
                 "exits": {},
+                "vnum": vnum,
             }
             if area := find_area_by_vnum(vnum):
                 proto["area"] = area.key

--- a/typeclasses/tests/test_redit_command.py
+++ b/typeclasses/tests/test_redit_command.py
@@ -251,6 +251,39 @@ class TestREditCommand(EvenniaTest):
         assert room.key == "New Room"
         assert room.db.desc == "New desc"
 
+    def test_redit_here_proto_has_vnum(self):
+        from evennia.utils import create
+        from typeclasses.rooms import Room
+        room = create.create_object(Room, location=self.char1.location, home=self.char1.location)
+        self.char1.location = room
+        vnum = 200010
+        with (
+            patch("commands.redit.validate_vnum", return_value=True),
+            patch("commands.redit.register_vnum"),
+            patch("commands.redit.save_prototype"),
+            patch("commands.redit.OLCEditor")
+        ):
+            self.char1.execute_cmd(f"redit here {vnum}")
+        proto = self.char1.ndb.room_protos[vnum]
+        assert proto["vnum"] == vnum
+
+    def test_redit_create_proto_has_vnum(self):
+        from evennia.utils import create
+        from typeclasses.rooms import Room
+        room = create.create_object(Room, location=self.char1.location, home=self.char1.location)
+        with (
+            patch("commands.redit.validate_vnum", return_value=True),
+            patch("commands.redit.register_vnum"),
+            patch("commands.redit.load_prototype", return_value=None),
+            patch("commands.redit.spawner.spawn", return_value=[room]),
+            patch("commands.redit.find_area_by_vnum", return_value=None),
+            patch("commands.redit.save_prototype"),
+            patch("commands.redit.OLCEditor")
+        ):
+            self.char1.execute_cmd("redit create 200011")
+        proto = self.char1.ndb.room_protos[200011]
+        assert proto["vnum"] == 200011
+
     def test_save_live_room_no_area_error(self):
         """Saving a live room with no area should show an error instead of crashing."""
         from evennia.utils import create

--- a/typeclasses/tests/test_redit_spawns.py
+++ b/typeclasses/tests/test_redit_spawns.py
@@ -45,3 +45,25 @@ class TestReditSpawns(EvenniaTest):
 
         assert room1.db.exits == {"north": room2}
 
+    def test_register_room_spawn_uses_proto_vnum(self):
+        room = create.create_object(Room, key="R1", location=self.char1.location, home=self.char1.location)
+        room.db.room_id = 5
+        room.db.area = "zone"
+        self.char1.location = room
+
+        with patch("commands.redit.load_prototype", return_value=None), patch("commands.redit.OLCEditor"):
+            self.char1.execute_cmd("redit 5")
+
+        proto = self.char1.ndb.room_protos[5]
+        proto["spawns"] = [{"prototype": "goblin"}]
+        self.char1.ndb.room_protos[5] = proto
+
+        mock_script = MagicMock()
+        with patch("commands.redit.save_prototype"), patch(
+            "commands.redit.ObjectDB.objects.filter", return_value=[room]
+        ), patch("commands.redit.ScriptDB.objects.filter") as mock_filter:
+            mock_filter.return_value.first.return_value = mock_script
+            redit.menunode_done(self.char1)
+            mock_script.register_room_spawn.assert_called_with(proto)
+            assert proto["vnum"] == 5
+


### PR DESCRIPTION
## Summary
- include `vnum` when creating prototypes via `redit here` and `redit create`
- keep `vnum` when saving prototypes
- test for prototype vnum field and SpawnManager integration

## Testing
- `pytest -q` *(fails: 229 failed, 18 passed, 4 warnings, 1 error)*

------
https://chatgpt.com/codex/tasks/task_e_6855f468e7d4832caa67b8127ee15fcd