### PR TITLE
Remove redundant death flags

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -1127,9 +1127,6 @@ class NPC(Character):
         """
         if not self.location or self.attributes.get("_dead"):
             return
-        self.db._dead = True
-        self.db.dead = True
-        self.db.is_dead = True
 
         from world.mechanics import on_death_manager
 


### PR DESCRIPTION
## Summary
- avoid setting death flags in `NPC.on_death`

## Testing
- `pytest -q` *(fails: OperationalError - no such table: accounts_accountdb)*
- `pytest typeclasses/tests/test_combat_engine.py::TestCombatDeath::test_npc_on_death_sets_flag_and_moves_out -q` *(fails: OperationalError - no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_685657492514832c854d9724378872aa