### PR TITLE
Clarify where attack command and combat classes live

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,10 @@ CombatRoundManager.get().start_combat([fighter1, fighter2])
 The old `combat.combat_manager` module now simply re-exports these
 classes and is considered deprecated.
 
+The primary combat classes `CombatRoundManager` and `CombatInstance` live in
+`combat/round_manager.py`. Player characters start fights using the `CmdAttack`
+command defined in `commands/combat.py`.
+
 Supports action queues, status effects, resistances
 
 Fully pluggable and extendable

--- a/docs/combat_loop_mapping.md
+++ b/docs/combat_loop_mapping.md
@@ -19,6 +19,8 @@ File: `combat/round_manager.py`
 
 ## CombatInstance
 
+File: `combat/round_manager.py`
+
 Created by `CombatRoundManager` when a new combat begins.
 - Tracks its participants and keeps them synchronized with the `CombatEngine`.
 - Replaces the old room-attached scripts used in earlier versions.
@@ -69,6 +71,8 @@ engine.queue_action(attacker, AttackAction(attacker, target))
 # The round manager will call `process_round` automatically every tick
 # which resolves queued actions and broadcasts the results to the room.
 ```
+In-game, players typically use the `attack` command (`CmdAttack` in
+`commands/combat.py`) which queues an appropriate `AttackAction` for them.
 
 When the round executes you will see messages such as
 ``Attacker hits Target for 5 damage!`` and the combatants' HP updated.


### PR DESCRIPTION
## Summary
- document that CombatRoundManager and CombatInstance live in `combat/round_manager.py`
- mention that `CmdAttack` is implemented in `commands/combat.py`
- add note about using the attack command in the combat loop docs

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_685ce257db7c832cb0c3b0a0d28badc3