### PR TITLE
Add generic NPC arrival message support

### DIFF
--- a/typeclasses/npcs/__init__.py
+++ b/typeclasses/npcs/__init__.py
@@ -6,6 +6,15 @@ from typeclasses.characters import NPC
 class BaseNPC(NPC):
     """Base NPC typeclass for specialized behaviors."""
 
+    #: Optional greeting message shown when a player enters the room.
+    arrival_message: str | None = None
+
+    def at_character_arrive(self, chara, **kwargs):
+        """Respond to a character entering the room."""
+        super().at_character_arrive(chara, **kwargs)
+        if chara.has_account and self.arrival_message:
+            chara.msg(f"{self.key} says, '{self.arrival_message}'")
+
     def at_object_creation(self):
         super().at_object_creation()
         ai_flags = {"aggressive", "scavenger", "assist", "call_for_help", "wander"}

--- a/typeclasses/npcs/banker.py
+++ b/typeclasses/npcs/banker.py
@@ -12,9 +12,5 @@ class BankerNPC(BankerRole, BaseNPC):
     added here.
     """
 
-    def at_character_arrive(self, chara, **kwargs):
-        """Greet arriving characters with a helpful message."""
-        super().at_character_arrive(chara, **kwargs)
-        if chara.has_account:
-            chara.msg(f"{self.key} says, 'Keep your coins safe with me.'")
+    arrival_message = "Keep your coins safe with me."
 

--- a/typeclasses/npcs/combat_trainer.py
+++ b/typeclasses/npcs/combat_trainer.py
@@ -11,9 +11,5 @@ class CombatTrainerNPC(CombatTrainerRole, BaseNPC):
     added when needed.
     """
 
-    def at_character_arrive(self, chara, **kwargs):
-        """Encourage the player to spar."""
-        super().at_character_arrive(chara, **kwargs)
-        if chara.has_account:
-            chara.msg(f"{self.key} says, 'Ready to test your mettle?'")
+    arrival_message = "Ready to test your mettle?"
 

--- a/typeclasses/npcs/event_npc.py
+++ b/typeclasses/npcs/event_npc.py
@@ -11,9 +11,5 @@ class EventNPC(EventNPCRole, BaseNPC):
     participate in time-limited events.
     """
 
-    def at_character_arrive(self, chara, **kwargs):
-        """Hint to the player that an event is available."""
-        super().at_character_arrive(chara, **kwargs)
-        if chara.has_account:
-            chara.msg(f"{self.key} says, 'Something exciting is about to happen!'")
+    arrival_message = "Something exciting is about to happen!"
 

--- a/typeclasses/npcs/guildmaster.py
+++ b/typeclasses/npcs/guildmaster.py
@@ -11,9 +11,5 @@ class GuildmasterNPC(GuildmasterRole, BaseNPC):
     guildmaster behaviors without modifying the base NPC class.
     """
 
-    def at_character_arrive(self, chara, **kwargs):
-        """Offer assistance with guild matters."""
-        super().at_character_arrive(chara, **kwargs)
-        if chara.has_account:
-            chara.msg(f"{self.key} says, 'Step forward if you seek guild business.'")
+    arrival_message = "Step forward if you seek guild business."
 

--- a/typeclasses/npcs/merchant.py
+++ b/typeclasses/npcs/merchant.py
@@ -12,9 +12,5 @@ class MerchantNPC(MerchantRole, BaseNPC):
     complex shopkeeper behavior.
     """
 
-    def at_character_arrive(self, chara, **kwargs):
-        """Invite players to browse the wares when they arrive."""
-        super().at_character_arrive(chara, **kwargs)
-        if chara.has_account:
-            chara.msg(f"{self.key} says, 'Take a look at my wares!'")
+    arrival_message = "Take a look at my wares!"
 

--- a/typeclasses/npcs/questgiver.py
+++ b/typeclasses/npcs/questgiver.py
@@ -11,9 +11,5 @@ class QuestGiverNPC(QuestGiverRole, BaseNPC):
     and customized in the future.
     """
 
-    def at_character_arrive(self, chara, **kwargs):
-        """Remind players they can ask for quests."""
-        super().at_character_arrive(chara, **kwargs)
-        if chara.has_account:
-            chara.msg(f"{self.key} says, 'Ask me for a quest if you're looking for work.'")
+    arrival_message = "Ask me for a quest if you're looking for work."
 

--- a/typeclasses/npcs/trainer.py
+++ b/typeclasses/npcs/trainer.py
@@ -11,9 +11,5 @@ class TrainerNPC(TrainerRole, BaseNPC):
     behavior can be implemented without altering the core NPC class.
     """
 
-    def at_character_arrive(self, chara, **kwargs):
-        """Offer training when a player enters."""
-        super().at_character_arrive(chara, **kwargs)
-        if chara.has_account:
-            chara.msg(f"{self.key} says, 'Interested in honing your skills?'")
+    arrival_message = "Interested in honing your skills?"
 


### PR DESCRIPTION
## Summary
- centralize greeting messages for NPCs with arrival_message attribute
- simplify NPC subclasses to just set a message string

## Testing
- `pytest -q` *(fails: OperationalError no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_685645d8abf8832c834ebf617c82c58c