### PR TITLE
Disable 'Combat ends' messages

### DIFF
--- a/combat/round_manager.py
+++ b/combat/round_manager.py
@@ -166,7 +166,9 @@ class CombatInstance:
             if getattr(actor, "pk", None) is None:
                 setattr(actor, "in_combat", True)
 
-    def _remove_missing_fighters(self, fighters: Set[object], current: Set[object]) -> None:
+    def _remove_missing_fighters(
+        self, fighters: Set[object], current: Set[object]
+    ) -> None:
         """Remove engine participants no longer present in this instance."""
         for actor in current - fighters:
             self.engine.remove_participant(actor)
@@ -176,13 +178,17 @@ class CombatInstance:
     def _remove_defeated_fighters(self, fighters: Set[object]) -> None:
         """Handle any fighters that have been defeated."""
         for actor in list(fighters):
-            if _current_hp(actor) <= 0 and not getattr(getattr(actor, "db", None), "is_dead", False):
+            if _current_hp(actor) <= 0 and not getattr(
+                getattr(actor, "db", None), "is_dead", False
+            ):
                 log = getattr(getattr(actor, "ndb", None), "damage_log", None) or {}
                 killer = max(log, key=log.get) if log else None
                 try:
                     self.engine.handle_defeat(actor, killer)
                 except Exception as err:  # pragma: no cover - safety
-                    log_trace(f"Error handling defeat of {getattr(actor, 'key', actor)}: {err}")
+                    log_trace(
+                        f"Error handling defeat of {getattr(actor, 'key', actor)}: {err}"
+                    )
 
     def process_round(self) -> None:
         """Process a single combat round for this instance."""
@@ -228,7 +234,7 @@ class CombatInstance:
     def _manual_round_processing(self) -> None:
         """Fallback round processing if engine doesn't have process_round."""
         fighters = [p.actor for p in self.engine.participants]
-        
+
         for fighter in list(fighters):
             if not fighter or _current_hp(fighter) <= 0:
                 continue
@@ -239,8 +245,8 @@ class CombatInstance:
             # Handle NPC auto-attacks
             if not hasattr(fighter, "has_account") or not fighter.has_account:
                 from combat.ai_combat import auto_attack
-                auto_attack(fighter, self.engine)
 
+                auto_attack(fighter, self.engine)
 
     def end_combat(self, reason: str = "") -> None:
         """Mark this instance as ended and clean up fighter states."""
@@ -269,12 +275,7 @@ class CombatInstance:
         if reason == "No active fighters remaining":
             reason = ""
 
-        message = f"Combat ends: {reason}" if reason else "Combat ends:"
-        if room and hasattr(room, "msg_contents"):
-            try:
-                room.msg_contents(message)
-            except Exception:  # pragma: no cover - safety
-                pass
+        # A combat conclusion no longer broadcasts a room message
 
         # Clean up fighter states
         if self.engine:
@@ -319,7 +320,9 @@ class CombatRoundManager:
     # ------------------------------------------------------------------
 
     def create_combat(
-        self, combatants: Optional[List[object]] = None, round_time: Optional[float] = None
+        self,
+        combatants: Optional[List[object]] = None,
+        round_time: Optional[float] = None,
     ) -> CombatInstance:
         """Create a new combat with ``combatants``."""
 
@@ -421,7 +424,6 @@ class CombatRoundManager:
         primary.start()
         combat_started.send(sender=self.__class__, instance=primary)
         return primary
-
 
     # ------------------------------------------------------------------
     # debugging helpers

--- a/typeclasses/tests/test_combat_flow.py
+++ b/typeclasses/tests/test_combat_flow.py
@@ -52,6 +52,7 @@ class Dummy:
         if getattr(self.db, "natural_weapon", None):
             return self.db.natural_weapon
         from typeclasses.gear import BareHand
+
         return BareHand()
 
 
@@ -74,8 +75,10 @@ class TestAttackAction(unittest.TestCase):
 
         engine = CombatEngine([attacker, defender], round_time=0)
         engine.queue_action(attacker, AttackAction(attacker, defender))
-        with patch("world.system.state_manager.apply_regen"), \
-             patch("random.randint", return_value=0):
+        with (
+            patch("world.system.state_manager.apply_regen"),
+            patch("random.randint", return_value=0),
+        ):
             engine.start_round()
             engine.process_round()
 
@@ -94,9 +97,12 @@ class TestAttackAction(unittest.TestCase):
 
         engine = CombatEngine([attacker, defender], round_time=0)
         engine.queue_action(attacker, AttackAction(attacker, defender))
-        with patch("world.system.state_manager.apply_regen"), \
-             patch("random.randint", return_value=0), \
-             patch("world.system.state_manager.get_effective_stat") as mock_get:
+        with (
+            patch("world.system.state_manager.apply_regen"),
+            patch("random.randint", return_value=0),
+            patch("world.system.state_manager.get_effective_stat") as mock_get,
+        ):
+
             def getter(obj, stat):
                 if obj is attacker and stat == "STR":
                     return 10
@@ -123,9 +129,13 @@ class TestAttackAction(unittest.TestCase):
 
         engine = CombatEngine([attacker, defender], round_time=0)
         engine.queue_action(attacker, AttackAction(attacker, defender))
-        with patch("world.system.state_manager.apply_regen"), \
-             patch("world.system.state_manager.get_effective_stat", return_value=0), \
-             patch("combat.engine.combat_math.roll_dice_string", return_value=3) as mock_roll:
+        with (
+            patch("world.system.state_manager.apply_regen"),
+            patch("world.system.state_manager.get_effective_stat", return_value=0),
+            patch(
+                "combat.engine.combat_math.roll_dice_string", return_value=3
+            ) as mock_roll,
+        ):
             engine.start_round()
             engine.process_round()
 
@@ -145,10 +155,14 @@ class TestAttackAction(unittest.TestCase):
 
         engine = CombatEngine([attacker, defender], round_time=0)
         engine.queue_action(attacker, AttackAction(attacker, defender))
-        with patch("world.system.state_manager.apply_regen"), \
-             patch("world.system.state_manager.get_effective_stat", return_value=0), \
-             patch("random.randint", return_value=0), \
-             patch("combat.combat_actions.roll_dice_string", side_effect=[2, 3]) as mock_roll:
+        with (
+            patch("world.system.state_manager.apply_regen"),
+            patch("world.system.state_manager.get_effective_stat", return_value=0),
+            patch("random.randint", return_value=0),
+            patch(
+                "combat.combat_actions.roll_dice_string", side_effect=[2, 3]
+            ) as mock_roll,
+        ):
             engine.start_round()
             engine.process_round()
 
@@ -164,14 +178,17 @@ class TestAttackAction(unittest.TestCase):
 
         engine = CombatEngine([attacker, defender], round_time=0)
         engine.queue_action(attacker, AttackAction(attacker, defender))
-        with patch("world.system.state_manager.apply_regen"), \
-             patch("world.system.stat_manager.check_hit", return_value=False), \
-             patch("random.randint", return_value=0):
+        with (
+            patch("world.system.state_manager.apply_regen"),
+            patch("world.system.stat_manager.check_hit", return_value=False),
+            patch("random.randint", return_value=0),
+        ):
             engine.start_round()
             engine.process_round()
 
         calls = [c.args[0] for c in attacker.location.msg_contents.call_args_list]
         self.assertTrue(any("fists" in msg for msg in calls))
+
 
 def test_npc_attack_uses_natural_weapon(self):
     attacker = Dummy()
@@ -187,9 +204,11 @@ def test_npc_attack_uses_natural_weapon(self):
     engine = CombatEngine([attacker, defender], round_time=0)
     engine.queue_action(attacker, AttackAction(attacker, defender))
 
-    with patch("world.system.state_manager.apply_regen"), \
-         patch("world.system.state_manager.get_effective_stat", return_value=0), \
-         patch("random.randint", return_value=0):
+    with (
+        patch("world.system.state_manager.apply_regen"),
+        patch("world.system.state_manager.get_effective_stat", return_value=0),
+        patch("random.randint", return_value=0),
+    ):
         engine.start_round()
         instance.process_round()
 
@@ -206,6 +225,7 @@ def test_barehand_attack_mentions_fists():
     attacker.at_emote.assert_called()
     msg = attacker.at_emote.call_args[0][0]
     assert "fists" in msg
+
 
 class TestCombatVictory(unittest.TestCase):
     def test_handle_defeat_removes_participant(self):
@@ -231,9 +251,11 @@ class TestCombatVictory(unittest.TestCase):
         engine = CombatEngine([a, b, c], round_time=0)
         engine.queue_action(a, KillAction(a, b))
 
-        with patch("world.system.state_manager.apply_regen"), \
-             patch("random.randint", return_value=0), \
-             patch("evennia.utils.delay"):
+        with (
+            patch("world.system.state_manager.apply_regen"),
+            patch("random.randint", return_value=0),
+            patch("evennia.utils.delay"),
+        ):
             engine.start_round()
             engine.process_round()
 
@@ -305,8 +327,6 @@ class TestNPCBehaviors(unittest.TestCase):
         npc.on_low_hp.assert_called()
 
 
-
-
 class TestSpellExample(unittest.TestCase):
     def test_spell_action_calls_cast(self):
         caster = Dummy()
@@ -315,7 +335,10 @@ class TestSpellExample(unittest.TestCase):
         caster.cast_spell = MagicMock()
         engine = CombatEngine([caster, target], round_time=0)
         engine.queue_action(caster, SpellAction(caster, "fireball", target))
-        with patch("world.system.state_manager.apply_regen"), patch("random.randint", return_value=0):
+        with (
+            patch("world.system.state_manager.apply_regen"),
+            patch("random.randint", return_value=0),
+        ):
             engine.start_round()
             engine.process_round()
         caster.cast_spell.assert_called_with("fireball", target)
@@ -333,10 +356,12 @@ def test_auto_attack_uses_combat_target():
 
     engine = CombatEngine([attacker, defender], round_time=0)
 
-    with patch("world.system.state_manager.apply_regen"), \
-         patch("world.system.state_manager.get_effective_stat", return_value=0), \
-         patch("evennia.utils.delay"), \
-         patch("random.randint", return_value=0):
+    with (
+        patch("world.system.state_manager.apply_regen"),
+        patch("world.system.state_manager.get_effective_stat", return_value=0),
+        patch("evennia.utils.delay"),
+        patch("random.randint", return_value=0),
+    ):
         engine.start_round()
         instance.process_round()
         assert defender.hp == 1
@@ -357,11 +382,13 @@ def test_haste_grants_extra_attacks():
 
     engine = CombatEngine([attacker, defender], round_time=0)
 
-    with patch("world.system.state_manager.apply_regen"), \
-         patch("world.system.state_manager.get_effective_stat") as mock_get, \
-         patch("evennia.utils.delay"), \
-         patch("combat.combat_utils.roll_evade", return_value=False), \
-         patch("world.system.stat_manager.randint", return_value=1):
+    with (
+        patch("world.system.state_manager.apply_regen"),
+        patch("world.system.state_manager.get_effective_stat") as mock_get,
+        patch("evennia.utils.delay"),
+        patch("combat.combat_utils.roll_evade", return_value=False),
+        patch("world.system.stat_manager.randint", return_value=1),
+    ):
 
         def getter(obj, stat):
             if obj is attacker and stat == "haste":
@@ -387,15 +414,19 @@ def test_npc_damage_dice_with_bonus():
     engine = CombatEngine([attacker, defender], round_time=0)
     engine.queue_action(attacker, AttackAction(attacker, defender))
 
-    with patch("world.system.state_manager.apply_regen"), \
-         patch("world.system.state_manager.get_effective_stat", return_value=0), \
-         patch("world.system.stat_manager.check_hit", return_value=True), \
-         patch("world.system.stat_manager.roll_crit", return_value=False), \
-         patch("combat.engine.combat_math.roll_evade", return_value=False), \
-         patch("combat.engine.combat_math.roll_parry", return_value=False), \
-         patch("combat.engine.combat_math.roll_block", return_value=False), \
-         patch("combat.engine.combat_math.roll_dice_string", return_value=4) as mock_roll, \
-         patch("evennia.utils.delay"):
+    with (
+        patch("world.system.state_manager.apply_regen"),
+        patch("world.system.state_manager.get_effective_stat", return_value=0),
+        patch("world.system.stat_manager.check_hit", return_value=True),
+        patch("world.system.stat_manager.roll_crit", return_value=False),
+        patch("combat.engine.combat_math.roll_evade", return_value=False),
+        patch("combat.engine.combat_math.roll_parry", return_value=False),
+        patch("combat.engine.combat_math.roll_block", return_value=False),
+        patch(
+            "combat.engine.combat_math.roll_dice_string", return_value=4
+        ) as mock_roll,
+        patch("evennia.utils.delay"),
+    ):
         engine.start_round()
         engine.process_round()
 
@@ -412,15 +443,19 @@ def test_npc_damage_dice_fallback_to_2d6():
     engine = CombatEngine([attacker, defender], round_time=0)
     engine.queue_action(attacker, AttackAction(attacker, defender))
 
-    with patch("world.system.state_manager.apply_regen"), \
-         patch("world.system.state_manager.get_effective_stat", return_value=0), \
-         patch("world.system.stat_manager.check_hit", return_value=True), \
-         patch("world.system.stat_manager.roll_crit", return_value=False), \
-         patch("combat.engine.combat_math.roll_evade", return_value=False), \
-         patch("combat.engine.combat_math.roll_parry", return_value=False), \
-         patch("combat.engine.combat_math.roll_block", return_value=False), \
-         patch("combat.engine.combat_math.roll_dice_string", return_value=1) as mock_roll, \
-         patch("evennia.utils.delay"):
+    with (
+        patch("world.system.state_manager.apply_regen"),
+        patch("world.system.state_manager.get_effective_stat", return_value=0),
+        patch("world.system.stat_manager.check_hit", return_value=True),
+        patch("world.system.stat_manager.roll_crit", return_value=False),
+        patch("combat.engine.combat_math.roll_evade", return_value=False),
+        patch("combat.engine.combat_math.roll_parry", return_value=False),
+        patch("combat.engine.combat_math.roll_block", return_value=False),
+        patch(
+            "combat.engine.combat_math.roll_dice_string", return_value=1
+        ) as mock_roll,
+        patch("evennia.utils.delay"),
+    ):
         engine.start_round()
         engine.process_round()
 
@@ -438,8 +473,10 @@ def test_round_output_blank_line():
     engine = CombatEngine([attacker, defender], round_time=0)
     engine.queue_action(attacker, AttackAction(attacker, defender))
 
-    with patch("world.system.state_manager.apply_regen"), \
-         patch("random.randint", return_value=0):
+    with (
+        patch("world.system.state_manager.apply_regen"),
+        patch("random.randint", return_value=0),
+    ):
         engine.start_round()
         engine.process_round()
 
@@ -459,7 +496,10 @@ def test_round_output_multiple_combatants_separated():
     engine = CombatEngine([a, b, c], round_time=0)
     engine.queue_action(a, AttackAction(a, b))
 
-    with patch("world.system.state_manager.apply_regen"), patch("random.randint", return_value=0):
+    with (
+        patch("world.system.state_manager.apply_regen"),
+        patch("random.randint", return_value=0),
+    ):
         engine.start_round()
         engine.process_round()
 
@@ -488,7 +528,7 @@ def test_end_combat_broadcasts_room_message():
         instance.remove_combatant(b)
         instance.end_combat("done")
 
-    room.msg_contents.assert_any_call("Combat ends: done")
+    room.msg_contents.assert_not_called()
 
 
 def test_npc_death_flow_keeps_combat_active_until_end():
@@ -570,7 +610,4 @@ def test_end_combat_suppresses_no_active_fighters_reason():
     with patch.object(CombatRoundManager, "get", return_value=manager):
         instance.end_combat("No active fighters remaining")
 
-    calls = [c.args[0] for c in room.msg_contents.call_args_list]
-    assert "Combat ends:" in calls
-    assert all("No active fighters remaining" not in msg for msg in calls)
-
+    room.msg_contents.assert_not_called()


### PR DESCRIPTION
## Summary
- don't broadcast 'Combat ends' after combat cleanup
- remove expectations of that message from combat flow tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685de18fa860832c99b9a194eb1cc09f