### PR TITLE
Fix combat restart cleanup

### DIFF
--- a/combat/round_manager.py
+++ b/combat/round_manager.py
@@ -364,8 +364,13 @@ class CombatRoundManager:
         instances = []
         for combatant in combatants:
             inst = self.get_combatant_combat(combatant)
-            if inst and inst not in instances:
-                instances.append(inst)
+            if inst:
+                if inst.combat_ended:
+                    # clean up stale references to ended combat
+                    self.remove_combat(inst.combat_id)
+                    continue
+                if inst not in instances:
+                    instances.append(inst)
 
         if not instances:
             # none of the combatants were already fighting

--- a/typeclasses/tests/test_round_manager.py
+++ b/typeclasses/tests/test_round_manager.py
@@ -109,3 +109,17 @@ class TestCombatRoundManager(EvenniaTest):
         self.assertIsNot(new_inst, self.instance)
         self.assertIs(self.manager.get_combatant_combat(self.char1), new_inst)
 
+    def test_restart_after_combat_end_creates_new_instance(self):
+        """Calling start_combat after an instance ends should start fresh combat."""
+        self.instance.end_combat("done")
+        self.assertFalse(self.char1.db.in_combat)
+        self.assertFalse(self.char2.db.in_combat)
+
+        with patch.object(CombatInstance, "start"):
+            new_inst = self.manager.start_combat([self.char1, self.char2])
+
+        self.assertIsNot(new_inst, self.instance)
+        self.assertIs(self.manager.get_combatant_combat(self.char1), new_inst)
+        self.assertTrue(self.char1.db.in_combat)
+        self.assertTrue(self.char2.db.in_combat)
+


### PR DESCRIPTION
## Summary
- handle ended instances when starting combat
- test restarting combat after an instance ends

## Testing
- `pytest -q` *(fails: django.db.utils.OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_685706f83ae8832ca385e2c6cd70fc48