### PR TITLE
Validate spawn rate in redit

### DIFF
--- a/commands/redit.py
+++ b/commands/redit.py
@@ -394,6 +394,9 @@ def _handle_spawn_cmd(caller, raw_string, **kwargs):
         except ValueError:
             caller.msg("Counts and rate must be numbers.")
             return "menunode_spawns"
+        if rate <= 0:
+            caller.msg("Spawn rate must be positive.")
+            return "menunode_spawns"
         proto_exists = False
         if isinstance(proto_key, int):
             mob_db = get_mobdb()


### PR DESCRIPTION
## Summary
- ensure spawn rate is a positive integer in the room spawn editor
- test spawn rate validation logic

## Testing
- `pytest typeclasses/tests/test_redit_spawns.py::TestReditSpawns::test_spawn_rate_must_be_positive -q`

------
https://chatgpt.com/codex/tasks/task_e_685e662bcb90832c8da0c0bb03a733ef