### PR TITLE
Centralize death handling

### DIFF
--- a/typeclasses/tests/test_active_fighters.py
+++ b/typeclasses/tests/test_active_fighters.py
@@ -59,7 +59,7 @@ class TestDefeatRewards(unittest.TestCase):
         engine = CombatEngine([attacker, defender], round_time=0)
         inst = CombatInstance(1, engine, {attacker, defender})
         self.manager.combats[1] = inst
-        with patch('combat.damage_processor.spawn_corpse') as mock_corpse, \
+        with patch('world.mechanics.on_death_manager.spawn_corpse') as mock_corpse, \
              patch.object(CombatEngine, 'award_experience') as mock_xp:
             engine.processor.handle_defeat(defender, attacker)
             mock_corpse.assert_called()

--- a/typeclasses/tests/test_combat_engine.py
+++ b/typeclasses/tests/test_combat_engine.py
@@ -638,7 +638,7 @@ class TestCombatDeath(EvenniaTest):
         corpse = create.create_object('typeclasses.objects.Object', key='corpse', location=None)
 
         with patch('world.system.state_manager.check_level_up'), \
-             patch('typeclasses.characters.spawn_corpse', return_value=corpse) as mock_spawn:
+             patch('world.mechanics.on_death_manager.spawn_corpse', return_value=corpse) as mock_spawn:
             npc.at_damage(self.char1, 0)
 
         mock_spawn.assert_called_once_with(npc, self.char1)

--- a/typeclasses/tests/test_on_death_manager.py
+++ b/typeclasses/tests/test_on_death_manager.py
@@ -1,0 +1,52 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from evennia.utils.test_resources import EvenniaTest
+from evennia.utils import create
+
+from typeclasses.characters import NPC, PlayerCharacter
+from typeclasses.rooms import Room
+from world.mechanics import on_death_manager
+from combat.round_manager import CombatRoundManager
+
+
+class TestOnDeathManager(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.room = create.create_object(Room, key="room")
+        self.char1.location = self.room
+        self.char1.msg = MagicMock()
+
+    def test_npc_death_awards_xp_and_leaves_combat(self):
+        npc = create.create_object(NPC, key="mob", location=self.room)
+        npc.db.drops = []
+        npc.db.exp_reward = 5
+        manager = CombatRoundManager.get()
+        manager.force_end_all_combat()
+        inst = manager.start_combat([self.char1, npc])
+
+        with patch.object(inst.engine, "award_experience") as mock_award:
+            on_death_manager.handle_death(npc, self.char1)
+
+        mock_award.assert_called_once_with(self.char1, npc)
+        self.assertIsNone(manager.get_combatant_combat(npc))
+        corpse = next(obj for obj in self.room.contents if obj.db.corpse_of == npc.key)
+        self.assertIsNotNone(corpse)
+
+    def test_player_death_creates_corpse_and_clears_combat(self):
+        npc = create.create_object(NPC, key="mob", location=self.room)
+        npc.db.drops = []
+        manager = CombatRoundManager.get()
+        manager.force_end_all_combat()
+        manager.start_combat([self.char1, npc])
+
+        with patch("world.system.state_manager.gain_xp") as mock_gain:
+            on_death_manager.handle_death(self.char1, npc)
+
+        mock_gain.assert_not_called()
+        self.assertIsNone(manager.get_combatant_combat(self.char1))
+        corpse = next(obj for obj in self.room.contents if obj.db.corpse_of == self.char1.key)
+        self.assertIsNotNone(corpse)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/world/mechanics/on_death_manager.py
+++ b/world/mechanics/on_death_manager.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+"""Centralized death handling helpers."""
+
+from evennia.utils import inherits_from, logger
+from combat.corpse_creation import spawn_corpse
+from combat.round_manager import CombatRoundManager, leave_combat
+from world.system import state_manager
+
+
+def handle_death(victim, killer=None):
+    """Handle generic death cleanup for any character."""
+    if not victim or getattr(victim, "location", None) is None:
+        return None
+
+    if getattr(victim.attributes, "get", lambda *a, **k: None)("_dead"):
+        return None
+
+    # mark death flags
+    try:
+        victim.db._dead = True
+        victim.db.dead = True
+        victim.db.is_dead = True
+    except Exception:
+        pass
+
+    manager = CombatRoundManager.get()
+    inst = manager.get_combatant_combat(victim)
+    engine = inst.engine if inst else None
+
+    # remove from combat
+    leave_combat(victim)
+
+    location = victim.location
+    corpse = None
+    if location:
+        corpse = next(
+            (
+                obj
+                for obj in location.contents
+                if obj.is_typeclass("typeclasses.objects.Corpse", exact=False)
+                and obj.db.corpse_of_id == getattr(victim, "dbref", None)
+            ),
+            None,
+        )
+        if not corpse:
+            corpse = spawn_corpse(victim, killer)
+            if corpse:
+                corpse.location = location
+                if getattr(victim, "key", None):
+                    corpse.db.corpse_of = victim.key
+                if getattr(victim, "dbref", None):
+                    corpse.db.corpse_of_id = victim.dbref
+                if getattr(getattr(victim, "db", None), "vnum", None) is not None:
+                    corpse.db.npc_vnum = victim.db.vnum
+
+    # broadcast messages
+    if killer:
+        victim.msg(f"You are slain by {killer.get_display_name(victim)}!")
+        if location:
+            location.msg_contents(f"{victim.key} is |Rslain|n by |C{killer.key}|n!")
+    else:
+        victim.msg("You have died.")
+        if location:
+            location.msg_contents(f"{victim.key} dies.")
+
+    # experience award
+    if killer:
+        if engine:
+            try:
+                engine.award_experience(killer, victim)
+            except Exception:  # pragma: no cover - safety
+                logger.log_trace()
+        elif inherits_from(victim, "typeclasses.characters.NPC"):
+            exp = int(getattr(victim.db, "exp_reward", 0) or 0)
+            if exp:
+                exp = state_manager.calculate_xp_reward(killer, victim, exp)
+                if exp:
+                    if hasattr(killer, "msg"):
+                        killer.msg(f"You gain |Y{exp}|n experience points!")
+                    state_manager.gain_xp(killer, exp)
+
+    # call at_death hooks
+    try:
+        victim.at_death(killer)
+    except Exception:  # pragma: no cover - safety
+        logger.log_trace()
+
+    return corpse


### PR DESCRIPTION
## Summary
- add new `on_death_manager` to manage XP, corpse creation and messaging
- refactor player and NPC `on_death` to use the manager
- update damage processor to delegate defeat logic
- adjust tests for new import paths and add tests for the manager

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_68563d0a424c832cb44be9519783b9a3