### PR TITLE
Fix corpse decay script initiation

### DIFF
--- a/typeclasses/objects.py
+++ b/typeclasses/objects.py
@@ -440,11 +440,10 @@ class Corpse(Object):
             script = self.scripts.add(
                 "typeclasses.scripts.DecayScript",
                 key="decay",
-                room_only=not settings.ALLOW_CORPSE_DECAY_IN_INVENTORY,
-                autostart=False,
             )
             if isinstance(script, list):
                 script = script[0]
+            script.db.room_only = not settings.ALLOW_CORPSE_DECAY_IN_INVENTORY
             script.interval = int(decay) * 60
             script.start()
 
@@ -457,11 +456,10 @@ class Corpse(Object):
             script = self.scripts.add(
                 "typeclasses.scripts.DecayScript",
                 key="decay",
-                room_only=not settings.ALLOW_CORPSE_DECAY_IN_INVENTORY,
-                autostart=False,
             )
             if isinstance(script, list):
                 script = script[0]
+            script.db.room_only = not settings.ALLOW_CORPSE_DECAY_IN_INVENTORY
             script.interval = int(decay) * 60
             script.start()
 

--- a/typeclasses/scripts.py
+++ b/typeclasses/scripts.py
@@ -97,10 +97,11 @@ class DecayScript(Script):
 
     def at_script_creation(self):
         self.key = "decay"
-        self.desc = "Delete the object after a delay"
+        self.interval = 300  # default decay interval in seconds
+        self.repeats = 1
+        self.start_delay = True
         self.persistent = True
-        # keep checking until we delete the object
-        self.repeats = -1
+        self.desc = "Causes corpses to decay and disappear."
         self.db.room_only = False
 
     def at_repeat(self):


### PR DESCRIPTION
## Summary
- fix DecayScript defaults and start parameters
- update Corpse typeclass to attach decay script without unsupported kwargs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685e1a22be08832c9e3d1fc0171a0ccf