### PR TITLE
Remove unused make_corpse import

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -12,7 +12,6 @@ from evennia.contrib.game_systems.cooldowns import CooldownHandler
 from evennia.prototypes.spawner import spawn
 from utils.currency import to_copper, from_copper, format_wallet
 from utils import normalize_slot
-from utils.mob_utils import make_corpse
 from utils.slots import SLOT_ORDER
 from collections.abc import Mapping
 import math


### PR DESCRIPTION
## Summary
- clean up Character typeclass by dropping unused `make_corpse` import

## Testing
- `pytest -q` *(fails: 292 failed, 23 passed, 4 warnings, 1 error)*

------
https://chatgpt.com/codex/tasks/task_e_685e0f352cc8832ca9e8d14c2d69b5f3