### PR TITLE
Fix autoprompt call on movement

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -353,11 +353,9 @@ class Character(TriggerMixin, ObjectParent, ClothedCharacter):
         if self.traits.stamina:
             self.traits.stamina.current = max(self.traits.stamina.current - cost, 0)
 
-        # check if we have auto-prompt in account settings
-        if self.account and (acct_settings := self.account.db.settings):
-            if acct_settings.get("auto prompt"):
-                status = self.get_display_status(self)
-                self.msg(prompt=status)
+        from utils import display_auto_prompt
+
+        display_auto_prompt(self.account, self, self.msg)
 
     def at_damage(self, attacker, damage, damage_type=None, critical=False):
         """


### PR DESCRIPTION
## Summary
- invoke `display_auto_prompt` from `Character.at_post_move`

## Testing
- `pytest -q` *(fails: OperationalError - no such table: accounts_accountdb)*
- `pytest -q utils/tests/test_prompt_utils.py` *(fails: OperationalError - no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_685d29c867b4832c95bef470fa836e32