### PR TITLE
Clarify NPC death return

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -1124,6 +1124,11 @@ class NPC(Character):
 
         The corpse created during this process stores this NPC's ``vnum``
         as ``npc_vnum`` when available.
+
+        Returns
+        -------
+        object or None
+            The newly created corpse or ``None`` if no corpse was made.
         """
         if not self.location or self.attributes.get("_dead"):
             return None


### PR DESCRIPTION
## Summary
- document corpse return for `NPC.on_death`

## Testing
- `pytest -q` *(fails: KeyboardInterrupt, 560 failed)*

------
https://chatgpt.com/codex/tasks/task_e_685de90b95a0832c910bf920f6b73270