### PR TITLE
Introduce pluggable death handler

### DIFF
--- a/combat/engine/combat_engine.py
+++ b/combat/engine/combat_engine.py
@@ -7,18 +7,31 @@ from typing import Iterable
 from .turn_manager import TurnManager
 from ..aggro_tracker import AggroTracker
 from ..damage_processor import DamageProcessor
+from world.mechanics.death_handlers import IDeathHandler
 from evennia.utils.logger import log_trace
 
 
 class CombatEngine:
     """Manage combat by delegating to helper classes."""
 
-    def __init__(self, participants: Iterable[object] | None = None, round_time: int = 0, use_initiative: bool = True) -> None:
+    def __init__(
+        self,
+        participants: Iterable[object] | None = None,
+        round_time: int = 0,
+        use_initiative: bool = True,
+        *,
+        death_handler: IDeathHandler | None = None,
+    ) -> None:
         self.round = 0
         self.round_time = round_time
         self.turn_manager = TurnManager(self, participants, use_initiative=use_initiative)
         self.aggro_tracker = AggroTracker()
-        self.processor = DamageProcessor(self, self.turn_manager, self.aggro_tracker)
+        self.processor = DamageProcessor(
+            self,
+            self.turn_manager,
+            self.aggro_tracker,
+            death_handler=death_handler,
+        )
 
     # -------------------------------------------------------------
     # delegate helpers

--- a/server/conf/settings.py
+++ b/server/conf/settings.py
@@ -98,6 +98,9 @@ COMBAT_DEBUG_TICKS = False
 # When True, include a damage summary at the end of each combat round
 COMBAT_DEBUG_SUMMARY = False
 
+# Class implementing death cleanup logic
+DEATH_HANDLER_CLASS = "world.mechanics.death_handlers.DefaultDeathHandler"
+
 # Clothing - https://www.evennia.com/docs/latest/Contribs/Contrib-Clothing.html#configuration
 CLOTHING_WEARSTYLE_MAXLENGTH = 40
 CLOTHING_TYPE_ORDERED = [

--- a/world/mechanics/death_handlers.py
+++ b/world/mechanics/death_handlers.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+"""Death handler interface and default implementation."""
+
+from abc import ABC, abstractmethod
+from django.conf import settings
+from evennia.utils.utils import class_from_module
+from evennia.utils import inherits_from, logger
+
+from combat.corpse_creation import spawn_corpse
+from combat.round_manager import CombatRoundManager, leave_combat
+from world.system import state_manager
+
+
+class IDeathHandler(ABC):
+    """Interface for custom death handlers."""
+
+    @abstractmethod
+    def handle(self, victim, killer=None):
+        """Handle cleanup when ``victim`` dies."""
+        raise NotImplementedError
+
+
+class DefaultDeathHandler(IDeathHandler):
+    """Replicates the original death handling logic."""
+
+    def handle(self, victim, killer=None):  # noqa: D401 - simple interface
+        if not victim or getattr(victim, "location", None) is None:
+            return None
+
+        if getattr(getattr(victim, "attributes", None), "get", lambda *a, **k: None)("_dead"):
+            return None
+
+        try:
+            victim.db._dead = True
+            victim.db.dead = True
+            victim.db.is_dead = True
+        except Exception:
+            pass
+
+        manager = CombatRoundManager.get()
+        inst = manager.get_combatant_combat(victim)
+        engine = inst.engine if inst else None
+
+        leave_combat(victim)
+
+        location = victim.location
+        corpse = None
+
+        if killer:
+            victim.msg(f"You are slain by {killer.get_display_name(victim)}!")
+            if location:
+                location.msg_contents(f"{victim.key} is |Rslain|n by |C{killer.key}|n!")
+        else:
+            victim.msg("You have died.")
+            if location:
+                location.msg_contents(f"{victim.key} dies.")
+
+        if killer:
+            if engine:
+                try:
+                    engine.award_experience(killer, victim)
+                except Exception:  # pragma: no cover - safety
+                    logger.log_trace()
+            elif inherits_from(victim, "typeclasses.characters.NPC"):
+                exp = int(getattr(victim.db, "exp_reward", 0) or 0)
+                if exp:
+                    exp = state_manager.calculate_xp_reward(killer, victim, exp)
+                    if exp:
+                        if hasattr(killer, "msg"):
+                            killer.msg(f"You gain |Y{exp}|n experience points!")
+                        state_manager.gain_xp(killer, exp)
+
+        if location:
+            corpse = next(
+                (
+                    obj
+                    for obj in location.contents
+                    if obj.is_typeclass("typeclasses.objects.Corpse", exact=False)
+                    and obj.db.corpse_of_id == getattr(victim, "dbref", None)
+                ),
+                None,
+            )
+            if not corpse:
+                corpse = spawn_corpse(victim, killer)
+                if corpse:
+                    corpse.location = location
+                    if getattr(victim, "key", None):
+                        corpse.db.corpse_of = victim.key
+                    if getattr(victim, "dbref", None):
+                        corpse.db.corpse_of_id = victim.dbref
+                    if getattr(getattr(victim, "db", None), "vnum", None) is not None:
+                        corpse.db.npc_vnum = victim.db.vnum
+
+        try:
+            victim.at_death(killer)
+        except Exception:  # pragma: no cover - safety
+            logger.log_trace()
+
+        return corpse
+
+
+def _load_handler():
+    path = getattr(settings, "DEATH_HANDLER_CLASS", "world.mechanics.death_handlers.DefaultDeathHandler")
+    cls = class_from_module(path)
+    return cls()
+
+
+_handler_instance: IDeathHandler | None = None
+
+
+def get_handler() -> IDeathHandler:
+    """Return the configured death handler instance."""
+    global _handler_instance
+    if _handler_instance is None:
+        _handler_instance = _load_handler()
+    return _handler_instance
+
+
+def set_handler(handler: IDeathHandler) -> None:
+    """Set the global death handler instance."""
+    global _handler_instance
+    _handler_instance = handler

--- a/world/mechanics/on_death_manager.py
+++ b/world/mechanics/on_death_manager.py
@@ -1,90 +1,12 @@
-from __future__ import annotations
-
 """Centralized death handling helpers."""
 
-from evennia.utils import inherits_from, logger
-from combat.corpse_creation import spawn_corpse
-from combat.round_manager import CombatRoundManager, leave_combat
-from world.system import state_manager
+from __future__ import annotations
+
+from world.mechanics.death_handlers import get_handler, IDeathHandler
 
 
-def handle_death(victim, killer=None):
-    """Handle generic death cleanup for any character."""
-    if not victim or getattr(victim, "location", None) is None:
-        return None
-
-    if getattr(victim.attributes, "get", lambda *a, **k: None)("_dead"):
-        return None
-
-    # mark death flags
-    try:
-        victim.db._dead = True
-        victim.db.dead = True
-        victim.db.is_dead = True
-    except Exception:
-        pass
-
-    manager = CombatRoundManager.get()
-    inst = manager.get_combatant_combat(victim)
-    engine = inst.engine if inst else None
-
-    # remove from combat
-    leave_combat(victim)
-
-    location = victim.location
-    corpse = None
-
-    # broadcast messages before converting to a corpse
-    if killer:
-        victim.msg(f"You are slain by {killer.get_display_name(victim)}!")
-        if location:
-            location.msg_contents(f"{victim.key} is |Rslain|n by |C{killer.key}|n!")
-    else:
-        victim.msg("You have died.")
-        if location:
-            location.msg_contents(f"{victim.key} dies.")
-
-    # experience award
-    if killer:
-        if engine:
-            try:
-                engine.award_experience(killer, victim)
-            except Exception:  # pragma: no cover - safety
-                logger.log_trace()
-        elif inherits_from(victim, "typeclasses.characters.NPC"):
-            exp = int(getattr(victim.db, "exp_reward", 0) or 0)
-            if exp:
-                exp = state_manager.calculate_xp_reward(killer, victim, exp)
-                if exp:
-                    if hasattr(killer, "msg"):
-                        killer.msg(f"You gain |Y{exp}|n experience points!")
-                    state_manager.gain_xp(killer, exp)
-
-    if location:
-        corpse = next(
-            (
-                obj
-                for obj in location.contents
-                if obj.is_typeclass("typeclasses.objects.Corpse", exact=False)
-                and obj.db.corpse_of_id == getattr(victim, "dbref", None)
-            ),
-            None,
-        )
-        if not corpse:
-            corpse = spawn_corpse(victim, killer)
-            if corpse:
-                corpse.location = location
-                if getattr(victim, "key", None):
-                    corpse.db.corpse_of = victim.key
-                if getattr(victim, "dbref", None):
-                    corpse.db.corpse_of_id = victim.dbref
-                if getattr(getattr(victim, "db", None), "vnum", None) is not None:
-                    corpse.db.npc_vnum = victim.db.vnum
-
-    # call at_death hooks
-    try:
-        victim.at_death(killer)
-    except Exception:  # pragma: no cover - safety
-        logger.log_trace()
-
-    return corpse
+def handle_death(victim, killer=None, handler: IDeathHandler | None = None):
+    """Delegate death cleanup to the configured handler."""
+    if handler is None:
+        handler = get_handler()
+    return handler.handle(victim, killer)


### PR DESCRIPTION
## Summary
- define `IDeathHandler` interface and `DefaultDeathHandler`
- route `on_death_manager.handle_death` through a handler instance
- inject a handler into `DamageProcessor` and `CombatEngine`
- allow customization via `settings.DEATH_HANDLER_CLASS`

## Testing
- `pytest -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cf6269e70832cb13bb8a03b08af29