### PR TITLE
Fix corpses being attackable

### DIFF
--- a/typeclasses/objects.py
+++ b/typeclasses/objects.py
@@ -428,6 +428,7 @@ class Corpse(Object):
     def at_object_creation(self):
         super().at_object_creation()
         self.db.display_priority = "corpse"
+        self.db.can_attack = False
         if getattr(self.db, "weight", None) is None:
             weight = 0
             if self.db.corpse_of and self.location:

--- a/typeclasses/tests/test_attack_command.py
+++ b/typeclasses/tests/test_attack_command.py
@@ -65,6 +65,20 @@ class TestAttackCommand(EvenniaTest):
 
         self.assertFalse(mob.attributes.has("fleeing"))
 
+    def test_attack_corpse_is_blocked(self):
+        corpse = create.create_object(
+            "typeclasses.objects.Corpse", key="corpse", location=self.room1
+        )
+        self.char1.msg.reset_mock()
+        self.char1.execute_cmd("attack corpse")
+        self.assertTrue(self.char1.msg.called)
+        out = self.char1.msg.call_args[0][0]
+        self.assertIn("can't attack", out)
+        from combat.round_manager import CombatRoundManager
+
+        manager = CombatRoundManager.get()
+        self.assertFalse(manager.combats)
+
     def test_joining_combat_queues_immediately(self):
         """Joining an ongoing fight should allow immediate actions."""
         from typeclasses.characters import PlayerCharacter


### PR DESCRIPTION
## Summary
- mark corpse objects as unable to be attacked
- add regression test for attacking corpses

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685e77d044e8832c86dca235edeaa65c