### PR TITLE
Move auto_attack import to module level

### DIFF
--- a/combat/round_manager.py
+++ b/combat/round_manager.py
@@ -15,6 +15,7 @@ from evennia.utils.logger import log_trace
 import logging
 from combat.combatants import _current_hp
 from combat.events import combat_started, round_processed, combat_ended
+from combat.ai_combat import auto_attack
 
 logger = logging.getLogger(__name__)
 
@@ -239,7 +240,6 @@ class CombatInstance:
 
             # Handle NPC auto-attacks
             if not hasattr(fighter, "has_account") or not fighter.has_account:
-                from combat.ai_combat import auto_attack
                 auto_attack(fighter, self.engine)
 
 


### PR DESCRIPTION
## Summary
- move `auto_attack` import to the top of `combat/round_manager.py`
- call `auto_attack` inside `_manual_round_processing` without re-importing

## Testing
- `pytest -q` *(fails: 81 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685d248916d4832cb37a31efbc399a2c