### PR TITLE
Omit no-fighters combat message

### DIFF
--- a/combat/round_manager.py
+++ b/combat/round_manager.py
@@ -267,7 +267,9 @@ class CombatInstance:
         CombatRoundManager.get().remove_combat(self.combat_id)
 
         message = f"Combat ends: {reason}" if reason else "Combat ends:"
-        if room and hasattr(room, "msg_contents"):
+        if reason == "No active fighters remaining":
+            message = ""
+        if room and hasattr(room, "msg_contents") and message:
             try:
                 room.msg_contents(message)
             except Exception:  # pragma: no cover - safety


### PR DESCRIPTION
## Summary
- skip broadcasting the "Combat ends: No active fighters remaining" message

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685d036cf190832c953bed9437f8c6e9