### PR TITLE
Implement search_first helper and use it

### DIFF
--- a/commands/achievements.py
+++ b/commands/achievements.py
@@ -66,7 +66,7 @@ class CmdAwardAchievement(Command):
         if not ach:
             self.msg("Unknown achievement.")
             return
-        target = self.caller.search(player_name, global_search=True)
+        target = self.caller.search_first(player_name, global_search=True)
         if not target:
             return
         earned = target.db.achievements or []

--- a/commands/admin/__init__.py
+++ b/commands/admin/__init__.py
@@ -158,7 +158,7 @@ class CmdSetStat(Command):
             self.msg("Usage: setstat <target> <stat> <value>")
             return
         target_name, stat_key, value_str = parts
-        target = self.caller.search(target_name, global_search=True)
+        target = self.caller.search_first(target_name, global_search=True)
         if not target:
             return
         value = int(value_str)
@@ -247,7 +247,7 @@ class CmdSetAttr(Command):
             self.msg("Usage: setattr <target> <attr> <value>")
             return
         target_name, attr, value = parts
-        target = self.caller.search(target_name, global_search=True)
+        target = self.caller.search_first(target_name, global_search=True)
         if not target:
             return
         target.attributes.add(attr, value)
@@ -280,7 +280,7 @@ class CmdSetBounty(Command):
             self.msg("Usage: setbounty <target> <amount>")
             return
         target_name, amt_str = parts
-        target = self.caller.search(target_name, global_search=True)
+        target = self.caller.search_first(target_name, global_search=True)
         if not target:
             return
         target.db.bounty = int(amt_str)
@@ -305,7 +305,7 @@ class CmdSlay(Command):
         if not self.args:
             self.msg("Usage: slay <target>")
             return
-        target = self.caller.search(self.args.strip(), global_search=True)
+        target = self.caller.search_first(self.args.strip(), global_search=True)
         if not target:
             return
         if not target.traits.get("health"):
@@ -335,7 +335,7 @@ class CmdSmite(Command):
         if not self.args:
             self.msg("Usage: smite <target>")
             return
-        target = self.caller.search(self.args.strip(), global_search=True)
+        target = self.caller.search_first(self.args.strip(), global_search=True)
         if not target:
             return
         if not target.traits.get("health"):
@@ -414,7 +414,7 @@ class CmdPurge(Command):
                 caller.msg("Nothing to purge.")
             return
 
-        target = caller.search(self.args.strip(), global_search=True)
+        target = caller.search_first(self.args.strip(), global_search=True)
         if not target:
             return
         if (
@@ -477,7 +477,7 @@ class CmdForceMobReport(Command):
             self.msg("Usage: force mob report <target>")
             return
 
-        target = self.caller.search(self.args.strip())
+        target = self.caller.search_first(self.args.strip())
         if not target:
             return
 
@@ -512,7 +512,7 @@ class CmdDebugCombat(Command):
         if not self.args:
             caller.msg("Usage: @debug_combat <target>")
             return
-        target = caller.search(self.args.strip(), global_search=True)
+        target = caller.search_first(self.args.strip(), global_search=True)
         if not target:
             return
         db_in_combat = getattr(target.db, "in_combat", None)

--- a/commands/areas.py
+++ b/commands/areas.py
@@ -463,7 +463,7 @@ class CmdRReg(Command):
             room = self.caller.location
         elif len(parts) == 3:
             room_name, area_name, num_str = parts
-            room = self.caller.search(room_name, global_search=True)
+            room = self.caller.search_first(room_name, global_search=True)
             if not room:
                 return
             if not room.is_typeclass(Room, exact=False):

--- a/commands/bank.py
+++ b/commands/bank.py
@@ -108,7 +108,7 @@ class CmdBank(Command):
                 caller.msg(f"Unknown coin type: {coin}.")
                 return
             amount = amt * COIN_VALUES[coin]
-            target = caller.search(target_name, global_search=True)
+            target = caller.search_first(target_name, global_search=True)
             if not target:
                 return
             if not transfer_coins(caller, target, amount):

--- a/commands/equip.py
+++ b/commands/equip.py
@@ -28,16 +28,22 @@ class CmdWear(ContribCmdWear):
         # The following replicates the search logic of the parent command so we
         # can operate on the item before it's worn.
         if not self.rhs:
-            clothing = self.caller.search(self.lhs, candidates=self.caller.contents, quiet=True)
+            clothing = self.caller.search_first(
+                self.lhs, candidates=self.caller.contents, quiet=True
+            )
             if not clothing:
                 argslist = self.lhs.split()
                 self.lhs = argslist[0]
                 self.rhs = " ".join(argslist[1:])
-                clothing = self.caller.search(self.lhs, candidates=self.caller.contents)
+                clothing = self.caller.search_first(
+                    self.lhs, candidates=self.caller.contents
+                )
             else:
                 clothing = at_search_result(clothing, self.caller, self.lhs)
         else:
-            clothing = self.caller.search(self.lhs, candidates=self.caller.contents)
+            clothing = self.caller.search_first(
+                self.lhs, candidates=self.caller.contents
+            )
 
         if not clothing:
             return

--- a/commands/equipment.py
+++ b/commands/equipment.py
@@ -16,7 +16,7 @@ def get_equipped_item_by_name(caller, itemname):
 
     # fall back to searching by item name
     candidates = [item for item in eq.values() if item]
-    obj = caller.search(searchstr, candidates=candidates)
+    obj = caller.search_first(searchstr, candidates=candidates)
     if not obj:
         return None, None
     for slt, itm in eq.items():

--- a/commands/guilds.py
+++ b/commands/guilds.py
@@ -307,7 +307,7 @@ class CmdGAccept(Command):
         if not guild:
             self.msg("You are not in a guild.")
             return
-        target = self.caller.search(self.args.strip(), global_search=True)
+        target = self.caller.search_first(self.args.strip(), global_search=True)
         if not target:
             return
         if target.db.guild:
@@ -347,7 +347,7 @@ class _BaseAdjustHonor(Command):
             self.msg("You are not in a guild.")
             return
         parts = self.args.split(None, 1)
-        target = self.caller.search(parts[0], global_search=True)
+        target = self.caller.search_first(parts[0], global_search=True)
         if not target:
             return
         if target.db.guild != guild:
@@ -427,7 +427,7 @@ class CmdGKick(Command):
         if not guild:
             self.msg("You are not in a guild.")
             return
-        target = self.caller.search(self.args.strip(), global_search=True)
+        target = self.caller.search_first(self.args.strip(), global_search=True)
         if not target:
             return
         if target.db.guild != guild:

--- a/commands/info.py
+++ b/commands/info.py
@@ -140,7 +140,7 @@ class CmdFinger(Command):
         if not self.args or self.args.strip().lower() in {"self", "me"}:
             target = self.caller
         else:
-            target = self.caller.search(self.args.strip(), global_search=True)
+            target = self.caller.search_first(self.args.strip(), global_search=True)
             if not target:
                 return
         # gather lines of information
@@ -220,7 +220,7 @@ class CmdBounty(Command):
 
         amount = int(amount_str)
         amount_copper = amount * COIN_VALUES[coin]
-        target = self.caller.search(target_name, global_search=True)
+        target = self.caller.search_first(target_name, global_search=True)
         if not target:
             return
 
@@ -331,7 +331,7 @@ class CmdDrop(Command):
             caller.msg(f"You drop {amount} {ctype} coin{'s' if amount != 1 else ''}.")
             return
 
-        obj = caller.search(self.args, location=caller)
+        obj = caller.search_first(self.args, location=caller)
         if not obj:
             return
         obj.move_to(caller.location, quiet=True, move_type="drop")
@@ -366,7 +366,7 @@ class CmdGive(Command):
             caller.msg("Give <item|amount coin> <target>")
             return
 
-        target = caller.search(self.rhs)
+        target = caller.search_first(self.rhs)
         if not target:
             return
 
@@ -397,7 +397,7 @@ class CmdGive(Command):
             )
             return
 
-        obj = caller.search(self.lhs, location=caller)
+        obj = caller.search_first(self.lhs, location=caller)
         if not obj:
             caller.msg("You aren't carrying that.")
             return
@@ -518,7 +518,7 @@ class CmdInspect(Command):
             else:
                 obj = matches
         if not obj:
-            obj = caller.search(query)
+            obj = caller.search_first(query)
             if not obj:
                 return
 

--- a/commands/interact.py
+++ b/commands/interact.py
@@ -53,7 +53,7 @@ class CmdEat(Command):
 
     def func(self):
         caller = self.caller
-        obj = caller.search(self.args.strip(), stacked=1)
+        obj = caller.search_first(self.args.strip(), stacked=1)
         if not obj:
             return
         # stacked sometimes returns a list, so make sure it is one for consistent handling

--- a/commands/loot.py
+++ b/commands/loot.py
@@ -26,7 +26,7 @@ class CmdLoot(Command):
                 caller.msg("Loot what?")
                 return
         else:
-            target = caller.search(self.args.strip())
+            target = caller.search_first(self.args.strip())
         if not target:
             return
         if not target.is_typeclass("typeclasses.objects.Corpse", exact=False):
@@ -56,7 +56,7 @@ class CmdLootCorpse(Command):
         if not self.args:
             caller.msg("Loot what?")
             return
-        target = caller.search(self.args.strip())
+        target = caller.search_first(self.args.strip())
         if not target:
             return
         if not target.is_typeclass("typeclasses.objects.Corpse", exact=False):

--- a/commands/quests.py
+++ b/commands/quests.py
@@ -155,7 +155,7 @@ class CmdQAssign(Command):
             return
         npc_key, quest_key = parts
         quest_key = normalize_quest_key(quest_key)
-        npc = self.caller.search(npc_key, global_search=True)
+        npc = self.caller.search_first(npc_key, global_search=True)
         if not npc or npc.has_account:
             self.msg("Invalid NPC.")
             return
@@ -474,7 +474,7 @@ class CmdTalk(Command):
             self.msg("Usage: talk <npc>")
             return
 
-        npc = caller.search(self.args.strip())
+        npc = caller.search_first(self.args.strip())
         if not npc:
             return
 

--- a/commands/shops.py
+++ b/commands/shops.py
@@ -90,7 +90,9 @@ class CmdBuy(Command):
             return
 
         # we want a stack of the item, matching the parsed count
-        objs = self.caller.search(self.args, location=storage, stacked=self.count)
+        objs = self.caller.search_first(
+            self.args, location=storage, stacked=self.count
+        )
         if not objs:
             # we found nothing, or it was too vague of a search
             return
@@ -171,7 +173,9 @@ class CmdSell(Command):
             return
 
         # we want a stack of the item, matching the parsed count
-        objs = self.caller.search(self.args, location=self.caller, stacked=self.count)
+        objs = self.caller.search_first(
+            self.args, location=self.caller, stacked=self.count
+        )
         if not objs:
             # we found nothing, or it was too vague of a search
             return
@@ -262,7 +266,9 @@ class CmdDonate(Command):
         ]
 
         # we want a stack of the item, matching the parsed count
-        objs = self.caller.search(self.args, candidates=candidates, stacked=self.count)
+        objs = self.caller.search_first(
+            self.args, candidates=candidates, stacked=self.count
+        )
         if not objs:
             # we found nothing, or it was too vague of a search
             return

--- a/commands/spells.py
+++ b/commands/spells.py
@@ -108,7 +108,7 @@ class CmdCast(Command):
             return
         target = None
         if self.target:
-            target = self.caller.search(self.target)
+            target = self.caller.search_first(self.target)
             if not target:
                 return
         if target:

--- a/commands/update.py
+++ b/commands/update.py
@@ -16,7 +16,7 @@ class CmdUpdate(Command):
         if not self.args:
             caller.msg("Usage: update <target>")
             return
-        target = caller.search(self.args.strip(), global_search=True)
+        target = caller.search_first(self.args.strip(), global_search=True)
         if not target:
             return
         charclass = target.db.charclass

--- a/tests/test_search_first.py
+++ b/tests/test_search_first.py
@@ -1,0 +1,41 @@
+from unittest.mock import MagicMock
+from django.test import override_settings
+from evennia.utils.test_resources import EvenniaTest
+from evennia.utils import create
+from typeclasses.rooms import Room
+from typeclasses.objects import Corpse
+from commands.default_cmdsets import CharacterCmdSet
+
+@override_settings(DEFAULT_HOME=None)
+class TestSearchFirst(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.char1.msg = MagicMock()
+        self.char1.cmdset.add_default(CharacterCmdSet)
+        self.room = create.create_object(
+            Room, key="room", location=self.char1.location, home=self.char1.location
+        )
+        self.char1.location = self.room
+        self.c1 = create.create_object(
+            Corpse,
+            key="corpse",
+            location=self.room,
+            attributes=[("corpse_of", "goblin1")],
+        )
+        self.c2 = create.create_object(
+            Corpse,
+            key="corpse",
+            location=self.room,
+            attributes=[("corpse_of", "goblin2")],
+        )
+
+    def test_look_picks_first_corpse(self):
+        expected = self.c1.return_appearance(self.char1)
+        self.char1.execute_cmd("look corpse")
+        self.char1.msg.assert_any_call(expected)
+
+    def test_numbered_alias_still_selects(self):
+        expected = self.c2.return_appearance(self.char1)
+        self.char1.msg.reset_mock()
+        self.char1.execute_cmd("look corpse-2")
+        self.char1.msg.assert_any_call(expected)

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -219,6 +219,13 @@ class Character(TriggerMixin, ObjectParent, ClothedCharacter):
 
         return True
 
+    def search_first(self, target, candidates=None, **kwargs):
+        """Return the first match from ``search`` if any."""
+        matches = self.search(target, candidates=candidates, quiet=True, **kwargs)
+        if matches:
+            return matches[0] if isinstance(matches, list) else matches
+        return None
+
     def defense(self, damage_type=None):
         """
         Get the total armor defense from equipped items and natural defenses


### PR DESCRIPTION
## Summary
- implement `Character.search_first`
- use `search_first` across command modules
- add regression tests for corpse targeting

## Testing
- `pytest tests/test_search_first.py -q` *(fails: no such table `accounts_accountdb`)*

------
https://chatgpt.com/codex/tasks/task_e_685e2d16d6f8832c8e41203e9c51d3fe