### PR TITLE
Fix unused import in on_death_manager

### DIFF
--- a/world/mechanics/on_death_manager.py
+++ b/world/mechanics/on_death_manager.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from world.mechanics.death_handlers import get_handler, IDeathHandler
-from combat.corpse_creation import spawn_corpse
 
 
 def handle_death(victim, killer=None, handler: IDeathHandler | None = None):


### PR DESCRIPTION
## Summary
- remove unused `spawn_corpse` import

## Testing
- `pytest -q` *(fails: OperationalError - no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_685e1210ce7c832cac7af86a1825f67c