### PR TITLE
Suppress noisy combat end messages

### DIFF
--- a/combat/round_manager.py
+++ b/combat/round_manager.py
@@ -266,6 +266,9 @@ class CombatInstance:
         self.cancel_tick()
         CombatRoundManager.get().remove_combat(self.combat_id)
 
+        if reason == "No active fighters remaining":
+            reason = ""
+
         message = f"Combat ends: {reason}" if reason else "Combat ends:"
         if room and hasattr(room, "msg_contents"):
             try:

--- a/typeclasses/tests/test_combat_flow.py
+++ b/typeclasses/tests/test_combat_flow.py
@@ -552,3 +552,25 @@ def test_npc_death_flow_keeps_combat_active_until_end():
         assert not ended
     assert instance.combat_ended
 
+
+def test_end_combat_suppresses_no_active_fighters_reason():
+    room = MagicMock()
+    room.msg_contents = MagicMock()
+
+    fighter = Dummy()
+    fighter.location = room
+
+    engine = CombatEngine([fighter], round_time=0)
+    instance = CombatInstance(1, engine, {fighter}, round_time=0)
+    instance.room = room
+
+    manager = MagicMock()
+    manager.combatant_to_combat = {}
+
+    with patch.object(CombatRoundManager, "get", return_value=manager):
+        instance.end_combat("No active fighters remaining")
+
+    calls = [c.args[0] for c in room.msg_contents.call_args_list]
+    assert "Combat ends:" in calls
+    assert all("No active fighters remaining" not in msg for msg in calls)
+


### PR DESCRIPTION
## Summary
- remove the specific "No active fighters remaining" reason before broadcasting combat end message
- test that the reason is suppressed

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685ddd50c628832c8a2f2f101bc8fb15