### PR TITLE
Refactor corpse creation logic

### DIFF
--- a/typeclasses/tests/test_active_fighters.py
+++ b/typeclasses/tests/test_active_fighters.py
@@ -59,7 +59,7 @@ class TestDefeatRewards(unittest.TestCase):
         engine = CombatEngine([attacker, defender], round_time=0)
         inst = CombatInstance(1, engine, {attacker, defender})
         self.manager.combats[1] = inst
-        with patch('world.mechanics.corpse_manager.create_corpse') as mock_corpse, \
+        with patch('world.mechanics.corpse_manager.make_corpse') as mock_corpse, \
              patch.object(CombatEngine, 'award_experience') as mock_xp:
             engine.processor.handle_defeat(defender, attacker)
             mock_corpse.assert_called()

--- a/typeclasses/tests/test_combat_end_order.py
+++ b/typeclasses/tests/test_combat_end_order.py
@@ -46,9 +46,7 @@ class TestCombatEndOrder(EvenniaTest):
 
         with (
             patch("world.mechanics.on_death_manager.handle_death", side_effect=wrapped_handle),
-            patch("world.mechanics.corpse_manager.create_corpse", return_value=corpse),
-            patch("world.mechanics.corpse_manager.apply_loot"),
-            patch("world.mechanics.corpse_manager.finalize_corpse"),
+            patch("world.mechanics.corpse_manager.make_corpse", return_value=corpse),
             patch("combat.engine.damage_processor.delay"),
             patch("world.system.state_manager.apply_regen"),
             patch("world.system.state_manager.check_level_up"),

--- a/typeclasses/tests/test_combat_engine.py
+++ b/typeclasses/tests/test_combat_engine.py
@@ -667,9 +667,7 @@ class TestCombatDeath(EvenniaTest):
         corpse = create.create_object('typeclasses.objects.Object', key='corpse', location=None)
 
         with patch('world.system.state_manager.check_level_up'), \
-             patch('world.mechanics.corpse_manager.create_corpse', return_value=corpse) as mock_spawn, \
-             patch('world.mechanics.corpse_manager.apply_loot'), \
-             patch('world.mechanics.corpse_manager.finalize_corpse'):
+             patch('world.mechanics.corpse_manager.make_corpse', return_value=corpse) as mock_spawn:
             npc.at_damage(self.char1, 0)
 
         mock_spawn.assert_called_once_with(npc)

--- a/utils/mob_utils.py
+++ b/utils/mob_utils.py
@@ -85,75 +85,9 @@ def mobprogs_to_triggers(mobprogs: list[dict]) -> Dict[str, list[dict]]:
 
 
 def make_corpse(npc):
-    """Create a corpse object for ``npc`` and transfer belongings.
+    """Create a corpse for ``npc`` using :mod:`corpse_manager`."""
 
-    If ``npc.db.vnum`` is defined, it will be copied to the corpse as the
-    ``npc_vnum`` Attribute.
-    """
+    from world.mechanics import corpse_manager
 
-    from evennia import create_object
-    from world.mob_constants import ACTFLAGS
-
-    if not npc or not npc.location:
-        return None
-
-    # avoid multiple corpses if on_death is called repeatedly for the same npc
-    existing = [
-        obj
-        for obj in npc.location.contents
-        if obj.is_typeclass("typeclasses.objects.Corpse", exact=False)
-        and obj.db.corpse_of_id == npc.dbref
-    ]
-    if existing:
-        return existing[0]
-
-    attrs = [("corpse_of", npc.key), ("corpse_of_id", npc.dbref), ("is_corpse", True)]
-    if getattr(npc.db, "vnum", None) is not None:
-        attrs.append(("npc_vnum", npc.db.vnum))
-    decay = getattr(npc.db, "corpse_decay_time", None)
-    if decay is None:
-        from django.conf import settings
-        from random import randint
-
-        decay = randint(
-            getattr(settings, "CORPSE_DECAY_MIN", 5),
-            getattr(settings, "CORPSE_DECAY_MAX", 10),
-        )
-    attrs.append(("decay_time", decay))
-    corpse = create_object(
-        "typeclasses.objects.Corpse",
-        key=f"corpse of {npc.key}",
-        location=npc.location,
-        attributes=attrs,
-    )
-    # store the vnum of the NPC on the corpse for bookkeeping
-    if hasattr(npc.db, "vnum"):
-        corpse.db.npc_vnum = npc.db.vnum
-
-    no_loot = ACTFLAGS.NOLOOT.value in (npc.db.actflags or [])
-
-    if not no_loot:
-        # move carried items
-        for obj in list(npc.contents):
-            obj.location = corpse
-
-        moved = set()
-        for item in npc.equipment.values():
-            if item and item not in moved:
-                item.location = corpse
-                moved.add(item)
-
-    # drop carried coins unless flagged NOLOOT
-    if not no_loot:
-        for coin, amt in (npc.db.coins or {}).items():
-            if int(amt):
-                pile = create_object(
-                    "typeclasses.objects.CoinPile",
-                    key=f"{coin} coins",
-                    location=corpse,
-                )
-                pile.db.coin_type = coin
-                pile.db.amount = int(amt)
-
-    return corpse
+    return corpse_manager.make_corpse(npc)
 

--- a/world/mechanics/death_handlers.py
+++ b/world/mechanics/death_handlers.py
@@ -82,11 +82,7 @@ class DefaultDeathHandler(IDeathHandler):
                 None,
             )
             if not corpse:
-                corpse = corpse_manager.create_corpse(victim)
-                if inherits_from(victim, "typeclasses.characters.NPC"):
-                    corpse_manager.apply_loot(victim, corpse, killer)
-                corpse_manager.finalize_corpse(victim, corpse)
-                corpse.location = location
+                corpse = corpse_manager.make_corpse(victim, killer)
 
         try:
             victim.at_death(killer)

--- a/world/tests/test_combat_engine_minimal.py
+++ b/world/tests/test_combat_engine_minimal.py
@@ -158,15 +158,13 @@ class TestCombatEngineMinimal(unittest.TestCase):
         with patch("world.system.state_manager.apply_regen"), patch(
             "combat.damage_processor.delay"
         ), patch("random.randint", return_value=0), patch(
-            "world.mechanics.corpse_manager.create_corpse", return_value=MagicMock(contents=[])
-        ) as mock_create, patch(
-            "world.mechanics.corpse_manager.apply_loot",
-            side_effect=lambda victim, corp, killer=None: corp.contents.extend(victim.loot),
-        ), patch("world.mechanics.corpse_manager.finalize_corpse"):
+            "world.mechanics.corpse_manager.make_corpse",
+            side_effect=lambda victim, killer=None: MagicMock(contents=list(victim.loot)),
+        ) as mock_make:
             engine.start_round()
             engine.process_round()
 
-        corpse = mock_create.return_value
+        corpse = mock_make.return_value
         self.assertIn(loot, corpse.contents)
         defender.drop_loot.assert_called_once_with(attacker)
 


### PR DESCRIPTION
## Summary
- delegate utils.mob_utils.make_corpse to world.mechanics.corpse_manager
- add new corpse_manager.make_corpse convenience helper
- use new function in default death handler
- update unit tests for the new API

## Testing
- `pytest -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_685e26108a3c832ca815f50e15ff80f2