### PR TITLE
Define __all__ in spells

### DIFF
--- a/combat/spells.py
+++ b/combat/spells.py
@@ -51,3 +51,6 @@ def colorize_spell(name: str) -> str:
     else:
         color = "|M"
     return f"{color}{name}|n"
+
+
+__all__ = ["Spell", "SPELLS", "colorize_spell"]


### PR DESCRIPTION
## Summary
- restrict star-imports in `combat.spells`
- verify symbols exported by the module

## Testing
- `pytest -q` *(fails: ImportError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685d27660918832cabedb640968d735d