### PR TITLE
Add combat extension docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,9 @@ command defined in `commands/combat.py`.
 
 Supports action queues, status effects, resistances
 
-Fully pluggable and extendable
+Fully pluggable and extendable—combat emits Django signals and you can
+override the `DamageProcessor`, `IDeathHandler` or NPC AI routines. See
+`docs/combat_loop_mapping.md` for examples.
 
 The available spells and the ``Spell`` dataclass now live in ``combat.spells``.
 


### PR DESCRIPTION
## Summary
- document combat event hooks and extension points
- add custom handler examples
- mention extensions in README

## Testing
- `pytest -q` *(fails: 170 failed)*

------
https://chatgpt.com/codex/tasks/task_e_685cfb8fccf0832c8b46849954b43523