### PR TITLE
Enable auto prompt by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## [Unreleased]
+- Default account setting `auto prompt` is now enabled.

--- a/typeclasses/accounts.py
+++ b/typeclasses/accounts.py
@@ -98,7 +98,7 @@ class Account(ContribChargenAccount):
     def at_account_creation(self):
         super().at_account_creation()
         # Initialize game settings
-        self.db.settings = {"auto prompt": False}
+        self.db.settings = {"auto prompt": True}
 
 
 class Guest(DefaultGuest):


### PR DESCRIPTION
## Summary
- default accounts to send the prompt automatically
- document the new default in CHANGELOG

## Testing
- `scripts/setup_test_env.sh` *(fails: Could not install dependencies)*
- `pytest -q` *(fails: missing setuptools)*

------
https://chatgpt.com/codex/tasks/task_e_685d29c41b10832cbccfed6cf261af79