### PR TITLE
Fix spawn manager deaths when spawn_room missing

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -1109,7 +1109,9 @@ class NPC(Character):
         as ``npc_vnum`` when available.
 
         Respawn timing is based on when this method records the death in the
-        global :class:`~scripts.spawn_manager.SpawnManager`.
+        global :class:`~scripts.spawn_manager.SpawnManager`.  If ``db.spawn_room``
+        is missing, the current location is used to ensure the room's respawn
+        timers update correctly.
 
         Returns
         -------
@@ -1130,7 +1132,10 @@ class NPC(Character):
 
         manager = get_spawn_manager()
         if manager and hasattr(manager, "record_death"):
-            manager.record_death(self.db.prototype_key, self.db.spawn_room, npc_id=self.id)
+            room = self.db.spawn_room or self.location
+            if room and not self.db.spawn_room:
+                self.db.spawn_room = room
+            manager.record_death(self.db.prototype_key, room, npc_id=self.id)
 
         self.delete()
 

--- a/world/tests/test_spawn_manager.py
+++ b/world/tests/test_spawn_manager.py
@@ -311,3 +311,13 @@ class TestSpawnManager(EvenniaTest):
         self.assertIn(str(self.room.db.room_id), msg)
         self.assertIn("boom", msg)
 
+    def test_npc_on_death_falls_back_to_location(self):
+        npc = create_object(BaseNPC, key="mob", location=self.room)
+        npc.db.prototype_key = "goblin"
+        with mock.patch("world.mechanics.on_death_manager.handle_death"), \
+             mock.patch("utils.script_utils.get_spawn_manager", return_value=self.script), \
+             mock.patch.object(self.script, "record_death") as mock_record:
+            npc.on_death(self.char1)
+
+        mock_record.assert_called_with("goblin", self.room, npc_id=npc.id)
+


### PR DESCRIPTION
## Summary
- ensure NPC deaths record spawn room using current location when `spawn_room` is unset
- cover fallback logic with a unit test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685e6cdf3e60832c9e835272e8053684