### PR TITLE
Remove leftover pass statements

### DIFF
--- a/typeclasses/gear.py
+++ b/typeclasses/gear.py
@@ -103,7 +103,6 @@ class BareHand:
                 effect, chance = status
                 if stat_manager.roll_status(wielder, target, int(chance)):
                     state_manager.add_status_effect(target, effect, 1)
-        pass
 
 
 class MeleeWeapon(Object):
@@ -219,7 +218,6 @@ class MeleeWeapon(Object):
                 effect, chance = status
                 if stat_manager.roll_status(wielder, target, int(chance)):
                     state_manager.add_status_effect(target, effect, 1)
-        pass
 
 
 class WearableContainer(ContribContainer, ClothingObject):


### PR DESCRIPTION
## Summary
- clean up `BareHand.at_attack` and `MeleeWeapon.at_attack`

## Testing
- `scripts/setup_test_env.sh` *(fails: Could not install dependencies)*
- `pytest -q` *(fails: import errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685d26514a90832ca90c54ffd752d542