### PR TITLE
Add available range hint when amake range overlaps

### DIFF
--- a/typeclasses/tests/test_commands.py
+++ b/typeclasses/tests/test_commands.py
@@ -807,6 +807,14 @@ class TestAreaMakeCommand(EvenniaTest):
         self.assertEqual(self.char1.location.db.area, "foo")
         self.assertEqual(self.char1.location.db.room_id, 1)
 
+    def test_amake_overlap_hint(self):
+        self.char1.execute_cmd("amake zone 1-5")
+        self.char1.msg = MagicMock()
+        self.char1.execute_cmd("amake other 3-7")
+        out = self.char1.msg.call_args[0][0]
+        self.assertIn("Range overlaps", out)
+        self.assertIn("Available ranges", out)
+
 
 class TestRoomMakeCommand(EvenniaTest):
     def setUp(self):


### PR DESCRIPTION
## Summary
- compute open gaps between area ranges in `amake`
- show hint about available ranges when range overlaps
- test for new message

## Testing
- `pytest -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6856193e594c832c91f812952829ebfc