### PR TITLE
Improve VNUM validation messages

### DIFF
--- a/commands/mob_builder_commands.py
+++ b/commands/mob_builder_commands.py
@@ -13,8 +13,7 @@ from utils.prototype_manager import load_all_prototypes
 from .command import Command
 from . import npc_builder
 from world import prototypes, area_npcs
-from world.areas import get_areas
-from world.areas import find_area_by_vnum
+from world.areas import get_areas, find_area_by_vnum, get_area_vnum_range
 from world.mob_constants import (
     NPC_RACES,
     NPC_CLASSES,
@@ -252,7 +251,10 @@ class CmdMCreate(Command):
                     builder=self.caller.key,
                 )
             except Exception:
-                pass
+                rng = get_area_vnum_range(area)
+                if rng:
+                    self.msg(f"Using global range. {area} uses {rng[0]}-{rng[1]}.")
+                proto["vnum"] = vnum_registry.get_next_vnum("npc")
         prototypes.register_npc_prototype(self.new_key, proto)
         self.msg(f"Prototype {self.new_key} created.")
 

--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -42,6 +42,7 @@ from world.scripts import classes
 from scripts import BuilderAutosave
 from copy import deepcopy
 from utils import vnum_registry
+from world.areas import get_area_vnum_range
 from utils.mob_utils import generate_base_stats, mobprogs_to_triggers
 from world.triggers import TriggerManager
 from .command import Command
@@ -1044,8 +1045,10 @@ class CmdSpawnNPC(Command):
             proto = get_prototype(vnum)
             if not proto:
                 if vnum_registry.validate_vnum(vnum, "npc"):
+                    start, end = vnum_registry.VNUM_RANGES["npc"]
+                    next_v = vnum_registry.peek_next_vnum("npc")
                     self.msg(
-                        "❌ Invalid VNUM. The prototype was never finalized or saved."
+                        f"❌ Invalid VNUM. NPCs use {start}-{end}. Next free: {next_v}."
                     )
                 else:
                     self.msg("Unknown NPC prototype.")
@@ -1200,8 +1203,10 @@ class CmdMSpawn(Command):
             proto = get_prototype(vnum)
             if not proto:
                 if vnum_registry.validate_vnum(vnum, "npc"):
+                    start, end = vnum_registry.VNUM_RANGES["npc"]
+                    next_v = vnum_registry.peek_next_vnum("npc")
                     self.msg(
-                        f"Prototype {vnum} not finalized. Use editnpc {vnum} and finalize with 'Yes & Save'."
+                        f"Prototype {vnum} not finalized. NPCs use {start}-{end}. Next free: {next_v}."
                     )
                 else:
                     self.msg("Invalid VNUM.")
@@ -1356,6 +1361,9 @@ class CmdQuickMob(Command):
                     builder=self.caller.key,
                 )
             except Exception:
+                rng = get_area_vnum_range(area)
+                if rng:
+                    self.msg(f"Using global range. {area} uses {rng[0]}-{rng[1]}.")
                 vnum = vnum_registry.get_next_vnum("npc")
         else:
             vnum = vnum_registry.get_next_vnum("npc")

--- a/commands/oedit.py
+++ b/commands/oedit.py
@@ -6,7 +6,7 @@ from utils.prototype_manager import (
     save_prototype,
     load_all_prototypes,
 )
-from utils.vnum_registry import validate_vnum, register_vnum
+from utils.vnum_registry import validate_vnum, register_vnum, VNUM_RANGES, peek_next_vnum
 from .command import Command
 from commands.admin import parse_stat_mods
 from utils import VALID_SLOTS, normalize_slot
@@ -191,7 +191,11 @@ class CmdOEdit(Command):
         proto = load_prototype("object", vnum)
         if proto is None:
             if not validate_vnum(vnum, "object"):
-                self.msg("Invalid or already used VNUM.")
+                start, end = VNUM_RANGES["object"]
+                next_vnum = peek_next_vnum("object")
+                self.msg(
+                    f"Invalid or already used VNUM. Objects use {start}-{end}. Next free: {next_vnum}."
+                )
                 return
             register_vnum(vnum)
             proto = {"key": f"object_{vnum}", "typeclass": "typeclasses.objects.Object"}

--- a/commands/redit.py
+++ b/commands/redit.py
@@ -15,6 +15,7 @@ from utils.vnum_registry import (
     register_vnum,
     unregister_vnum,
     VNUM_RANGES,
+    peek_next_vnum,
 )
 from world.areas import find_area_by_vnum, get_areas, update_area
 from evennia.prototypes import spawner
@@ -348,7 +349,11 @@ def _handle_exit_cmd(caller, raw_string, **kwargs):
             return "menunode_exits"
         vnum = int(args[2])
         if not validate_vnum(vnum, "room"):
-            caller.msg("Invalid or used vnum.")
+            start, end = VNUM_RANGES["room"]
+            next_vnum = peek_next_vnum("room")
+            caller.msg(
+                f"Invalid or used VNUM. Rooms use {start}-{end}. Next free: {next_vnum}."
+            )
             return "menunode_exits"
         register_vnum(vnum)
         current_vnum = caller.ndb.current_vnum
@@ -685,7 +690,11 @@ class CmdREdit(Command):
                 _clear_state()
                 return
             if not validate_vnum(new_vnum, "room"):
-                self.msg("Invalid or already used VNUM.")
+                start, end = VNUM_RANGES["room"]
+                next_vnum = peek_next_vnum("room")
+                self.msg(
+                    f"Invalid or already used VNUM. Rooms use {start}-{end}. Next free: {next_vnum}."
+                )
                 _clear_state()
                 return
             save_prototype("room", proto, vnum=new_vnum)
@@ -726,9 +735,9 @@ class CmdREdit(Command):
                 return
             if not validate_vnum(vnum, "room"):
                 start, end = VNUM_RANGES["room"]
+                next_vnum = peek_next_vnum("room")
                 self.msg(
-                    f"Invalid or already used VNUM. Rooms use {start}-{end}. "
-                    "Try @nextvnum R."
+                    f"Invalid or already used VNUM. Rooms use {start}-{end}. Next free: {next_vnum}."
                 )
                 _clear_state()
                 return
@@ -738,7 +747,9 @@ class CmdREdit(Command):
             if area_name:
                 idx, area = find_area(area_name)
                 if area and not (area.start <= vnum <= area.end):
-                    self.msg("Number outside area range.")
+                    self.msg(
+                        f"Number outside area range {area.start}-{area.end}."
+                    )
                     _clear_state()
                     return
                 objs = ObjectDB.objects.filter(
@@ -836,9 +847,9 @@ class CmdREdit(Command):
         vnum = int(parts[1])
         if not validate_vnum(vnum, "room"):
             start, end = VNUM_RANGES["room"]
+            next_vnum = peek_next_vnum("room")
             self.msg(
-                f"Invalid or already used VNUM. Rooms use {start}-{end}. "
-                "Try @nextvnum R."
+                f"Invalid or already used VNUM. Rooms use {start}-{end}. Next free: {next_vnum}."
             )
             _clear_state()
             return

--- a/commands/rom_mob_editor.py
+++ b/commands/rom_mob_editor.py
@@ -11,7 +11,12 @@ from world.mob_constants import (
     parse_flag_list,
 )
 from utils.mob_proto import register_prototype, get_prototype
-from utils.vnum_registry import validate_vnum, register_vnum
+from utils.vnum_registry import (
+    validate_vnum,
+    register_vnum,
+    VNUM_RANGES,
+    peek_next_vnum,
+)
 from world.areas import find_area_by_vnum
 from world.templates.mob_templates import get_template
 from .command import Command
@@ -736,7 +741,11 @@ class CmdMEdit(Command):
                 return
             vnum = int(parts[1])
             if get_prototype(vnum) is not None or not validate_vnum(vnum, "npc"):
-                caller.msg("Invalid or already used VNUM.")
+                start, end = VNUM_RANGES["npc"]
+                next_vnum = peek_next_vnum("npc")
+                caller.msg(
+                    f"Invalid or already used VNUM. NPCs use {start}-{end}. Next free: {next_vnum}."
+                )
                 return
             register_vnum(vnum)
             proto = get_template("warrior") or {}

--- a/utils/vnum_registry.py
+++ b/utils/vnum_registry.py
@@ -12,6 +12,7 @@ __all__ = [
     "register_vnum",
     "unregister_vnum",
     "get_next_vnum",
+    "peek_next_vnum",
     "get_next_vnum_for_area",
 ]
 
@@ -103,6 +104,23 @@ def get_next_vnum(category: str) -> int:
     entry["next"] = vnum + 1
     data[category] = entry
     _save(data)
+    return vnum
+
+
+def peek_next_vnum(category: str) -> int:
+    """Return the next available VNUM for ``category`` without reserving it."""
+
+    if category not in VNUM_RANGES:
+        raise KeyError(f"Unknown category: {category}")
+    start, end = VNUM_RANGES[category]
+    data = _load()
+    entry = data.get(category, {"used": [], "next": start})
+    vnum = max(entry.get("next", start), start)
+    used = set(entry.get("used", []))
+    while vnum in used and vnum <= end:
+        vnum += 1
+    if vnum > end:
+        raise ValueError("No available VNUMs in range")
     return vnum
 
 

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -485,7 +485,7 @@ Examples:
     None
 
 Notes:
-    - Valid VNUM range is 200000-299999.
+    - Invalid numbers list the allowed range and next free slot.
     - Use @nextvnum R to obtain a free number.
     - redit create immediately spawns a usable room and registers it to the area.
     - redit here <vnum> assigns the current room to that VNUM and opens the editor.
@@ -3504,7 +3504,7 @@ Example:
     medit create 10
 
 Notes:
-    - VNUMs are validated against the registry.
+    - Invalid numbers list the allowed range and next free slot.
     - The mob is spawned when you finish the menu.
 """,
     },
@@ -4001,6 +4001,7 @@ Use |w@nextvnum <I|M|R|O|Q|S>|n to fetch the next free number. Prefix the
 value with its letter, like |wM5|n, when spawning or referencing by VNUM.
 NPCs spawned from a VNUM automatically gain a |wM<number>|n tag so you can
 find them later with |wsearch_tag(key="M<number>", category="vnum")|n.
+Invalid VNUMs will include the allowed range and next free slot in the error message.
 """,
     },
     {


### PR DESCRIPTION
## Summary
- update VNUM error handling for rooms, objects and NPCs
- show area ranges for room creation
- add peek_next_vnum utility
- clarify help entries with new messaging

## Testing
- `pytest -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68561b5cc8b8832c986851fea48143c5