### PR TITLE
Improve spawn tracking

### DIFF
--- a/commands/npc_builder.py
+++ b/commands/npc_builder.py
@@ -1255,7 +1255,7 @@ class CmdMSpawn(Command):
         from utils.script_utils import get_spawn_manager
         script = get_spawn_manager()
         if script and hasattr(script, "record_spawn"):
-            script.record_spawn(proto_key, self.caller.location)
+            script.record_spawn(proto_key, self.caller.location, npc_id=obj.id)
 
         self.msg(f"Spawned {obj.key}.")
 

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -1130,7 +1130,7 @@ class NPC(Character):
 
         manager = get_spawn_manager()
         if manager and hasattr(manager, "record_death"):
-            manager.record_death(self.db.prototype_key, self.db.spawn_room)
+            manager.record_death(self.db.prototype_key, self.db.spawn_room, npc_id=self.id)
 
         self.delete()
 

--- a/typeclasses/tests/test_spawn_manager.py
+++ b/typeclasses/tests/test_spawn_manager.py
@@ -131,6 +131,8 @@ class TestSpawnManager(EvenniaTest):
 
             npc = [o for o in self.room1.contents if o.key == "goblin"][0]
             npc.delete()
+            with patch("scripts.spawn_manager.time.time", return_value=1001):
+                self.script.record_death("goblin", self.room1, npc_id=npc.id)
 
             # interval not reached, no spawn
             with patch("scripts.spawn_manager.time.time", return_value=1003):
@@ -175,7 +177,7 @@ class TestSpawnManager(EvenniaTest):
             npc.delete()
 
             with patch("scripts.spawn_manager.time.time", return_value=1001):
-                self.script.record_death("goblin", self.room1)
+                self.script.record_death("goblin", self.room1, npc_id=npc.id)
 
             # not enough time since death
             with patch("scripts.spawn_manager.time.time", return_value=1005):

--- a/world/tests/test_spawn_manager.py
+++ b/world/tests/test_spawn_manager.py
@@ -25,7 +25,8 @@ class TestSpawnManager(EvenniaTest):
                 "room": 1,
                 "max_count": 2,
                 "respawn_rate": 5,
-                "last_spawn": 0,
+                "spawned": [],
+                "dead_timestamps": [],
             }
         ]
         npc = create_object(BaseNPC, key="basic_merchant")
@@ -133,7 +134,8 @@ class TestSpawnManager(EvenniaTest):
                 "room_id": 1,
                 "max_count": 1,
                 "respawn_rate": 5,
-                "last_spawn": 0,
+                "spawned": [],
+                "dead_timestamps": [],
             }
         ]
         with mock.patch("scripts.spawn_manager.spawn_from_vnum") as m_spawn:
@@ -176,7 +178,8 @@ class TestSpawnManager(EvenniaTest):
                 "room_id": 1,
                 "max_count": 1,
                 "respawn_rate": 5,
-                "last_spawn": 0,
+                "spawned": [],
+                "dead_timestamps": [],
             },
             {
                 "prototype": "b",
@@ -184,7 +187,8 @@ class TestSpawnManager(EvenniaTest):
                 "room_id": 2,
                 "max_count": 1,
                 "respawn_rate": 5,
-                "last_spawn": 0,
+                "spawned": [],
+                "dead_timestamps": [],
             },
         ]
         with mock.patch.object(self.script, "_spawn") as m_spawn, \
@@ -212,7 +216,8 @@ class TestSpawnManager(EvenniaTest):
                 "room_id": 1,
                 "max_count": 1,
                 "respawn_rate": 5,
-                "last_spawn": 0,
+                "spawned": [],
+                "dead_timestamps": [],
             }
         ]
         npc = create_object(BaseNPC, key="basic_merchant")
@@ -245,7 +250,8 @@ class TestSpawnManager(EvenniaTest):
                 "room_id": 1,
                 "max_count": 1,
                 "respawn_rate": 5,
-                "last_spawn": 0,
+                "spawned": [],
+                "dead_timestamps": [],
             }
         ]
         npc = create_object(BaseNPC, key="num")

--- a/world/tests/test_spawncontrol_commands.py
+++ b/world/tests/test_spawncontrol_commands.py
@@ -78,7 +78,8 @@ class TestSpawnControlCommands(TestCase):
                                 "room_id": rid,
                                 "max_count": int(entry.get("max_count", 1)),
                                 "respawn_rate": int(entry.get("respawn_rate", 60)),
-                                "last_spawn": 0.0,
+                                "spawned": [],
+                                "dead_timestamps": [],
                             }
                         )
 


### PR DESCRIPTION
## Summary
- track active and dead NPCs
- update spawn manager logic
- update NPC death cleanup
- tweak NPC builder
- adjust spawn manager tests

## Testing
- `pytest -q` *(fails: django.db.utils.OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_685e3cc59e40832cb09a09b36b533b5f