### PR TITLE
Update NPC death cleanup

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -1135,7 +1135,6 @@ class NPC(Character):
         if attacker and getattr(attacker.db, "combat_target", None) is self:
             attacker.db.combat_target = None
 
-        self.location = None
         self.delete()
 
     # property to mimic weapons

--- a/typeclasses/tests/test_combat_engine.py
+++ b/typeclasses/tests/test_combat_engine.py
@@ -451,7 +451,6 @@ class TestCombatDeath(EvenniaTest):
             )
             self.assertEqual(corpse.db.npc_vnum, 77)
             self.assertTrue(npc.db.is_dead)
-            self.assertIsNone(npc.location)
             mock_delete.assert_called_once()
 
     def test_unsaved_npc_death_creates_corpse_and_awards_xp(self):


### PR DESCRIPTION
## Summary
- drop `self.location = None` in `NPC.on_death`
- adjust combat engine test for corpse removal

## Testing
- `pytest -q` *(fails: OperationalError no such table)*

------
https://chatgpt.com/codex/tasks/task_e_68565b235f2c832c8576cab29e31e1b9