### PR TITLE
Fix round_time handling in combat

### DIFF
--- a/combat/round_manager.py
+++ b/combat/round_manager.py
@@ -329,14 +329,22 @@ class CombatRoundManager:
         except ImportError as err:
             raise ImportError("Combat engine could not be imported") from err
 
-        engine = CombatEngine(fighters, round_time=round_time or 2.0)
+        engine = CombatEngine(
+            fighters,
+            round_time=round_time if round_time is not None else 2.0,
+        )
         if not engine:
             raise RuntimeError("CombatEngine failed to initialize")
 
         combat_id = self._next_id
         self._next_id += 1
 
-        inst = CombatInstance(combat_id, engine, set(fighters), round_time or 2.0)
+        inst = CombatInstance(
+            combat_id,
+            engine,
+            set(fighters),
+            round_time if round_time is not None else 2.0,
+        )
         if fighters:
             inst.room = getattr(fighters[0], "location", None)
         self.combats[combat_id] = inst

--- a/world/tests/test_round_manager_create.py
+++ b/world/tests/test_round_manager_create.py
@@ -1,0 +1,19 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+from combat.round_manager import CombatRoundManager
+
+class TestCombatRoundManagerCreate(unittest.TestCase):
+    def setUp(self):
+        CombatRoundManager._instance = None
+
+    def test_round_time_zero_preserved(self):
+        with patch('combat.engine.CombatEngine') as MockEngine, \
+             patch('combat.round_manager.delay'):
+            manager = CombatRoundManager.get()
+            inst = manager.create_combat([], round_time=0)
+        MockEngine.assert_called_with([], round_time=0)
+        self.assertEqual(inst.round_time, 0)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- preserve explicit `round_time=0` when creating combats
- test that CombatRoundManager retains a zero round time

## Testing
- `pytest world/tests/test_round_manager_create.py::TestCombatRoundManagerCreate::test_round_time_zero_preserved -q`

------
https://chatgpt.com/codex/tasks/task_e_685d0d0be1e0832cb8fd2b86a4537743