### PR TITLE
Refactor NPC auto attack function

### DIFF
--- a/combat/ai_combat.py
+++ b/combat/ai_combat.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from typing import Any
 
+from evennia.utils.logger import log_trace
+
+from combat.combatants import _current_hp
+
 from combat.combat_ai.npc_logic import npc_take_turn as _npc_take_turn
 
 
@@ -15,4 +19,36 @@ def queue_npc_action(engine: CombatEngine | None, npc: Any, target: Any) -> None
     :meth:`CombatEngine.queue_action`.
     """
     _npc_take_turn(engine, npc, target)
+
+
+def auto_attack(npc: Any, engine: Any) -> None:
+    """Perform a basic auto attack for ``npc`` using ``engine``.
+
+    This mirrors the manual round auto-attack logic previously
+    implemented on :class:`CombatRoundManager`.
+    """
+    if not npc or not hasattr(npc, "location"):
+        return
+
+    fighters = [p.actor for p in engine.participants] if engine else []
+    targets = []
+
+    for fighter in fighters:
+        if (
+            fighter is not npc
+            and getattr(fighter, "has_account", False)
+            and _current_hp(fighter) > 0
+            and getattr(fighter, "in_combat", False)
+        ):
+            targets.append(fighter)
+
+    if not targets:
+        return
+
+    target = targets[0]
+    if hasattr(npc, "attack"):
+        try:
+            npc.attack(target)
+        except Exception as err:  # pragma: no cover - safety
+            log_trace(f"NPC {getattr(npc, 'key', npc)} attack failed: {err}")
 

--- a/combat/round_manager.py
+++ b/combat/round_manager.py
@@ -223,35 +223,9 @@ class CombatInstance:
 
             # Handle NPC auto-attacks
             if not hasattr(fighter, "has_account") or not fighter.has_account:
-                self._npc_auto_attack(fighter)
+                from combat.ai_combat import auto_attack
+                auto_attack(fighter, self.engine)
 
-    def _npc_auto_attack(self, npc) -> None:
-        """Handle NPC automatic attacks."""
-        if not npc or not hasattr(npc, "location"):
-            return
-
-        fighters = [p.actor for p in self.engine.participants]
-        targets = []
-        
-        for fighter in fighters:
-            if (
-                fighter != npc
-                and hasattr(fighter, "has_account")
-                and fighter.has_account
-                and _current_hp(fighter) > 0
-                and getattr(fighter, "in_combat", False)
-            ):
-                targets.append(fighter)
-
-        if not targets:
-            return
-
-        target = targets[0]
-        if hasattr(npc, "attack"):
-            try:
-                npc.attack(target)
-            except Exception as e:
-                log_trace(f"NPC {npc.key} attack failed: {e}")
 
     def end_combat(self, reason: str = "") -> None:
         """Mark this instance as ended and clean up fighter states."""

--- a/typeclasses/tests/test_mob_ai.py
+++ b/typeclasses/tests/test_mob_ai.py
@@ -7,6 +7,7 @@ from django.test import override_settings
 
 from world.npc_handlers import mob_ai
 from scripts.global_npc_ai import GlobalNPCAI
+from combat.ai_combat import auto_attack
 
 
 @override_settings(DEFAULT_HOME=None)
@@ -273,7 +274,7 @@ class TestMobAIBehaviors(EvenniaTest):
             helper.db.auto_assist = True
 
             with patch.object(helper, "attack") as mock_attack, \
-                 patch.object(instance, "_npc_auto_attack", wraps=instance._npc_auto_attack) as mock_auto, \
+                 patch("combat.ai_combat.auto_attack", wraps=auto_attack) as mock_auto, \
                  patch.object(helper, "enter_combat", wraps=helper.enter_combat) as mock_enter, \
                  patch("world.npc_handlers.mob_ai._call_for_help"):
                 mob_ai.process_mob_ai(helper)


### PR DESCRIPTION
## Summary
- move NPC auto-attack logic to `combat.ai_combat.auto_attack`
- call new function from manual combat rounds
- update mob AI tests

## Testing
- `pytest typeclasses/tests/test_mob_ai.py::TestMobAIBehaviors::test_helper_auto_attacks_when_ally_attacked -q` *(fails: django.db.utils.OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_685cf1462b90832ca05032c2a37b8771