### PR TITLE
Remove duplicate VALID_ROOM_FLAGS in redit

### DIFF
--- a/commands/redit.py
+++ b/commands/redit.py
@@ -26,20 +26,7 @@ from world import prototypes
 from world.scripts.mob_db import get_mobdb
 from .building import DIR_FULL, OPPOSITE
 from .command import Command
-
-
-VALID_ROOM_FLAGS = (
-    "dark",
-    "nopvp",
-    "sanctuary",
-    "indoors",
-    "safe",
-    "no_recall",
-    "no_mount",
-    "no_flee",
-    "rest_area",
-)
-
+from .room_flags import VALID_ROOM_FLAGS
 
 def proto_from_room(room) -> dict:
     """Return a prototype dict generated from ``room``."""


### PR DESCRIPTION
## Summary
- centralize VALID_ROOM_FLAGS in `room_flags`
- import the constant in `redit`

## Testing
- `pytest -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_6856410c5c34832ca1ed8bc8027f91ad