### PR TITLE
Handle unsaved attackers in combat logs

### DIFF
--- a/combat/round_manager.py
+++ b/combat/round_manager.py
@@ -169,7 +169,16 @@ class CombatInstance:
         for actor in list(fighters):
             if _current_hp(actor) <= 0 and not getattr(getattr(actor, "db", None), "is_dead", False):
                 log = getattr(getattr(actor, "ndb", None), "damage_log", None) or {}
-                killer = max(log, key=log.get) if log else None
+                killer_key = max(log, key=log.get) if log else None
+                killer = None
+                if killer_key is not None:
+                    if isinstance(killer_key, int):
+                        for obj in fighters + [p.actor for p in self.engine.participants]:
+                            if id(obj) == killer_key:
+                                killer = obj
+                                break
+                    else:
+                        killer = killer_key
                 try:
                     self.engine.handle_defeat(actor, killer)
                 except Exception as err:  # pragma: no cover - safety

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -380,7 +380,10 @@ class Character(TriggerMixin, ObjectParent, ClothedCharacter):
         damage = int(max(0, round(damage * (1 - armor / 100))))
         if attacker:
             log = getattr(self.ndb, "damage_log", None) or {}
-            log[attacker] = log.get(attacker, 0) + int(damage)
+            key = attacker
+            if getattr(attacker, "pk", None) is None:
+                key = id(attacker)
+            log[key] = log.get(key, 0) + int(damage)
             self.ndb.damage_log = log
 
         dt = None

--- a/typeclasses/tests/test_unsaved_round_manager.py
+++ b/typeclasses/tests/test_unsaved_round_manager.py
@@ -38,3 +38,35 @@ class TestUnsavedRoundManager(unittest.TestCase):
             inst._tick()
         self.assertFalse(inst.combat_ended)
         self.assertTrue(getattr(npc, "in_combat", False))
+
+
+class TestUnsavedAttackerDamage(unittest.TestCase):
+    def test_unsaved_attacker_damage_logging(self):
+        from typeclasses.characters import Character
+
+        class Victim:
+            def __init__(self, hp=10):
+                self.traits = type("Traits", (), {})()
+                self.traits.health = type("Health", (), {"current": hp, "value": hp})()
+                self.ndb = type("NDB", (), {})()
+                self.msg = MagicMock()
+                self.db = type("DB", (), {"bounty": 0})()
+
+            def defense(self, dt=None):
+                return 0
+
+        player = Victim()
+        npc = UnsavedDummy()
+        npc.get_display_name = lambda looker=None: "NPC"
+
+        manager = CombatRoundManager.get()
+        manager.combats.clear()
+        manager.combatant_to_combat.clear()
+
+        with patch.object(CombatInstance, "start"):
+            manager.create_combat([player, npc])
+
+        with patch("world.system.state_manager.get_effective_stat", return_value=0):
+            Character.at_damage(player, npc, 5)
+
+        self.assertEqual(player.ndb.damage_log.get(id(npc)), 5)


### PR DESCRIPTION
## Summary
- support logging unsaved attackers by id in `Character.at_damage`
- resolve killer ids back to objects in `CombatRoundManager`
- test for combat with unsaved attacker

## Testing
- `pytest typeclasses/tests/test_unsaved_round_manager.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68564de26928832c8f6f3943a020baff