### PR TITLE
Fix mspawn handling for empty vnums

### DIFF
--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -1202,14 +1202,15 @@ class CmdMSpawn(Command):
         if vnum is not None:
             proto = get_prototype(vnum)
             if not proto:
-                if vnum_registry.validate_vnum(vnum, "npc"):
-                    start, end = vnum_registry.VNUM_RANGES["npc"]
-                    next_v = vnum_registry.peek_next_vnum("npc")
+                start, end = vnum_registry.VNUM_RANGES["npc"]
+                if not (start <= vnum <= end):
+                    self.msg("Invalid VNUM.")
+                elif vnum_registry.validate_vnum(vnum, "npc"):
                     self.msg(
-                        f"Prototype {vnum} not finalized. NPCs use {start}-{end}. Next free: {next_v}."
+                        f"No prototype found for VNUM {vnum}. Use 'medit create {vnum}' to create one."
                     )
                 else:
-                    self.msg("Invalid VNUM.")
+                    self.msg("Unknown NPC prototype.")
                 return
             try:
                 obj = spawn_from_vnum(vnum, location=self.caller.location)

--- a/typeclasses/tests/test_vnum_mobs.py
+++ b/typeclasses/tests/test_vnum_mobs.py
@@ -221,8 +221,8 @@ class TestVnumMobs(EvenniaTest):
             self.char1.execute_cmd("@mspawn 42")
             mock_spawn.assert_not_called()
         out = self.char1.msg.call_args[0][0]
-        self.assertIn("not finalized", out)
-        self.assertIn("editnpc 42", out)
+        self.assertIn("medit create 42", out)
+        self.assertIn("No prototype", out)
 
     def test_spawn_from_vnum_missing_key_error(self):
         proto = {"desc": "bad"}


### PR DESCRIPTION
## Summary
- update `CmdMSpawn.func` to clarify message when a vnum is free but has no prototype
- update the related unit test

## Testing
- `pytest -q typeclasses/tests/test_vnum_mobs.py::TestVnumMobs::test_mspawn_not_finalized_message` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68562dd62224832cb4d6c011409092b3