### PR TITLE
Document XP triggers

### DIFF
--- a/combat/combat_actions.py
+++ b/combat/combat_actions.py
@@ -101,7 +101,12 @@ class Action:
 
 
 class AttackAction(Action):
-    """Simple weapon attack."""
+    """Simple weapon attack.
+
+    If this action deals the finishing blow, ``CombatRoundManager``
+    handles defeat and calls the target's ``on_death`` hook. Any
+    experience reward is granted during that callback.
+    """
 
     priority = 1
 

--- a/docs/combat_loop_mapping.md
+++ b/docs/combat_loop_mapping.md
@@ -123,4 +123,7 @@ from combat.engine import CombatEngine, TurnManager, AggroTracker, DamageProcess
   and issues the `flee` command when triggered.
 - **Dead NPC Cleanup** – combatants flagged with `db.is_dead` skip any queued
   actions and are removed from combat at the end of the round.
+- **Experience Rewards** – when an `AttackAction` drops a combatant to 0 HP,
+  `CombatRoundManager` handles their defeat. The target's `on_death` hook runs
+  and any accumulated XP is distributed to contributors.
 


### PR DESCRIPTION
## Summary
- mention that defeating a target awards XP in `AttackAction` docs
- document XP awards in combat mapping guide

## Testing
- `pytest -q` *(fails: OperationalError - no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_685ce7b080bc832cb8a39c530ab41430