### PR TITLE
Ensure combat ends after death hooks

### DIFF
--- a/combat/round_manager.py
+++ b/combat/round_manager.py
@@ -248,6 +248,12 @@ class CombatInstance:
         if self.combat_ended:
             return
 
+        # ensure any pending defeat or death logic runs first
+        try:
+            self.sync_participants()
+        except Exception as err:  # pragma: no cover - safety
+            log_trace(f"Error syncing participants on end: {err}")
+
         room = getattr(self, "room", None)
         try:
             if self.engine and self.engine.participants:
@@ -258,7 +264,6 @@ class CombatInstance:
         except Exception:  # pragma: no cover - safety
             room = None
 
-        self.combat_ended = True
         self.cancel_tick()
         CombatRoundManager.get().remove_combat(self.combat_id)
 
@@ -286,6 +291,8 @@ class CombatInstance:
 
         if reason:
             log_trace(f"Combat ended: {reason}")
+
+        self.combat_ended = True
 
 
 class CombatRoundManager:

--- a/typeclasses/tests/test_combat_end_order.py
+++ b/typeclasses/tests/test_combat_end_order.py
@@ -1,0 +1,60 @@
+from unittest.mock import MagicMock, patch
+from evennia.utils.test_resources import EvenniaTest
+from evennia.utils import create
+from combat.round_manager import CombatRoundManager, CombatInstance
+from typeclasses.characters import NPC
+from typeclasses.tests.test_combat_engine import KillAction
+
+
+class TestCombatEndOrder(EvenniaTest):
+    def test_death_hooks_fire_before_combat_end(self):
+        room = self.room1
+        player = self.char1
+        player.location = room
+        npc = create.create_object(NPC, key="mob", location=room)
+        npc.db.drops = []
+        npc.db.exp_reward = 5
+
+        manager = CombatRoundManager.get()
+        manager.force_end_all_combat()
+        with patch.object(CombatInstance, "start"):
+            instance = manager.start_combat([player, npc])
+        engine = instance.engine
+        engine.queue_action(player, KillAction(player, npc))
+
+        order = []
+
+        def player_msg(msg, *args, **kwargs):
+            if "experience points" in msg:
+                order.append(("xp", instance.combat_ended))
+
+        def room_msg(msg, *args, **kwargs):
+            if "slain" in msg or "dies" in msg:
+                order.append(("death", instance.combat_ended))
+
+        player.msg = MagicMock(side_effect=player_msg)
+        room.msg_contents = MagicMock(side_effect=room_msg)
+
+        from world.mechanics import on_death_manager
+        orig_handle = on_death_manager.handle_death
+
+        def wrapped_handle(victim, killer=None):
+            order.append(("handle", instance.combat_ended))
+            return orig_handle(victim, killer)
+
+        corpse = create.create_object("typeclasses.objects.Object", key="corpse", location=None)
+
+        with (
+            patch("world.mechanics.on_death_manager.handle_death", side_effect=wrapped_handle),
+            patch("world.mechanics.on_death_manager.spawn_corpse", return_value=corpse),
+            patch("combat.engine.damage_processor.delay"),
+            patch("world.system.state_manager.apply_regen"),
+            patch("world.system.state_manager.check_level_up"),
+            patch("random.randint", return_value=0),
+        ):
+            engine.start_round()
+            engine.process_round()
+
+        assert instance.combat_ended
+        for _, ended in order:
+            assert not ended


### PR DESCRIPTION
## Summary
- only set `combat_ended` after defeat processing finishes
- test that death and XP messages occur before `combat_ended` flips

## Testing
- `pytest -q` *(fails: 375 failed, 22 passed, 4 warnings, 1 error)*

------
https://chatgpt.com/codex/tasks/task_e_685708de55ec832ca58ab49eab4664d5