### PR TITLE
Add shared target scanning helper

### DIFF
--- a/scripts/bandit_ai.py
+++ b/scripts/bandit_ai.py
@@ -12,8 +12,9 @@ class BanditAI(BaseCombatAI):
         npc = self.obj
         if not npc or not npc.location:
             return None
-        for obj in npc.location.contents:
-            if obj.has_account and obj.db.level and npc.db.level:
-                if obj.db.level < npc.db.level:
-                    return obj
-        return None
+        return self.find_target(
+            lambda obj: obj.has_account
+            and obj.db.level
+            and npc.db.level
+            and obj.db.level < npc.db.level
+        )

--- a/scripts/combat_ai.py
+++ b/scripts/combat_ai.py
@@ -12,15 +12,22 @@ class BaseCombatAI(Script):
         # player in the current location.
         self.db.skip_move_if_target = False
 
-    def select_target(self):
-        """Return a valid player character in the same room or ``None``."""
+    def find_target(self, predicate):
+        """Return the first object in the room matching ``predicate``."""
         npc = self.obj
         if not npc or not npc.location:
             return None
         for obj in npc.location.contents:
-            if getattr(obj, "account", None) and not obj.tags.has("unconscious", category="status"):
+            if predicate(obj):
                 return obj
         return None
+
+    def select_target(self):
+        """Return a valid player character in the same room or ``None``."""
+        return self.find_target(
+            lambda obj: getattr(obj, "account", None)
+            and not obj.tags.has("unconscious", category="status")
+        )
 
     def attack_target(self, target):
         npc = self.obj

--- a/scripts/guard_patrol.py
+++ b/scripts/guard_patrol.py
@@ -15,10 +15,7 @@ class GuardPatrol(BaseCombatAI):
         npc = self.obj
         if not npc or not npc.location:
             return None
-        for obj in npc.location.contents:
-            if obj.tags.get("wanted"):
-                return obj
-        return None
+        return self.find_target(lambda obj: obj.tags.get("wanted"))
 
     def move(self):
         npc = self.obj


### PR DESCRIPTION
## Summary
- add `find_target` helper to BaseCombatAI
- use helper in BanditAI and GuardPatrol

## Testing
- `pytest tests/test_redit_spawn_integration.py -q` *(fails: OperationalError no such table)*

------
https://chatgpt.com/codex/tasks/task_e_68564c252edc832c83a57b1ff1790dc6