### PR TITLE
Remove combat end room message

### DIFF
--- a/combat/round_manager.py
+++ b/combat/round_manager.py
@@ -266,7 +266,6 @@ class CombatInstance:
         self.cancel_tick()
         CombatRoundManager.get().remove_combat(self.combat_id)
 
-        send_room_msg = True
         if reason == "No active fighters remaining":
             reason = ""
         if reason == "Invalid combat instance":
@@ -275,14 +274,6 @@ class CombatInstance:
             except Exception:
                 log_trace(reason)
             reason = ""
-            send_room_msg = False
-
-        message = f"Combat ends: {reason}" if reason else "Combat ends."
-        if send_room_msg and room and hasattr(room, "msg_contents"):
-            try:
-                room.msg_contents(message)
-            except Exception:  # pragma: no cover - safety
-                pass
 
         # Clean up fighter states
         if self.engine:

--- a/typeclasses/tests/test_combat_flow.py
+++ b/typeclasses/tests/test_combat_flow.py
@@ -488,7 +488,9 @@ def test_end_combat_broadcasts_room_message():
         instance.remove_combatant(b)
         instance.end_combat("done")
 
-    room.msg_contents.assert_any_call("Combat ends: done")
+    assert not any(
+        "Combat ends" in call.args[0] for call in room.msg_contents.call_args_list
+    )
 
 
 def test_npc_death_flow_keeps_combat_active_until_end():
@@ -570,7 +572,7 @@ def test_end_combat_suppresses_no_active_fighters_reason():
     with patch.object(CombatRoundManager, "get", return_value=manager):
         instance.end_combat("No active fighters remaining")
 
-    calls = [c.args[0] for c in room.msg_contents.call_args_list]
-    assert "Combat ends." in calls
-    assert all("No active fighters remaining" not in msg for msg in calls)
+    assert not any(
+        "Combat ends" in call.args[0] for call in room.msg_contents.call_args_list
+    )
 


### PR DESCRIPTION
## Summary
- stop announcing combat end in the room
- adjust tests checking for the broadcast

## Testing
- `pytest -q` *(fails: OperationalError - no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_685e4772cb1c832ca7d8974211a715bd