### PR TITLE
Add command to list available VNUMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Mob Prototype Manager
 @mobproto set 1 level 3
 @mobproto spawn 1
 ```
+Use `@listvnums <npc|room|object> [area]` to see free numbers.
 Spawning and Room Systems
 Room JSONs may include:
 ```json

--- a/commands/admin/__init__.py
+++ b/commands/admin/__init__.py
@@ -56,7 +56,7 @@ from ..npc_builder import (
 from ..rom_mob_editor import CmdMEdit
 from ..mob_builder_commands import CmdProtoEdit
 from ..cmdmobbuilder import CmdMobProto
-from ..nextvnum import CmdNextVnum
+from ..nextvnum import CmdNextVnum, CmdListVnums
 from ..builder_types import CmdBuilderTypes
 from ..hedit import CmdHEdit
 from ..opedit import CmdOPEdit
@@ -1507,6 +1507,7 @@ class BuilderCmdSet(CmdSet):
         self.add(CmdMobValidate)
         self.add(CmdMobProto)
         self.add(CmdNextVnum)
+        self.add(CmdListVnums)
         self.add(CmdHEdit)
         self.add(CmdOPEdit)
         self.add(CmdRPEdit)

--- a/commands/nextvnum.py
+++ b/commands/nextvnum.py
@@ -1,5 +1,6 @@
 from .command import Command
 from utils import vnum_registry
+from world.areas import get_area_vnum_range
 
 
 class CmdNextVnum(Command):
@@ -30,4 +31,49 @@ class CmdNextVnum(Command):
             self.msg("Unsupported VNUM category.")
             return
         self.msg(str(vnum))
+
+
+class CmdListVnums(Command):
+    """List a few unused VNUMs for a category or area."""
+
+    key = "@listvnums"
+    locks = "cmd:perm(Builder)"
+    help_category = "Building"
+
+    def func(self):
+        if not self.args:
+            self.msg("Usage: @listvnums <npc|room|object> [area]")
+            return
+
+        parts = self.args.split(None, 1)
+        category = parts[0].lower()
+        if category not in ("npc", "room", "object"):
+            self.msg("Category must be npc, room, or object.")
+            return
+
+        area = parts[1].strip() if len(parts) > 1 else None
+        start, end = vnum_registry.VNUM_RANGES[category]
+
+        if area:
+            rng = get_area_vnum_range(area)
+            if not rng:
+                self.msg("Area not found.")
+                return
+            start = max(start, rng[0])
+            end = min(end, rng[1])
+            if start > end:
+                self.msg("Area range does not overlap with category range.")
+                return
+
+        free = []
+        for num in range(start, end + 1):
+            if vnum_registry.validate_vnum(num, category):
+                free.append(num)
+                if len(free) >= 5:
+                    break
+
+        if free:
+            self.msg("Next free VNUMs: " + ", ".join(str(n) for n in free))
+        else:
+            self.msg("No free VNUMs found in range.")
 

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -4030,4 +4030,33 @@ Related:
     help ansi
 """,
     },
+    {
+        "key": "listvnums",
+        "category": "Building",
+        "text": """Help for listvnums
+
+Show a few unused VNUMs without reserving them.
+
+Usage:
+    @listvnums <npc|room|object> [area]
+
+Switches:
+    None
+
+Arguments:
+    category - vnum type to check (npc, room, object)
+    area - optional area name to limit the search
+
+Examples:
+    @listvnums npc
+    @listvnums room town
+
+Notes:
+    - Lists the next five free numbers.
+    - Does not reserve the VNUMs.
+
+Related:
+    help vnums
+""",
+    },
 ]


### PR DESCRIPTION
## Summary
- add `CmdListVnums` command for builders
- hook command into the admin cmdset
- document it in help entries and README

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_685616f39114832c8485f840770da91e