### PR TITLE
Improve redit spawn validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ Check server logs for messages from `SpawnManager` about errors or skipped
 rooms. Also confirm each room prototype includes a valid `spawns` field with the
 correct NPC identifiers.
 The `redit` spawn editor now warns if you try to add an unknown prototype.
+It will also alert you when a numeric prototype exists only in memory:
+`Prototype <vnum> is not saved to disk. Use 'Save & write prototype' to persist it.`
 Weapon Creation
 ```bash
 cweapon "longsword" mainhand 1d8 4 STR+2 A reliable longsword.

--- a/commands/redit.py
+++ b/commands/redit.py
@@ -415,7 +415,14 @@ def _handle_spawn_cmd(caller, raw_string, **kwargs):
             return "menunode_spawns"
         proto_exists = False
         if isinstance(proto_key, int):
-            proto_exists = get_mobdb().get_proto(proto_key) is not None
+            mob_db = get_mobdb()
+            proto_exists = mob_db.get_proto(proto_key) is not None
+            if proto_exists:
+                path = CATEGORY_DIRS["npc"] / f"{proto_key}.json"
+                if not path.exists():
+                    caller.msg(
+                        f"Prototype {proto_key} is not saved to disk. Use 'Save & write prototype' to persist it."
+                    )
         else:
             proto_exists = proto_key in prototypes.get_npc_prototypes()
         if not proto_exists:


### PR DESCRIPTION
## Summary
- warn if numeric mob prototype isn't saved on disk
- document troubleshooting step for mob spawns

## Testing
- `pytest -q` *(fails: OperationalError - no such table accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6856105661d0832cb8b11b4151589120