### PR TITLE
Fix handle_defeat deleted-target case

### DIFF
--- a/combat/damage_processor.py
+++ b/combat/damage_processor.py
@@ -121,10 +121,12 @@ class DamageProcessor:
         else:
             handle_death(target, attacker)
 
-        if getattr(target, "pk", None) is not None:
+        deleted = getattr(target, "pk", None) is None
+
+        if not deleted:
             self.update_pos(target)
 
-        if inst:
+        if inst and not deleted:
             inst.remove_combatant(target)
 
         survivors = []

--- a/typeclasses/tests/test_damage_processor_handle_defeat.py
+++ b/typeclasses/tests/test_damage_processor_handle_defeat.py
@@ -1,0 +1,32 @@
+from unittest.mock import MagicMock, patch
+from evennia.utils.test_resources import EvenniaTest
+from evennia.utils import create
+from combat.engine import CombatEngine
+from typeclasses.characters import NPC
+from typeclasses.tests.test_combat_engine import KillAction
+
+
+class TestDamageProcessorHandleDefeat(EvenniaTest):
+    def test_npc_death_removes_and_broadcasts(self):
+        room = self.room1
+        player = self.char1
+        npc = create.create_object(NPC, key="mob", location=room)
+        npc.db.drops = []
+        room.msg_contents = MagicMock()
+
+        engine = CombatEngine([player, npc], round_time=0)
+        engine.queue_action(player, KillAction(player, npc))
+
+        with patch("world.system.state_manager.apply_regen"), patch(
+            "world.system.state_manager.check_level_up"
+        ), patch("random.randint", return_value=0):
+            engine.start_round()
+            engine.process_round()
+
+        self.assertNotIn(npc, room.contents)
+        corpse = next(
+            obj for obj in room.contents if obj.is_typeclass("typeclasses.objects.Corpse", exact=False)
+        )
+        self.assertIsNotNone(corpse)
+        calls = [c.args[0] for c in room.msg_contents.call_args_list]
+        self.assertTrue(any("slain" in msg for msg in calls))


### PR DESCRIPTION
## Summary
- avoid calling update_pos/remove_combatant on deleted target
- regression test for npc death cleanup via handle_defeat

## Testing
- `pytest -q` *(fails: environment limits prevent running full suite)*

------
https://chatgpt.com/codex/tasks/task_e_68566564d898832cafdb75bb969b3701