### PR TITLE
Add NPC defeat cleanup test

### DIFF
--- a/typeclasses/tests/test_damage_processor_handle_defeat.py
+++ b/typeclasses/tests/test_damage_processor_handle_defeat.py
@@ -30,3 +30,30 @@ class TestDamageProcessorHandleDefeat(EvenniaTest):
         self.assertIsNotNone(corpse)
         calls = [c.args[0] for c in room.msg_contents.call_args_list]
         self.assertTrue(any("slain" in msg for msg in calls))
+
+    def test_npc_defeat_creates_corpse_and_removes_npc(self):
+        """Defeated NPCs should leave a corpse and be removed from the room."""
+
+        room = self.room1
+        player = self.char1
+        npc = create.create_object(NPC, key="mob", location=room)
+        npc.db.drops = []
+
+        engine = CombatEngine([player, npc], round_time=0)
+        engine.queue_action(player, KillAction(player, npc))
+
+        with patch("world.system.state_manager.apply_regen"), patch(
+            "world.system.state_manager.check_level_up"
+        ), patch("random.randint", return_value=0):
+            engine.start_round()
+            engine.process_round()
+
+        corpses = [
+            obj
+            for obj in room.contents
+            if obj.is_typeclass("typeclasses.objects.Corpse", exact=False)
+        ]
+
+        self.assertEqual(len(corpses), 1)
+        self.assertNotIn(npc, room.contents)
+        self.assertFalse(any(getattr(obj.db, "is_dead", False) for obj in room.contents))


### PR DESCRIPTION
## Summary
- add test ensuring defeated NPC spawns corpse and no dead NPC remains

## Testing
- `pytest -q typeclasses/tests/test_damage_processor_handle_defeat.py::TestDamageProcessorHandleDefeat::test_npc_defeat_creates_corpse_and_removes_npc -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_685d0a9aaa94832cadbbf550f30c0fb2