### PR TITLE
Add fallback respawn when death not recorded

### DIFF
--- a/scripts/spawn_manager.py
+++ b/scripts/spawn_manager.py
@@ -518,6 +518,9 @@ class SpawnManager(Script):
                 f"SpawnManager: processing room {self._normalize_room_id(entry)} for {proto} - {live_count}/{max_count}"
             )
 
+            if not ready and capacity > 0 and now - entry.get("last_spawn", 0) >= respawn:
+                ready.append({})
+
             to_spawn = min(capacity, len(ready))
             for _ in range(to_spawn):
                 self._spawn(proto, room, idx=idx)


### PR DESCRIPTION
## Summary
- handle NPC respawn even if no death record exists
- update tests for missing-death respawn
- add new test verifying respawn after interval without death

## Testing
- `pytest typeclasses/tests/test_spawn_manager.py::TestSpawnManager::test_respawn_missing_npc_without_death_record typeclasses/tests/test_spawn_manager.py::TestSpawnManager::test_respawn_without_death_occurs_after_interval -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_685e84007440832cadc9853eb9f56baf