### PR TITLE
Clarify spawn interval naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,8 +164,10 @@ Room JSONs may include:
 "spawns": [
   {"proto": "mob_goblin", "max_spawns": 2, "spawn_interval": 300}
 ]
-SpawnManager automatically registers spawns when a room prototype is saved. If
 ```
+SpawnManager automatically registers spawns when a room prototype is saved.
+The `spawn_interval` value is stored internally on SpawnManager entries as
+`respawn_rate`. Commands like `@showspawns` display this runtime field. If
 spawns appear to be missing (for example after a server restart), use:
 
 ```bash

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -1250,6 +1250,10 @@ Arguments:
 Examples:
     @showspawns
     @showspawns 200001
+
+Notes:
+    - Room prototypes use |wspawn_interval|n. SpawnManager stores this as
+      |wrespawn_rate|n, which is what this command displays.
 """,
     },
     {
@@ -1263,7 +1267,7 @@ This describes how to make NPCs automatically appear in a room.
 1. Create or edit a mob prototype using |wcnpc|n or |wmobbuilder|n.
 2. Save the prototype with a VNUM.
 3. Use |wredit <room_vnum>|n and choose |wEdit spawns|n to add the prototype,
-   max count and respawn interval.
+   max count and spawn interval (stored at runtime as |wrespawn_rate|n).
 4. Save the room prototype. Spawns are registered automatically, but you can
    use |w@spawnreload|n or |wasave changed|n to refresh them manually.
 5. Check spawns with |w@showspawns <room_vnum>|n.


### PR DESCRIPTION
## Summary
- mention spawn_interval vs respawn_rate in README
- document same difference in help entries for @showspawns and mob spawn setup

## Testing
- `scripts/setup_test_env.sh` *(fails: Could not install dependencies)*
- `pytest -q` *(fails: many test failures and keyboard interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_685e662c1d24832c81008811904f20d6