### PR TITLE
Fix unsaved combatant hashing

### DIFF
--- a/combat/damage_processor.py
+++ b/combat/damage_processor.py
@@ -169,12 +169,12 @@ class DamageProcessor:
                     ) is not None
                     if not has_hp:
                         continue
-                    if obj in inst.combatants:
+                    if any(obj is c for c in inst.combatants):
                         continue
                     if _current_hp(obj) <= 0:
                         continue
                     t = getattr(getattr(obj, "db", None), "combat_target", None)
-                    if t in inst.combatants:
+                    if any(t is c for c in inst.combatants):
                         inst.add_combatant(obj)
             inst.sync_participants()
 

--- a/world/skills/utils.py
+++ b/world/skills/utils.py
@@ -6,7 +6,7 @@ def maybe_start_combat(attacker, target):
     manager = CombatRoundManager.get()
     inst = manager.get_combatant_combat(attacker)
     if inst:
-        if target not in inst.combatants:
+        if all(target is not c for c in inst.combatants):
             inst.add_combatant(target)
     else:
         inst = manager.get_combatant_combat(target)


### PR DESCRIPTION
## Summary
- avoid hashing unsaved combatants
- handle participants using lists and id-based lookup
- check identity when verifying combatant membership

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685647bfefa4832ca2c9dfe30718fdc8