### PR TITLE
Ensure SpawnManager runs repeatedly without start delay

### DIFF
--- a/scripts/spawn_manager.py
+++ b/scripts/spawn_manager.py
@@ -35,6 +35,8 @@ class SpawnManager(Script):
         # run frequently so short spawn intervals are respected
         self.interval = 5
         self.persistent = True
+        self.repeats = -1
+        self.start_delay = False
         self.db.entries = self.db.entries or []
         self.db.batch_size = self.db.batch_size or 1
         self.db.tick_count = self.db.tick_count or 0


### PR DESCRIPTION
## Summary
- set `self.repeats=-1` and `self.start_delay=False` so SpawnManager keeps running immediately

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_685e3787b8f4832c90ada71c81a568fb