### PR TITLE
Fix circular import in combat AI

### DIFF
--- a/combat/combat_ai/ai_controller.py
+++ b/combat/combat_ai/ai_controller.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Callable, Iterable
 
-from ..engine import CombatEngine
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type checking
+    from ..engine import CombatEngine
 
 
 @dataclass(order=True)

--- a/combat/combat_ai/npc_logic.py
+++ b/combat/combat_ai/npc_logic.py
@@ -4,9 +4,12 @@ from typing import Iterable
 
 from .ai_controller import Behavior, run_behaviors
 from ..combat_actions import AttackAction
-from ..engine import CombatEngine
+from typing import TYPE_CHECKING
 from ..combat_skills import SKILL_CLASSES
 from ..scripts import queue_skill, queue_spell, get_spell
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type checking
+    from ..engine import CombatEngine
 
 
 def _default_behaviors(npc) -> Iterable[Behavior]:


### PR DESCRIPTION
## Summary
- avoid importing CombatEngine at module import time in AI modules

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685d27cc2440832cac73f610376684d3