### PR TITLE
Start combat round immediately on first attack

### DIFF
--- a/commands/combat.py
+++ b/commands/combat.py
@@ -108,6 +108,10 @@ class CmdAttack(Command):
         from combat import AttackAction
         instance.engine.queue_action(self.caller, AttackAction(self.caller, target))
 
+        if instance.round_number == 0:
+            instance.cancel_tick()
+            instance.process_round()
+
 
     def at_post_cmd(self):
         """

--- a/world/skills/utils.py
+++ b/world/skills/utils.py
@@ -5,6 +5,7 @@ def maybe_start_combat(attacker, target):
     """Ensure ``attacker`` and ``target`` are in combat together."""
     manager = CombatRoundManager.get()
     inst = manager.get_combatant_combat(attacker)
+    new_instance = False
     if inst:
         if target not in inst.combatants:
             inst.add_combatant(target)
@@ -14,8 +15,14 @@ def maybe_start_combat(attacker, target):
             inst.add_combatant(attacker)
         else:
             inst = manager.start_combat([attacker, target])
+            new_instance = True
     if hasattr(attacker, "db"):
         attacker.db.combat_target = target
     if hasattr(target, "db"):
         target.db.combat_target = attacker
+
+    if new_instance and inst.round_number == 0:
+        inst.cancel_tick()
+        inst.process_round()
+
     return inst


### PR DESCRIPTION
## Summary
- make `attack` command process the first round right away
- auto-run first round when skills initiate combat

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685717983924832c87357857a9d9a71b