### PR TITLE
Implement spawn manager death tracking

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -1125,6 +1125,9 @@ class NPC(Character):
         The corpse created during this process stores this NPC's ``vnum``
         as ``npc_vnum`` when available.
 
+        Respawn timing is based on when this method records the death in the
+        global :class:`~scripts.spawn_manager.SpawnManager`.
+
         Returns
         -------
         object or None
@@ -1139,6 +1142,12 @@ class NPC(Character):
 
         if attacker and getattr(attacker.db, "combat_target", None) is self:
             attacker.db.combat_target = None
+
+        from utils.script_utils import get_spawn_manager
+
+        manager = get_spawn_manager()
+        if manager and hasattr(manager, "record_death"):
+            manager.record_death(self.db.prototype_key, self.db.spawn_room)
 
         self.delete()
 

--- a/typeclasses/tests/test_spawn_manager.py
+++ b/typeclasses/tests/test_spawn_manager.py
@@ -146,3 +146,43 @@ class TestSpawnManager(EvenniaTest):
             with patch("scripts.spawn_manager.time.time", return_value=1007):
                 self.script.at_repeat()
             self.assertEqual(len([o for o in self.room1.contents if o.key == "goblin"]), 2)
+
+    def test_respawn_delay_uses_death_time(self):
+        proto = {
+            "vnum": self.room1.db.room_id,
+            "area": "zone",
+            "spawns": [
+                {
+                    "prototype": "goblin",
+                    "max_spawns": 2,
+                    "spawn_interval": 5,
+                    "location": f"#{self.room1.db.room_id}",
+                }
+            ],
+        }
+        with patch("evennia.prototypes.spawner.spawn", side_effect=self._fake_spawn), patch(
+            "evennia.utils.delay",
+            lambda t, func, *a, **kw: None,
+        ), patch(
+            "world.prototypes.get_npc_prototypes",
+            return_value={"goblin": {"key": "goblin"}},
+        ):
+            with patch("scripts.spawn_manager.time.time", return_value=1000):
+                self.script.register_room_spawn(proto)
+                self.script.at_start()
+
+            npc = [o for o in self.room1.contents if o.key == "goblin"][0]
+            npc.delete()
+
+            with patch("scripts.spawn_manager.time.time", return_value=1001):
+                self.script.record_death("goblin", self.room1)
+
+            # not enough time since death
+            with patch("scripts.spawn_manager.time.time", return_value=1005):
+                self.script.at_repeat()
+            self.assertEqual(len([o for o in self.room1.contents if o.key == "goblin"]), 1)
+
+            # enough time since death
+            with patch("scripts.spawn_manager.time.time", return_value=1006):
+                self.script.at_repeat()
+            self.assertEqual(len([o for o in self.room1.contents if o.key == "goblin"]), 2)


### PR DESCRIPTION
## Summary
- track deaths in `SpawnManager` so respawns wait on last NPC death
- call `record_death` when NPCs die
- clarify death-based respawn timing
- test `record_death` behaviour

## Testing
- `pytest -q typeclasses/tests/test_spawn_manager.py::TestSpawnManager::test_respawn_delay_uses_death_time` *(fails: OperationalError - no such table)*

------
https://chatgpt.com/codex/tasks/task_e_685dec5630f8832cb2f81b58f167ee78