### PR TITLE
Increase corpse decay minimum timer

### DIFF
--- a/server/conf/settings.py
+++ b/server/conf/settings.py
@@ -59,10 +59,11 @@ DEFAULT_RECALL_ROOM = "#2"
 # ----------------------------------------------------------------------
 # Corpse decay settings
 # ----------------------------------------------------------------------
-# Minimum and maximum minutes before an NPC corpse decays. The exact
-# duration is chosen randomly for each corpse within this range.
-CORPSE_DECAY_MIN = 5
-CORPSE_DECAY_MAX = 10
+# Minimum and maximum time in seconds before an NPC corpse decays. The exact
+# duration is chosen randomly for each corpse within this range. Increase the
+# minimum to five minutes so corpses persist longer by default.
+CORPSE_DECAY_MIN = 300
+CORPSE_DECAY_MAX = 600
 
 # When ``True`` a corpse will decay even if being carried in someone's
 # inventory. Set to ``False`` to only allow decay when lying in a room.


### PR DESCRIPTION
## Summary
- ensure corpses last for at least five minutes

## Testing
- `scripts/setup_test_env.sh` *(fails: could not install dependencies)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685e4ecbbedc832c8d75ca72c994f1b5