### PR TITLE
Fix NPC deletion timing

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -1126,16 +1126,18 @@ class NPC(Character):
         as ``npc_vnum`` when available.
         """
         if not self.location or self.attributes.get("_dead"):
-            return
+            return None
 
         from world.mechanics import on_death_manager
 
-        on_death_manager.handle_death(self, attacker)
+        corpse = on_death_manager.handle_death(self, attacker)
 
         if attacker and getattr(attacker.db, "combat_target", None) is self:
             attacker.db.combat_target = None
 
         self.delete()
+
+        return corpse
 
     # property to mimic weapons
     @property


### PR DESCRIPTION
## Summary
- ensure NPCs delete after corpse creation

## Testing
- `pytest typeclasses/tests/test_combat_engine.py::TestCombatDeath::test_npc_on_death_sets_flag_and_moves_out -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685de58d96d0832c8fc15d36364872fe