### PR TITLE
Prevent ticks for non-positive intervals

### DIFF
--- a/combat/round_manager.py
+++ b/combat/round_manager.py
@@ -72,13 +72,14 @@ class CombatInstance:
         """Schedule the next combat round."""
         if self.combat_ended or self.tick_handle:
             return
-        if settings.COMBAT_DEBUG_TICKS:
-            logger.debug(
-                "Scheduling combat tick %s in %s seconds",
-                self.round_number + 1,
-                self.round_time,
-            )
-        self.tick_handle = delay(self.round_time, self._tick)
+        if self.round_time and self.round_time > 0:
+            if settings.COMBAT_DEBUG_TICKS:
+                logger.debug(
+                    "Scheduling combat tick %s in %s seconds",
+                    self.round_number + 1,
+                    self.round_time,
+                )
+            self.tick_handle = delay(self.round_time, self._tick)
 
     def cancel_tick(self) -> None:
         """Cancel any pending tick."""

--- a/world/tests/test_combat_tick_logging.py
+++ b/world/tests/test_combat_tick_logging.py
@@ -31,3 +31,21 @@ class TestCombatTickLogging(unittest.TestCase):
             with self.assertLogs('combat.round_manager', level='DEBUG') as cm:
                 inst._schedule_tick()
         self.assertTrue(any('Scheduling combat tick' in msg for msg in cm.output))
+
+    def test_zero_round_time_skips_schedule(self):
+        engine = MagicMock()
+        engine.participants = []
+        inst = CombatInstance(1, engine, {object(), object()}, round_time=0)
+        with patch('combat.round_manager.delay') as mock_delay:
+            inst._schedule_tick()
+        mock_delay.assert_not_called()
+        self.assertIsNone(inst.tick_handle)
+
+    def test_negative_round_time_skips_schedule(self):
+        engine = MagicMock()
+        engine.participants = []
+        inst = CombatInstance(1, engine, {object(), object()}, round_time=-1)
+        with patch('combat.round_manager.delay') as mock_delay:
+            inst._schedule_tick()
+        mock_delay.assert_not_called()
+        self.assertIsNone(inst.tick_handle)


### PR DESCRIPTION
## Summary
- skip scheduling combat ticks when the configured round_time is <= 0
- test that _schedule_tick does nothing for zero or negative round_time

## Testing
- `pytest world/tests/test_combat_tick_logging.py::TestCombatTickLogging::test_zero_round_time_skips_schedule world/tests/test_combat_tick_logging.py::TestCombatTickLogging::test_negative_round_time_skips_schedule -q`

------
https://chatgpt.com/codex/tasks/task_e_685d0ec7e774832c9d579276587dbefe