### PR TITLE
Fix corpse decay start delay

### DIFF
--- a/typeclasses/objects.py
+++ b/typeclasses/objects.py
@@ -440,7 +440,6 @@ class Corpse(Object):
             script = self.scripts.add(
                 "typeclasses.scripts.DecayScript",
                 key="decay",
-                start_delay=True,
                 room_only=not settings.ALLOW_CORPSE_DECAY_IN_INVENTORY,
                 autostart=False,
             )
@@ -458,7 +457,6 @@ class Corpse(Object):
             script = self.scripts.add(
                 "typeclasses.scripts.DecayScript",
                 key="decay",
-                start_delay=True,
                 room_only=not settings.ALLOW_CORPSE_DECAY_IN_INVENTORY,
                 autostart=False,
             )


### PR DESCRIPTION
## Summary
- make corpses start decay timers immediately by removing `start_delay=True`

## Testing
- `pytest -q` *(fails: no such table errors and keyboard interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_685d05a71d58832c82f4924d05fe35a5