### PR TITLE
Ensure in_combat flag set before queuing participant

### DIFF
--- a/combat/engine/turn_manager.py
+++ b/combat/engine/turn_manager.py
@@ -28,10 +28,14 @@ class TurnManager:
     # participant management
     # -------------------------------------------------------------
     def add_participant(self, actor: object) -> None:
+        # Always mark the actor as being in combat **before** it is queued. This
+        # ensures that any hooks triggered during `on_enter_combat` or later
+        # phases can rely on this flag being set.
         if hasattr(actor, "db") and getattr(actor, "pk", None) is not None:
             actor.db.in_combat = True
         else:
             setattr(actor, "in_combat", True)
+
         self.participants.append(CombatParticipant(actor=actor))
         if hasattr(actor, "ndb"):
             actor.ndb.combat_engine = self.engine


### PR DESCRIPTION
## Summary
- clarify in_combat flag update when adding combat participants

## Testing
- `pytest -q` *(fails: django OperationalError no such table)*

------
https://chatgpt.com/codex/tasks/task_e_6857129de7b0832ca8ce7a64b01ac275