### PR TITLE
Fix ended combat reuse

### DIFF
--- a/combat/round_manager.py
+++ b/combat/round_manager.py
@@ -351,7 +351,10 @@ class CombatRoundManager:
         cid = self.combatant_to_combat.get(combatant)
         if cid is None:
             return None
-        return self.combats.get(cid)
+        inst = self.combats.get(cid)
+        if inst and inst.combat_ended:
+            return None
+        return inst
 
     def start_combat(self, combatants: List[object]) -> CombatInstance:
         """Start combat for the given ``combatants``."""

--- a/typeclasses/tests/test_round_manager.py
+++ b/typeclasses/tests/test_round_manager.py
@@ -89,3 +89,15 @@ class TestCombatRoundManager(EvenniaTest):
         self.assertEqual(inst.round_time, 3.5)
         self.assertEqual(inst.engine.round_time, 3.5)
 
+    def test_get_combatant_combat_returns_none_for_ended_instance(self):
+        self.instance.combat_ended = True
+        inst = self.manager.get_combatant_combat(self.char1)
+        self.assertIsNone(inst)
+
+    def test_start_combat_creates_new_when_existing_ended(self):
+        self.instance.combat_ended = True
+        with patch.object(CombatInstance, "start"):
+            new_inst = self.manager.start_combat([self.char1, self.char2])
+        self.assertIsNot(new_inst, self.instance)
+        self.assertIs(self.manager.get_combatant_combat(self.char1), new_inst)
+


### PR DESCRIPTION
## Summary
- ensure `get_combatant_combat` ignores ended instances
- add tests for ended combat logic

## Testing
- `pytest -q` *(fails: OperationalError - no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_685701676e28832c9099c7e354de54a7