### PR TITLE
Fix stale combat mapping removal

### DIFF
--- a/combat/round_manager.py
+++ b/combat/round_manager.py
@@ -353,6 +353,8 @@ class CombatRoundManager:
             return None
         inst = self.combats.get(cid)
         if inst and inst.combat_ended:
+            # clean up stale reference
+            self.combatant_to_combat.pop(combatant, None)
             return None
         return inst
 

--- a/typeclasses/tests/test_round_manager.py
+++ b/typeclasses/tests/test_round_manager.py
@@ -94,6 +94,14 @@ class TestCombatRoundManager(EvenniaTest):
         inst = self.manager.get_combatant_combat(self.char1)
         self.assertIsNone(inst)
 
+    def test_get_combatant_combat_clears_mapping_for_ended_instance(self):
+        self.instance.combat_ended = True
+        inst = self.manager.get_combatant_combat(self.char1)
+        self.assertIsNone(inst)
+        self.assertNotIn(self.char1, self.manager.combatant_to_combat)
+        # subsequent lookups should remain None since mapping is removed
+        self.assertIsNone(self.manager.get_combatant_combat(self.char1))
+
     def test_start_combat_creates_new_when_existing_ended(self):
         self.instance.combat_ended = True
         with patch.object(CombatInstance, "start"):


### PR DESCRIPTION
## Summary
- clear stale combatant-to-combat mapping when instance ended
- test mapping cleanup in round manager

## Testing
- `pytest typeclasses/tests/test_round_manager.py::TestCombatRoundManager::test_get_combatant_combat_clears_mapping_for_ended_instance -q` *(fails: OperationalError no such table)*

------
https://chatgpt.com/codex/tasks/task_e_6857059e5fe4832ca7387f8e745fb54b