### PR TITLE
Fix decay script addition

### DIFF
--- a/typeclasses/objects.py
+++ b/typeclasses/objects.py
@@ -440,7 +440,6 @@ class Corpse(Object):
             script = self.scripts.add(
                 "typeclasses.scripts.DecayScript",
                 key="decay",
-                start_delay=True,
                 room_only=not settings.ALLOW_CORPSE_DECAY_IN_INVENTORY,
                 autostart=False,
             )
@@ -458,7 +457,6 @@ class Corpse(Object):
             script = self.scripts.add(
                 "typeclasses.scripts.DecayScript",
                 key="decay",
-                start_delay=True,
                 room_only=not settings.ALLOW_CORPSE_DECAY_IN_INVENTORY,
                 autostart=False,
             )


### PR DESCRIPTION
## Summary
- remove invalid `start_delay` kwarg when attaching `DecayScript`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685ddfa453d0832c9f98ab6458350444