### PR TITLE
Add test for numeric string spawn

### DIFF
--- a/world/tests/test_spawn_manager.py
+++ b/world/tests/test_spawn_manager.py
@@ -235,3 +235,27 @@ class TestSpawnManager(EvenniaTest):
             room = self.script._get_room(entry)
         self.assertIsNone(room)
         self.assertEqual(entry["room"], "fake")
+
+    def test_force_respawn_handles_string_room_and_proto(self):
+        self.script.db.entries = [
+            {
+                "area": "testarea",
+                "prototype": "5",
+                "room": "1",
+                "room_id": 1,
+                "max_count": 1,
+                "respawn_rate": 5,
+                "last_spawn": 0,
+            }
+        ]
+        npc = create_object(BaseNPC, key="num")
+        with mock.patch("scripts.spawn_manager.spawn_from_vnum") as m_spawn:
+            def side(vnum, location=None):
+                npc.location = location
+                return npc
+
+            m_spawn.side_effect = side
+            self.script.force_respawn(1)
+
+        self.assertEqual(npc.location, self.room)
+        m_spawn.assert_called_once_with(5, location=self.room)


### PR DESCRIPTION
## Summary
- add regression test ensuring SpawnManager handles numeric strings for room and mob vnums

## Testing
- `pytest world/tests/test_spawn_manager.py::TestSpawnManager::test_force_respawn_handles_string_room_and_proto -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6855fde5c7bc832cb182f26bcae5a21a