### PR TITLE
Fix EvMenu decorator raw input handling

### DIFF
--- a/commands/redit.py
+++ b/commands/redit.py
@@ -78,11 +78,13 @@ def require_redit_state(func):
     """Decorator to ensure caller has a valid redit state."""
 
     @wraps(func)
-    def wrapper(caller, *args, **kwargs):
+    def wrapper(caller, raw_string=None, *args, **kwargs):
         if not _state_exists(caller):
             caller.msg("Room editing state missing. Exiting.")
             return None
-        return func(caller, *args, **kwargs)
+        if raw_string is None:
+            return func(caller, *args, **kwargs)
+        return func(caller, raw_string, *args, **kwargs)
 
     return wrapper
 


### PR DESCRIPTION
## Summary
- ensure `require_redit_state` wrapper passes raw input to callbacks

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685cffd4794c832ca9d1400921c8ccf3