### PR TITLE
Enable optional combat tick debug logging

### DIFF
--- a/combat/round_manager.py
+++ b/combat/round_manager.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import time
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Set
+from django.conf import settings
 
 from evennia.utils import delay
 from evennia.utils.logger import log_trace
@@ -84,6 +85,8 @@ class CombatInstance:
     def _tick(self) -> None:
         """Process a round and schedule the next one."""
         self.tick_handle = None
+        if settings.COMBAT_DEBUG_TICKS:
+            logger.debug("Combat tick %s", self.round_number)
         if not self.is_valid():
             self.end_combat("Invalid combat instance")
             return

--- a/world/tests/test_combat_tick_logging.py
+++ b/world/tests/test_combat_tick_logging.py
@@ -1,0 +1,20 @@
+import unittest
+from unittest.mock import MagicMock
+from django.test import override_settings
+from combat.round_manager import CombatInstance
+
+
+class TestCombatTickLogging(unittest.TestCase):
+    @override_settings(COMBAT_DEBUG_TICKS=True)
+    def test_tick_emits_debug_log(self):
+        fighter1 = object()
+        fighter2 = object()
+        engine = MagicMock()
+        engine.participants = []
+        inst = CombatInstance(1, engine, {fighter1, fighter2})
+        inst.sync_participants = MagicMock()
+        inst.has_active_fighters = MagicMock(return_value=True)
+        inst.process_round = MagicMock()
+        with self.assertLogs('combat.round_manager', level='DEBUG') as cm:
+            inst._tick()
+        self.assertTrue(any('Combat tick' in msg for msg in cm.output))


### PR DESCRIPTION
## Summary
- log combat round ticks when `COMBAT_DEBUG_TICKS` is enabled
- test debug log emission for combat ticks

## Testing
- `pytest world/tests/test_combat_tick_logging.py::TestCombatTickLogging::test_tick_emits_debug_log -q`
- `pytest -q` *(fails: OperationalError - no such table)*

------
https://chatgpt.com/codex/tasks/task_e_685ce0cc9d54832cbac5ca1634f94dbd