### PR TITLE
Add global corpse decay manager

### DIFF
--- a/server/conf/at_server_startstop.py
+++ b/server/conf/at_server_startstop.py
@@ -151,12 +151,25 @@ def at_server_start():
         elif getattr(script.db, "_paused_time", None):
             script.unpause()
 
-    script = get_spawn_manager()
-    if not script or script.typeclass_path != "scripts.spawn_manager.SpawnManager":
+    spawn_script = get_spawn_manager()
+    if not spawn_script or spawn_script.typeclass_path != "scripts.spawn_manager.SpawnManager":
+        if spawn_script:
+            spawn_script.delete()
+        spawn_script = create.create_script(
+            "scripts.spawn_manager.SpawnManager", key="spawn_manager"
+        )
+    else:
+        if not spawn_script.is_active:
+            spawn_script.start()
+        elif getattr(spawn_script.db, "_paused_time", None):
+            spawn_script.unpause()
+
+    script = ScriptDB.objects.filter(db_key="corpse_decay").first()
+    if not script or script.typeclass_path != "typeclasses.scripts.CorpseDecayManager":
         if script:
             script.delete()
         script = create.create_script(
-            "scripts.spawn_manager.SpawnManager", key="spawn_manager"
+            "typeclasses.scripts.CorpseDecayManager", key="corpse_decay"
         )
     else:
         if not script.is_active:
@@ -164,8 +177,8 @@ def at_server_start():
         elif getattr(script.db, "_paused_time", None):
             script.unpause()
 
-    if hasattr(script, "reload_spawns"):
-        script.reload_spawns()
+    if hasattr(spawn_script, "reload_spawns"):
+        spawn_script.reload_spawns()
 
     # Ensure mob database script exists
     get_mobdb()

--- a/world/mechanics/corpse_manager.py
+++ b/world/mechanics/corpse_manager.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from evennia import create_object
 from evennia.utils import inherits_from, logger
 from evennia.prototypes.spawner import spawn
+import time
 
 from utils.currency import to_copper, from_copper, format_wallet
 from world.mob_constants import BODYPARTS
@@ -42,6 +43,11 @@ def create_corpse(victim):
         location=None,
         attributes=[("decay_time", decay), ("is_corpse", True)],
     )
+
+    corpse.tags.add("corpse", category="corpse_decay")
+    corpse.db.created_at = time.time()
+    if corpse.db.decay_time is None:
+        corpse.db.decay_time = 300
 
     return corpse
 


### PR DESCRIPTION
## Summary
- implement `CorpseDecayManager` that periodically removes corpses
- tag corpses on creation and track their decay time
- adjust corpse creation utilities
- start the manager from server startup

## Testing
- `pytest -q` *(fails: OperationalError no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_685e32cd07fc832c9b3170de4a8a896a