### PR TITLE
Handle invalid combat instance cleanly

### DIFF
--- a/combat/round_manager.py
+++ b/combat/round_manager.py
@@ -11,7 +11,7 @@ from typing import Dict, List, Optional, Set
 from django.conf import settings
 
 from evennia.utils import delay
-from evennia.utils.logger import log_trace
+from evennia.utils.logger import log_trace, log_info
 import logging
 from combat.combatants import _current_hp
 from combat.events import combat_started, round_processed, combat_ended
@@ -266,11 +266,19 @@ class CombatInstance:
         self.cancel_tick()
         CombatRoundManager.get().remove_combat(self.combat_id)
 
+        send_room_msg = True
         if reason == "No active fighters remaining":
             reason = ""
+        if reason == "Invalid combat instance":
+            try:
+                log_info(reason)
+            except Exception:
+                log_trace(reason)
+            reason = ""
+            send_room_msg = False
 
         message = f"Combat ends: {reason}" if reason else "Combat ends:"
-        if room and hasattr(room, "msg_contents"):
+        if send_room_msg and room and hasattr(room, "msg_contents"):
             try:
                 room.msg_contents(message)
             except Exception:  # pragma: no cover - safety

--- a/world/tests/test_combat_end_invalid_instance.py
+++ b/world/tests/test_combat_end_invalid_instance.py
@@ -1,0 +1,23 @@
+import unittest
+from unittest.mock import MagicMock, patch
+from combat.round_manager import CombatInstance
+
+
+class TestCombatEndInvalidInstance(unittest.TestCase):
+    def test_room_message_skipped_on_invalid_instance(self):
+        engine = MagicMock()
+        engine.participants = []
+        inst = CombatInstance(1, engine, set())
+        inst.sync_participants = MagicMock()
+        inst.room = MagicMock()
+        with (
+            patch('combat.round_manager.CombatRoundManager.get') as mock_get,
+            patch('combat.round_manager.log_info') as mock_info,
+            patch('combat.round_manager.log_trace') as mock_trace,
+        ):
+            mock_get.return_value = MagicMock(remove_combat=MagicMock())
+            inst.end_combat("Invalid combat instance")
+        inst.room.msg_contents.assert_not_called()
+        mock_info.assert_called_with("Invalid combat instance")
+        mock_trace.assert_not_called()
+


### PR DESCRIPTION
## Summary
- skip room message for invalid combat instances
- log invalid combat reason
- add regression test for invalid combat termination

## Testing
- `pytest world/tests/test_combat_end_invalid_instance.py::TestCombatEndInvalidInstance::test_room_message_skipped_on_invalid_instance -q`
- `pytest tests/test_redit_spawn_integration.py -q` *(fails: OperationalError no such table)*

------
https://chatgpt.com/codex/tasks/task_e_685e32c7a4fc832cacfa3467fae1448f