### PR TITLE
Add spawn manager helpers

### DIFF
--- a/commands/admin/resetworld.py
+++ b/commands/admin/resetworld.py
@@ -1,6 +1,6 @@
 from evennia import CmdSet
 from ..command import Command
-from evennia.scripts.models import ScriptDB
+from utils.script_utils import get_spawn_manager, respawn_area
 
 class CmdResetWorld(Command):
     """Trigger respawn checks for all areas without despawning existing mobs."""
@@ -11,7 +11,7 @@ class CmdResetWorld(Command):
     help_category = "Admin"
 
     def func(self):
-        script = ScriptDB.objects.filter(db_key="spawn_manager").first()
+        script = get_spawn_manager()
         if not script:
             self.msg("Spawn manager not found.")
             return
@@ -20,14 +20,7 @@ class CmdResetWorld(Command):
             self.msg("No areas found to reset.")
             return
         for key in areas:
-            for entry in script.db.entries:
-                if entry.get("area") == key:
-                    rid = entry.get("room_id")
-                    if rid is None:
-                        rid = entry.get("room")
-                        if isinstance(rid, str) and rid.isdigit():
-                            rid = int(rid)
-                    script.force_respawn(rid)
+            respawn_area(key)
         self.msg(f"World reset complete. [{len(areas)}] areas repopulated.")
 
 class ResetWorldCmdSet(CmdSet):

--- a/commands/admin/spawncontrol.py
+++ b/commands/admin/spawncontrol.py
@@ -1,5 +1,5 @@
 from evennia import CmdSet
-from evennia.scripts.models import ScriptDB
+from utils.script_utils import get_spawn_manager
 from ..command import Command
 
 
@@ -11,7 +11,7 @@ class CmdSpawnReload(Command):
     help_category = "Admin"
 
     def func(self):
-        script = ScriptDB.objects.filter(db_key="spawn_manager").first()
+        script = get_spawn_manager()
         if not script or not hasattr(script, "reload_spawns"):
             self.msg("Spawn manager not found.")
             return
@@ -28,7 +28,7 @@ class CmdForceRespawn(Command):
 
     def func(self):
         arg = self.args.strip()
-        script = ScriptDB.objects.filter(db_key="spawn_manager").first()
+        script = get_spawn_manager()
         if not script or not hasattr(script, "force_respawn"):
             self.msg("Spawn manager not found.")
             return
@@ -57,7 +57,7 @@ class CmdShowSpawns(Command):
 
     def func(self):
         arg = self.args.strip()
-        script = ScriptDB.objects.filter(db_key="spawn_manager").first()
+        script = get_spawn_manager()
         if not script:
             self.msg("Spawn manager not found.")
             return

--- a/commands/aedit.py
+++ b/commands/aedit.py
@@ -240,8 +240,8 @@ class CmdASave(Command):
             for room in rooms:
                 proto = proto_from_room(room)
                 save_prototype("room", proto, vnum=room.db.room_id)
-                from evennia.scripts.models import ScriptDB
-                script = ScriptDB.objects.filter(db_key="spawn_manager").first()
+                from utils.script_utils import get_spawn_manager
+                script = get_spawn_manager()
                 if script and hasattr(script, "register_room_spawn"):
                     script.register_room_spawn(proto)
                     if hasattr(script, "force_respawn"):

--- a/commands/areas.py
+++ b/commands/areas.py
@@ -2,6 +2,7 @@ from evennia.objects.models import ObjectDB
 from evennia.utils.evtable import EvTable
 from evennia import CmdSet
 from evennia.prototypes import spawner
+from utils.script_utils import get_spawn_manager, respawn_area
 
 from .command import Command, MuxCommand
 from world.areas import (
@@ -13,7 +14,6 @@ from world.areas import (
     parse_area_identifier,
 )
 from .aedit import CmdAEdit, CmdAList, CmdASave, CmdAreaReset, CmdAreaAge
-from evennia.scripts.models import ScriptDB
 from typeclasses.rooms import Room
 from utils.prototype_manager import load_prototype, load_all_prototypes
 
@@ -569,18 +569,11 @@ class CmdAreasReset(Command):
                 f"Area '{area_name}' not found. Use 'alist' to view available areas."
             )
             return
-        script = ScriptDB.objects.filter(db_key="spawn_manager").first()
+        script = get_spawn_manager()
         if not script or not hasattr(script, "force_respawn"):
             self.msg("Spawn manager not found.")
             return
-        for entry in script.db.entries:
-            if entry.get("area") == area.key.lower():
-                rid = entry.get("room_id")
-                if rid is None:
-                    rid = entry.get("room")
-                    if isinstance(rid, str) and rid.isdigit():
-                        rid = int(rid)
-                script.force_respawn(rid)
+        respawn_area(area.key.lower())
         self.msg(f"Spawn entries reset for {area.key}.")
 
 

--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -1252,8 +1252,8 @@ class CmdMSpawn(Command):
         obj.db.spawn_room = self.caller.location
         obj.db.prototype_key = proto_key
 
-        from evennia.scripts.models import ScriptDB
-        script = ScriptDB.objects.filter(db_key="spawn_manager").first()
+        from utils.script_utils import get_spawn_manager
+        script = get_spawn_manager()
         if script and hasattr(script, "record_spawn"):
             script.record_spawn(proto_key, self.caller.location)
 

--- a/commands/redit.py
+++ b/commands/redit.py
@@ -578,9 +578,9 @@ def menunode_done(caller, raw_string="", **kwargs):
                         exits[dirkey] = dest_obj
                 room.db.exits = exits
 
-        from evennia.scripts.models import ScriptDB
+        from utils.script_utils import get_spawn_manager
 
-        script = ScriptDB.objects.filter(db_key="spawn_manager").first()
+        script = get_spawn_manager()
         if script and hasattr(script, "register_room_spawn"):
             script.register_room_spawn(proto)
             if hasattr(script, "force_respawn"):

--- a/server/conf/at_server_startstop.py
+++ b/server/conf/at_server_startstop.py
@@ -23,7 +23,7 @@ import time
 from evennia.utils import logger
 from evennia.server.models import ServerConfig
 from utils.prototype_manager import load_all_prototypes
-from utils.script_utils import resume_paused_scripts
+from utils.script_utils import resume_paused_scripts, get_spawn_manager
 
 
 _PROTOTYPE_CACHE = {}
@@ -151,7 +151,7 @@ def at_server_start():
         elif getattr(script.db, "_paused_time", None):
             script.unpause()
 
-    script = ScriptDB.objects.filter(db_key="spawn_manager").first()
+    script = get_spawn_manager()
     if not script or script.typeclass_path != "scripts.spawn_manager.SpawnManager":
         if script:
             script.delete()

--- a/tests/test_redit_spawn_integration.py
+++ b/tests/test_redit_spawn_integration.py
@@ -51,10 +51,9 @@ class TestReditSpawnIntegration(EvenniaTest):
         with (
             patch("commands.redit.save_prototype"),
             patch("commands.redit.ObjectDB.objects.filter", return_value=[self.room]),
-            patch("commands.redit.ScriptDB.objects.filter") as mock_filter,
+            patch("commands.redit.get_spawn_manager", return_value=self.script),
             patch.object(self.script, "_spawn") as mock_spawn,
         ):
-            mock_filter.return_value.first.return_value = self.script
             mock_spawn.side_effect = lambda proto, room: create.create_object(
                 BaseNPC, key=str(proto), location=room
             )

--- a/typeclasses/tests/test_asave_spawn_manager.py
+++ b/typeclasses/tests/test_asave_spawn_manager.py
@@ -18,14 +18,14 @@ class TestASaveSpawnManager(EvenniaTest):
     @patch("commands.aedit.update_area")
     @patch("commands.aedit.save_prototype")
     @patch("commands.aedit.proto_from_room")
-    @patch("commands.aedit.ScriptDB.objects.filter")
+    @patch("commands.aedit.get_spawn_manager")
     @patch("commands.aedit.ObjectDB.objects.filter")
     @patch("commands.aedit.get_areas")
     def test_spawn_manager_called(
         self,
         mock_get_areas,
         mock_obj_filter,
-        mock_script_filter,
+        mock_get_spawn_manager,
         mock_proto,
         mock_save,
         mock_update,
@@ -39,7 +39,7 @@ class TestASaveSpawnManager(EvenniaTest):
         proto = {"vnum": room.db.room_id}
         mock_proto.return_value = proto
         mock_script = MagicMock()
-        mock_script_filter.return_value.first.return_value = mock_script
+        mock_get_spawn_manager.return_value = mock_script
 
         cmd = aedit.CmdASave()
         cmd.caller = self.char1

--- a/typeclasses/tests/test_redit_spawns.py
+++ b/typeclasses/tests/test_redit_spawns.py
@@ -61,8 +61,7 @@ class TestReditSpawns(EvenniaTest):
         mock_script = MagicMock()
         with patch("commands.redit.save_prototype"), patch(
             "commands.redit.ObjectDB.objects.filter", return_value=[room]
-        ), patch("commands.redit.ScriptDB.objects.filter") as mock_filter:
-            mock_filter.return_value.first.return_value = mock_script
+        ), patch("commands.redit.get_spawn_manager", return_value=mock_script):
             redit.menunode_done(self.char1)
             mock_script.register_room_spawn.assert_called_with(proto)
             assert proto["vnum"] == 5

--- a/utils/script_utils.py
+++ b/utils/script_utils.py
@@ -48,3 +48,35 @@ def resume_paused_scripts(keys: Iterable[str] | None = None,
             logger.log_info(f"[Startup] Resuming paused script: {script.key} ({obj_name})")
 
     return resumed
+
+
+def get_spawn_manager() -> ScriptDB | None:
+    """Return the global ``SpawnManager`` script if it exists."""
+
+    return ScriptDB.objects.filter(db_key="spawn_manager").first()
+
+
+def respawn_area(area_key: str) -> None:
+    """Force respawn of all rooms in ``area_key`` using ``SpawnManager``."""
+
+    script = get_spawn_manager()
+    if not script or not hasattr(script, "force_respawn"):
+        return
+    key = area_key.lower()
+    for entry in getattr(script.db, "entries", []):
+        if entry.get("area") == key:
+            rid = script._normalize_room_id(entry)
+            if rid is not None:
+                script.force_respawn(rid)
+
+
+def respawn_world() -> None:
+    """Force respawn of every defined area."""
+
+    script = get_spawn_manager()
+    if not script or not hasattr(script, "force_respawn"):
+        return
+    areas = {entry.get("area") for entry in getattr(script.db, "entries", [])}
+    for area in areas:
+        if area:
+            respawn_area(area)

--- a/utils/tests/test_script_utils.py
+++ b/utils/tests/test_script_utils.py
@@ -1,0 +1,40 @@
+import os
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "server.conf.settings")
+import django
+import evennia
+import unittest
+from unittest.mock import patch, MagicMock
+
+django.setup()
+if getattr(evennia, "SESSION_HANDLER", None) is None:
+    evennia._init()
+
+from utils import script_utils
+
+
+class TestScriptUtils(unittest.TestCase):
+    def test_get_spawn_manager_filters_key(self):
+        with patch("utils.script_utils.ScriptDB.objects.filter") as mock_filter:
+            mock_filter.return_value.first.return_value = "script"
+            result = script_utils.get_spawn_manager()
+            self.assertEqual(result, "script")
+            mock_filter.assert_called_with(db_key="spawn_manager")
+
+    def test_respawn_area_calls_force_respawn(self):
+        mock_script = MagicMock()
+        mock_script.db.entries = [
+            {"area": "zone", "room_id": 1},
+            {"area": "town", "room_id": 2},
+            {"area": "zone", "room_id": 3},
+        ]
+        mock_script._normalize_room_id.side_effect = lambda entry: entry.get("room_id")
+        with patch("utils.script_utils.get_spawn_manager", return_value=mock_script):
+            script_utils.respawn_area("zone")
+        mock_script.force_respawn.assert_any_call(1)
+        mock_script.force_respawn.assert_any_call(3)
+        self.assertEqual(mock_script.force_respawn.call_count, 2)
+
+    def test_respawn_area_missing_manager(self):
+        with patch("utils.script_utils.get_spawn_manager", return_value=None):
+            script_utils.respawn_area("zone")
+

--- a/world/area_reset.py
+++ b/world/area_reset.py
@@ -1,6 +1,6 @@
 from evennia.scripts.scripts import DefaultScript
 from world.areas import get_areas, update_area
-from evennia.scripts.models import ScriptDB
+from utils.script_utils import respawn_area
 
 class AreaReset(DefaultScript):
     """Global script that increments area ages and performs resets."""
@@ -17,14 +17,5 @@ class AreaReset(DefaultScript):
             area.age += 1
             if area.reset_interval and area.age >= area.reset_interval:
                 area.age = 0
-                script = ScriptDB.objects.filter(db_key="spawn_manager").first()
-                if script and hasattr(script, "force_respawn"):
-                    for entry in script.db.entries:
-                        if entry.get("area") == area.key.lower():
-                            rid = entry.get("room_id")
-                            if rid is None:
-                                rid = entry.get("room")
-                                if isinstance(rid, str) and rid.isdigit():
-                                    rid = int(rid)
-                            script.force_respawn(rid)
+                respawn_area(area.key.lower())
             update_area(idx, area)


### PR DESCRIPTION
## Summary
- add new spawn manager helpers
- update reset commands and scripts to use helpers
- use helpers in start scripts and building commands
- test helpers
- update unit tests for new API

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6856410552b8832c92fbc69952b216ea