### PR TITLE
Fix corpse decay script

### DIFF
--- a/typeclasses/objects.py
+++ b/typeclasses/objects.py
@@ -440,7 +440,6 @@ class Corpse(Object):
             script = self.scripts.add(
                 "typeclasses.scripts.DecayScript",
                 key="decay",
-                start_delay=True,
                 room_only=not settings.ALLOW_CORPSE_DECAY_IN_INVENTORY,
                 autostart=False,
             )
@@ -458,7 +457,6 @@ class Corpse(Object):
             script = self.scripts.add(
                 "typeclasses.scripts.DecayScript",
                 key="decay",
-                start_delay=True,
                 room_only=not settings.ALLOW_CORPSE_DECAY_IN_INVENTORY,
                 autostart=False,
             )


### PR DESCRIPTION
## Summary
- remove `start_delay=True` from corpse decay script creation

## Testing
- `pytest -q` *(fails: django OperationalError: no such table)*

------
https://chatgpt.com/codex/tasks/task_e_685dfa559b28832ca08013456a823e6b