### PR TITLE
Expose spawn_corpse on on_death_manager

### DIFF
--- a/typeclasses/tests/test_active_fighters.py
+++ b/typeclasses/tests/test_active_fighters.py
@@ -59,7 +59,7 @@ class TestDefeatRewards(unittest.TestCase):
         engine = CombatEngine([attacker, defender], round_time=0)
         inst = CombatInstance(1, engine, {attacker, defender})
         self.manager.combats[1] = inst
-        with patch('world.mechanics.on_death_manager.spawn_corpse') as mock_corpse, \
+        with patch('world.mechanics.death_handlers.spawn_corpse') as mock_corpse, \
              patch.object(CombatEngine, 'award_experience') as mock_xp:
             engine.processor.handle_defeat(defender, attacker)
             mock_corpse.assert_called()

--- a/typeclasses/tests/test_combat_end_order.py
+++ b/typeclasses/tests/test_combat_end_order.py
@@ -46,7 +46,7 @@ class TestCombatEndOrder(EvenniaTest):
 
         with (
             patch("world.mechanics.on_death_manager.handle_death", side_effect=wrapped_handle),
-            patch("world.mechanics.on_death_manager.spawn_corpse", return_value=corpse),
+            patch("world.mechanics.death_handlers.spawn_corpse", return_value=corpse),
             patch("combat.engine.damage_processor.delay"),
             patch("world.system.state_manager.apply_regen"),
             patch("world.system.state_manager.check_level_up"),

--- a/typeclasses/tests/test_combat_engine.py
+++ b/typeclasses/tests/test_combat_engine.py
@@ -667,7 +667,7 @@ class TestCombatDeath(EvenniaTest):
         corpse = create.create_object('typeclasses.objects.Object', key='corpse', location=None)
 
         with patch('world.system.state_manager.check_level_up'), \
-             patch('world.mechanics.on_death_manager.spawn_corpse', return_value=corpse) as mock_spawn:
+             patch('world.mechanics.death_handlers.spawn_corpse', return_value=corpse) as mock_spawn:
             npc.at_damage(self.char1, 0)
 
         mock_spawn.assert_called_once_with(npc, self.char1)

--- a/world/mechanics/on_death_manager.py
+++ b/world/mechanics/on_death_manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from world.mechanics.death_handlers import get_handler, IDeathHandler
+from combat.corpse_creation import spawn_corpse
 
 
 def handle_death(victim, killer=None, handler: IDeathHandler | None = None):


### PR DESCRIPTION
## Summary
- export `spawn_corpse` from `on_death_manager`
- patch tests to use `world.mechanics.death_handlers.spawn_corpse`

## Testing
- `pytest -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_685defcdb54c832c9541c5f72e2ea649