### PR TITLE
Add quickstart combat guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,8 @@ Supports action queues, status effects, resistances
 
 Fully pluggable and extendable—combat emits Django signals and you can
 override the `DamageProcessor`, `IDeathHandler` or NPC AI routines. See
-`docs/combat_loop_mapping.md` for examples.
+`docs/combat_loop_mapping.md` for examples. For a hands-on demonstration, see
+`docs/quickstart_combat.md`.
 
 The available spells and the ``Spell`` dataclass now live in ``combat.spells``.
 

--- a/docs/quickstart_combat.md
+++ b/docs/quickstart_combat.md
@@ -1,0 +1,29 @@
+# Quickstart: Combat
+
+Follow these steps to see two characters fight using the built-in combat system.
+
+## 1. Run the Evennia server
+
+From the project root run:
+
+```bash
+evennia migrate
+evennia start
+```
+
+Create your superuser account when prompted and connect using the web client or any telnet client.
+
+## 2. Create two characters
+
+Open two client connections. For each connection use the `ic` command to create and puppet a character. If the name does not already exist `ic <name>` will create it for you. New characters appear in the start room, so both should be together immediately. If needed you can move them with `@teleport`.
+
+## 3. Start combat
+
+From one of the characters run:
+
+```
+attack <target>
+```
+
+Replace `<target>` with the other character's name. The `attack` command queues the first action and combat rounds begin automatically every few seconds until one combatant falls or flees.
+


### PR DESCRIPTION
## Summary
- document how to quickly try combat in Evennia
- link to quickstart from README

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_685cfe6254ec832ca096043a3f1cef78