### PR TITLE
Fix damage round scheduling

### DIFF
--- a/combat/damage_processor.py
+++ b/combat/damage_processor.py
@@ -353,6 +353,10 @@ class DamageProcessor:
         self._broadcast_round_output(room)
 
         self.engine.round += 1
-        if self.engine.round_time is not None and any(_current_hp(p.actor) > 0 for p in self.turn_manager.participants):
+        if (
+            self.engine.round_time
+            and self.engine.round_time > 0
+            and any(_current_hp(p.actor) > 0 for p in self.turn_manager.participants)
+        ):
             delay(self.engine.round_time, self.engine.process_round)
 


### PR DESCRIPTION
## Summary
- check for round_time > 0 before scheduling another round
- adjust combat engine test
- test that no delay occurs when round_time is zero

## Testing
- `pytest typeclasses/tests/test_combat_engine.py::TestCombatEngine::test_schedules_next_round typeclasses/tests/test_combat_engine.py::TestCombatEngine::test_zero_round_time_no_schedule -q`

------
https://chatgpt.com/codex/tasks/task_e_685d10a294ec832c9163439297e2444f