### PR TITLE
Fix early return in damage broadcast

### DIFF
--- a/combat/damage_processor.py
+++ b/combat/damage_processor.py
@@ -314,9 +314,10 @@ class DamageProcessor:
             self.round_output.extend(summary_lines)
 
     def _broadcast_round_output(self, room=None) -> None:
+        if not self.turn_manager.participants:
+            return
         if room is None:
-            if self.turn_manager.participants:
-                room = getattr(self.turn_manager.participants[0].actor, "location", None)
+            room = getattr(self.turn_manager.participants[0].actor, "location", None)
 
         if room:
             for line in self.round_output:

--- a/world/tests/test_damage_processor_broadcast.py
+++ b/world/tests/test_damage_processor_broadcast.py
@@ -1,0 +1,18 @@
+import unittest
+from unittest.mock import MagicMock
+
+from combat.damage_processor import DamageProcessor
+
+class TestDamageProcessorBroadcast(unittest.TestCase):
+    def test_no_participants_returns_early(self):
+        engine = MagicMock()
+        manager = MagicMock()
+        manager.participants = []
+        processor = DamageProcessor(engine, manager, MagicMock())
+        processor.round_output = ["msg"]
+        room = MagicMock()
+        processor._broadcast_round_output(room)
+        room.msg_contents.assert_not_called()
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- exit `_broadcast_round_output` early when no combatants remain
- test that broadcasting with zero participants is a no-op

## Testing
- `pytest -k TestDamageProcessorBroadcast -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_685d1447b220832c964d528830daf714