### PR TITLE
Fix Character commandset restoration on puppet

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -277,6 +277,9 @@ class Character(TriggerMixin, ObjectParent, ClothedCharacter):
 
         stats.apply_stats(self)
         stat_manager.recalculate_stats(self)
+        self.cmdset.add_default(
+            "commands.default_cmdsets.CharacterCmdSet", permanent=True
+        )
 
     def at_object_receive(self, obj, source_location, **kwargs):
         """Update carry weight when gaining an item."""


### PR DESCRIPTION
## Summary
- ensure that characters regain default commandset when puppeted

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'CombatRoundManager')*
- `evennia stop` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_685dd6b9b0a8832ca0876982f1fade1a