### PR TITLE
Add NPC prototype persistence and loader

### DIFF
--- a/scripts/spawn_manager.py
+++ b/scripts/spawn_manager.py
@@ -12,7 +12,7 @@ if not hasattr(logger, "log_debug"):
 from typeclasses.rooms import Room
 
 from typeclasses.scripts import Script
-from utils.mob_proto import apply_proto_items, spawn_from_vnum
+from utils.mob_proto import apply_proto_items, spawn_from_vnum, load_npc_prototypes
 from world import prototypes
 
 
@@ -143,6 +143,7 @@ class SpawnManager(Script):
             entry["last_spawn"] = now
 
     def reload_spawns(self) -> None:
+        load_npc_prototypes()
         self.load_spawn_data()
         logger.log_info(
             f"SpawnManager: loaded {len(self.db.entries)} spawn entries"

--- a/server/conf/at_server_startstop.py
+++ b/server/conf/at_server_startstop.py
@@ -163,11 +163,15 @@ def at_server_start():
             script.start()
         elif getattr(script.db, "_paused_time", None):
             script.unpause()
+
     if hasattr(script, "reload_spawns"):
         script.reload_spawns()
 
     # Ensure mob database script exists
     get_mobdb()
+    from utils.mob_proto import load_npc_prototypes
+
+    load_npc_prototypes()
 
     # Ensure all characters are marked tickable for the global ticker
     from typeclasses.characters import Character

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,10 @@
+import os
+import django
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "server.conf.settings")
+django.setup()
+
+import evennia
+
+if getattr(evennia, "SESSION_HANDLER", None) is None:
+    evennia._init()

--- a/utils/mob_proto.py
+++ b/utils/mob_proto.py
@@ -10,6 +10,7 @@ from world.scripts.mob_db import get_mobdb
 from .vnum_registry import get_next_vnum, register_vnum, validate_vnum
 from world import prototypes
 from world.areas import get_area_vnum_range
+from utils.prototype_manager import save_prototype, load_all_prototypes
 
 
 def register_prototype(
@@ -63,6 +64,7 @@ def register_prototype(
     if area:
         data["area"] = area
     mob_db.add_proto(vnum, data)
+    save_prototype("npc", data, vnum=vnum)
 
     key = data.get("key")
     if key:
@@ -237,3 +239,14 @@ def spawn_from_vnum(vnum: int, location=None):
     # track how often this prototype has spawned
     mob_db.increment_spawn_count(vnum)
     return npc
+
+
+def load_npc_prototypes() -> None:
+    """Load all NPC prototype files into the MobDB."""
+    mob_db = get_mobdb()
+    mob_db.db.vnums = {}
+    protos = load_all_prototypes("npc")
+    for vnum, proto in protos.items():
+        mob_db.add_proto(int(vnum), proto)
+    if protos:
+        mob_db.db.next_vnum = max(int(v) for v in protos) + 1

--- a/utils/tests/test_mob_proto.py
+++ b/utils/tests/test_mob_proto.py
@@ -1,0 +1,53 @@
+from unittest import mock
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from django.test import override_settings
+from django.conf import settings
+from evennia.utils.test_resources import EvenniaTest
+
+from utils import prototype_manager, vnum_registry
+from utils.mob_proto import register_prototype, load_npc_prototypes
+from world.scripts.mob_db import get_mobdb
+
+
+@override_settings(DEFAULT_HOME=None)
+class TestMobProtoDisk(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.tmp = TemporaryDirectory()
+        patcher1 = mock.patch.dict(
+            prototype_manager.CATEGORY_DIRS,
+            {"npc": Path(self.tmp.name)},
+        )
+        patcher2 = mock.patch.object(
+            settings, "PROTOTYPE_NPC_FILE", Path(self.tmp.name) / "npcs.json"
+        )
+        patcher3 = mock.patch.object(
+            settings, "VNUM_REGISTRY_FILE", Path(self.tmp.name) / "vnums.json"
+        )
+        patcher4 = mock.patch.object(
+            vnum_registry, "_REG_PATH", Path(self.tmp.name) / "vnums.json"
+        )
+        for p in (patcher1, patcher2, patcher3, patcher4):
+            p.start()
+            self.addCleanup(p.stop)
+        self.addCleanup(self.tmp.cleanup)
+
+    def test_register_writes_file(self):
+        data = {"key": "orc"}
+        vnum = register_prototype(data, vnum=1)
+        path = prototype_manager.CATEGORY_DIRS["npc"] / f"{vnum}.json"
+        assert path.exists()
+        with path.open() as f:
+            saved = json.load(f)
+        assert saved["key"] == "orc"
+
+    def test_loader_populates_mobdb(self):
+        data = {"key": "ogre"}
+        vnum = register_prototype(data, vnum=2)
+        mob_db = get_mobdb()
+        mob_db.db.vnums = {}
+        load_npc_prototypes()
+        assert mob_db.get_proto(vnum)["key"] == "ogre"


### PR DESCRIPTION
## Summary
- save NPC prototypes to disk when registered
- load npc prototype files into MobDB at startup and before spawn reload
- expose loader via SpawnManager
- initialise Django for standalone tests
- unit tests for saving/loading npc prototype files

## Testing
- `DJANGO_SETTINGS_MODULE=server.conf.settings pytest -q` *(fails: OperationalError - no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68560be18864832cb2321b3533fb5349