### PR TITLE
Remove xyz attribute from proto cloning

### DIFF
--- a/commands/redit.py
+++ b/commands/redit.py
@@ -58,7 +58,7 @@ def proto_from_room(room) -> dict:
     except json.JSONDecodeError:
         existing = {}
 
-    for key in ("spawns", "xyz"):
+    for key in ("spawns",):
         if key in existing:
             proto[key] = existing[key]
 


### PR DESCRIPTION
## Summary
- prune leftover "xyz" when cloning room attributes in `proto_from_room`

## Testing
- `evennia migrate`
- `pytest tests/test_redit_spawn_integration.py tests/test_search_first.py -q` *(fails: AssertionError/TypeError)*

------
https://chatgpt.com/codex/tasks/task_e_685e5892b274832c8fcbbb847083b5d8