### PR TITLE
Add debug logs for combat tick scheduling

### DIFF
--- a/combat/round_manager.py
+++ b/combat/round_manager.py
@@ -71,6 +71,12 @@ class CombatInstance:
         """Schedule the next combat round."""
         if self.combat_ended or self.tick_handle:
             return
+        if settings.COMBAT_DEBUG_TICKS:
+            logger.debug(
+                "Scheduling combat tick %s in %s seconds",
+                self.round_number + 1,
+                self.round_time,
+            )
         self.tick_handle = delay(self.round_time, self._tick)
 
     def cancel_tick(self) -> None:
@@ -86,7 +92,7 @@ class CombatInstance:
         """Process a round and schedule the next one."""
         self.tick_handle = None
         if settings.COMBAT_DEBUG_TICKS:
-            logger.debug("Combat tick %s", self.round_number)
+            logger.debug("Combat tick %s executed", self.round_number)
         if not self.is_valid():
             self.end_combat("Invalid combat instance")
             return

--- a/world/tests/test_combat_tick_logging.py
+++ b/world/tests/test_combat_tick_logging.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from django.test import override_settings
 from combat.round_manager import CombatInstance
 
@@ -18,3 +18,16 @@ class TestCombatTickLogging(unittest.TestCase):
         with self.assertLogs('combat.round_manager', level='DEBUG') as cm:
             inst._tick()
         self.assertTrue(any('Combat tick' in msg for msg in cm.output))
+
+    @override_settings(COMBAT_DEBUG_TICKS=True)
+    def test_schedule_emits_debug_log(self):
+        fighter1 = object()
+        fighter2 = object()
+        engine = MagicMock()
+        engine.participants = []
+        inst = CombatInstance(1, engine, {fighter1, fighter2})
+        with patch('combat.round_manager.delay') as mock_delay:
+            mock_delay.return_value = MagicMock()
+            with self.assertLogs('combat.round_manager', level='DEBUG') as cm:
+                inst._schedule_tick()
+        self.assertTrue(any('Scheduling combat tick' in msg for msg in cm.output))


### PR DESCRIPTION
## Summary
- add debug logging for scheduling and executing combat ticks
- test that scheduling a tick produces a debug log message

## Testing
- `pytest -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_685ce25ebdd4832cb401165d8279fec1