### PR TITLE
Introduce MobRespawnManager

### DIFF
--- a/commands/admin/resetworld.py
+++ b/commands/admin/resetworld.py
@@ -1,6 +1,9 @@
 from evennia import CmdSet
+
+from utils.script_utils import get_respawn_manager, respawn_area
+
 from ..command import Command
-from utils.script_utils import get_spawn_manager, respawn_area
+
 
 class CmdResetWorld(Command):
     """Trigger respawn checks for all areas without despawning existing mobs."""
@@ -11,7 +14,7 @@ class CmdResetWorld(Command):
     help_category = "Admin"
 
     def func(self):
-        script = get_spawn_manager()
+        script = get_respawn_manager()
         if not script:
             self.msg("Spawn manager not found.")
             return
@@ -22,6 +25,7 @@ class CmdResetWorld(Command):
         for key in areas:
             respawn_area(key)
         self.msg(f"World reset complete. [{len(areas)}] areas repopulated.")
+
 
 class ResetWorldCmdSet(CmdSet):
     key = "ResetWorldCmdSet"

--- a/commands/admin/spawncontrol.py
+++ b/commands/admin/spawncontrol.py
@@ -1,5 +1,7 @@
 from evennia import CmdSet
-from utils.script_utils import get_spawn_manager
+
+from utils.script_utils import get_respawn_manager
+
 from ..command import Command
 
 
@@ -11,7 +13,7 @@ class CmdSpawnReload(Command):
     help_category = "Admin"
 
     def func(self):
-        script = get_spawn_manager()
+        script = get_respawn_manager()
         if not script or not hasattr(script, "reload_spawns"):
             self.msg("Spawn manager not found.")
             return
@@ -28,7 +30,7 @@ class CmdForceRespawn(Command):
 
     def func(self):
         arg = self.args.strip()
-        script = get_spawn_manager()
+        script = get_respawn_manager()
         if not script or not hasattr(script, "force_respawn"):
             self.msg("Spawn manager not found.")
             return
@@ -57,7 +59,7 @@ class CmdShowSpawns(Command):
 
     def func(self):
         arg = self.args.strip()
-        script = get_spawn_manager()
+        script = get_respawn_manager()
         if not script:
             self.msg("Spawn manager not found.")
             return

--- a/commands/areas.py
+++ b/commands/areas.py
@@ -1,21 +1,16 @@
-from evennia.objects.models import ObjectDB
-from evennia.utils.evtable import EvTable
 from evennia import CmdSet
+from evennia.objects.models import ObjectDB
 from evennia.prototypes import spawner
-from utils.script_utils import get_spawn_manager, respawn_area
+from evennia.utils.evtable import EvTable
 
-from .command import Command, MuxCommand
-from world.areas import (
-    Area,
-    get_areas,
-    save_area,
-    update_area,
-    find_area,
-    parse_area_identifier,
-)
-from .aedit import CmdAEdit, CmdAList, CmdASave, CmdAreaReset, CmdAreaAge
 from typeclasses.rooms import Room
-from utils.prototype_manager import load_prototype, load_all_prototypes
+from utils.prototype_manager import load_all_prototypes, load_prototype
+from utils.script_utils import get_respawn_manager, respawn_area
+from world.areas import (Area, find_area, get_areas, parse_area_identifier,
+                         save_area, update_area)
+
+from .aedit import CmdAEdit, CmdAList, CmdAreaAge, CmdAreaReset, CmdASave
+from .command import Command, MuxCommand
 
 
 class CmdAMake(Command):
@@ -175,7 +170,11 @@ class CmdRooms(Command):
             self.msg("This room is not within a registered area.")
             return
         objs = ObjectDB.objects.filter(id__gte=current.start, id__lte=current.end)
-        rooms = {obj.id: obj for obj in objs if obj.is_typeclass("evennia.objects.objects.DefaultRoom", exact=False)}
+        rooms = {
+            obj.id: obj
+            for obj in objs
+            if obj.is_typeclass("evennia.objects.objects.DefaultRoom", exact=False)
+        }
         show_all = self.cmdstring.lower() == "roomsall"
         lines = []
         for num in range(current.start, current.end + 1):
@@ -569,7 +568,7 @@ class CmdAreasReset(Command):
                 f"Area '{area_name}' not found. Use 'alist' to view available areas."
             )
             return
-        script = get_spawn_manager()
+        script = get_respawn_manager()
         if not script or not hasattr(script, "force_respawn"):
             self.msg("Spawn manager not found.")
             return
@@ -599,7 +598,5 @@ class AreaCmdSet(CmdSet):
         self.add(CmdRReg)
         self.add(CmdRRegAll)
         from .redit import CmdREdit
+
         self.add(CmdREdit)
-
-
-

--- a/commands/redit.py
+++ b/commands/redit.py
@@ -2,32 +2,26 @@
 
 from __future__ import annotations
 
-from olc.base import OLCEditor, OLCState, OLCValidator
 import json
-from utils.prototype_manager import (
-    save_prototype,
-    load_prototype,
-    load_all_prototypes,
-    CATEGORY_DIRS,
-)
-from utils.vnum_registry import (
-    validate_vnum,
-    register_vnum,
-    unregister_vnum,
-    VNUM_RANGES,
-    peek_next_vnum,
-)
-from world.areas import find_area_by_vnum, get_areas, update_area
-from evennia.prototypes import spawner
-from world.areas import find_area
-from evennia.objects.models import ObjectDB
-from typeclasses.rooms import Room
-from world import prototypes
-from world.scripts.mob_db import get_mobdb
 from functools import wraps
+
+from evennia.objects.models import ObjectDB
+from evennia.prototypes import spawner
+
+from olc.base import OLCEditor, OLCState, OLCValidator
+from typeclasses.rooms import Room
+from utils.prototype_manager import (CATEGORY_DIRS, load_all_prototypes,
+                                     load_prototype, save_prototype)
+from utils.vnum_registry import (VNUM_RANGES, peek_next_vnum, register_vnum,
+                                 unregister_vnum, validate_vnum)
+from world import prototypes
+from world.areas import find_area, find_area_by_vnum, get_areas, update_area
+from world.scripts.mob_db import get_mobdb
+
 from .building import DIR_FULL, OPPOSITE
 from .command import Command
 from .room_flags import VALID_ROOM_FLAGS
+
 
 def proto_from_room(room) -> dict:
     """Return a prototype dict generated from ``room``."""
@@ -146,7 +140,6 @@ def menunode_main(caller, raw_string="", **kwargs):
 def menunode_view_prototype(caller, raw_string="", **kwargs):
     """Display the saved prototype for a room."""
 
-
     vnum = kwargs.get("vnum", caller.ndb.current_vnum)
     try:
         proto = load_prototype("room", vnum)
@@ -183,7 +176,6 @@ menunode_show = menunode_view_prototype
 @require_redit_state
 def menunode_list_prototypes(caller, raw_string="", **kwargs):
     """Browse all prototypes in the current room's area."""
-
 
     current = caller.ndb.room_protos.get(caller.ndb.current_vnum, {})
     area_name = current.get("area")
@@ -555,9 +547,9 @@ def menunode_done(caller, raw_string="", **kwargs):
                         exits[dirkey] = dest_obj
                 room.db.exits = exits
 
-        from utils.script_utils import get_spawn_manager
+        from utils.script_utils import get_respawn_manager
 
-        script = get_spawn_manager()
+        script = get_respawn_manager()
         if script and hasattr(script, "register_room_spawn"):
             script.register_room_spawn(proto)
             if hasattr(script, "force_respawn"):
@@ -724,9 +716,7 @@ class CmdREdit(Command):
             if area_name:
                 idx, area = find_area(area_name)
                 if area and not (area.start <= vnum <= area.end):
-                    self.msg(
-                        f"Number outside area range {area.start}-{area.end}."
-                    )
+                    self.msg(f"Number outside area range {area.start}-{area.end}.")
                     _clear_state()
                     return
                 objs = ObjectDB.objects.filter(

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,4 +1,3 @@
 from .builder_autosave import BuilderAutosave
 from .global_npc_ai import GlobalNPCAI
-from .spawn_manager import SpawnManager
-
+from .mob_respawn_manager import MobRespawnManager

--- a/scripts/mob_respawn_manager.py
+++ b/scripts/mob_respawn_manager.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, List
+
+from evennia.objects.models import ObjectDB
+from evennia.prototypes import spawner
+from evennia.utils import logger, search
+
+from typeclasses.rooms import Room
+from typeclasses.scripts import Script
+from utils.mob_proto import apply_proto_items, spawn_from_vnum
+from world import prototypes
+
+
+class MobRespawnTracker:
+    """Track respawns for a single area."""
+
+    def __init__(self, area: str):
+        self.area = (area or "").lower()
+        self.rooms: Dict[int, Room] = {}
+
+    # ------------------------------------------------------------
+    # public API
+    # ------------------------------------------------------------
+    def add_room(self, room: Room) -> None:
+        rid = getattr(room.db, "room_id", None)
+        if rid is not None:
+            self.rooms[rid] = room
+
+    def remove_room(self, room: Room) -> None:
+        rid = getattr(room.db, "room_id", None)
+        if rid is not None and rid in self.rooms:
+            self.rooms.pop(rid)
+
+    def record_death(
+        self, prototype: Any, room: Room, npc_id: int | None = None
+    ) -> None:
+        norm = self._normalize_proto(prototype)
+        entries = room.db.spawn_entries or []
+        now = time.time()
+        for idx, entry in enumerate(entries):
+            if self._normalize_proto(entry.get("prototype")) != norm:
+                continue
+            active = [sid for sid in entry.get("active_mobs", []) if sid != npc_id]
+            entry["active_mobs"] = active
+            if npc_id is not None:
+                dead = entry.get("dead_mobs", [])
+                dead.append({"id": npc_id, "time_of_death": now})
+                entry["dead_mobs"] = dead
+            entry["last_spawn"] = now
+            entries[idx] = entry
+            break
+        room.db.spawn_entries = entries
+        room.save()
+
+    def record_spawn(
+        self, prototype: Any, room: Room, npc_id: int | None = None
+    ) -> None:
+        norm = self._normalize_proto(prototype)
+        entries = room.db.spawn_entries or []
+        for idx, entry in enumerate(entries):
+            if self._normalize_proto(entry.get("prototype")) != norm:
+                continue
+            if npc_id is not None:
+                active = entry.get("active_mobs", [])
+                if npc_id not in active:
+                    active.append(npc_id)
+                    entry["active_mobs"] = active
+            entry["last_spawn"] = time.time()
+            entries[idx] = entry
+            break
+        room.db.spawn_entries = entries
+        room.save()
+
+    def process_room(self, room: Room) -> None:
+        now = time.time()
+        entries = room.db.spawn_entries or []
+        updated = False
+        for idx, entry in enumerate(entries):
+            proto = entry.get("prototype")
+            max_count = entry.get("max_count", 0)
+            respawn = entry.get("respawn_rate", 60)
+            live_objs = [
+                obj
+                for obj in room.contents
+                if self._normalize_proto(getattr(obj.db, "prototype_key", None))
+                == self._normalize_proto(proto)
+                and obj.db.spawn_room == room
+            ]
+            live_count = len(live_objs)
+            entry["active_mobs"] = [obj.id for obj in live_objs]
+            dead_list = entry.get("dead_mobs", [])
+            ready = [d for d in dead_list if now - d.get("time_of_death", 0) >= respawn]
+            remaining = [
+                d for d in dead_list if now - d.get("time_of_death", 0) < respawn
+            ]
+            if (
+                not ready
+                and live_count < max_count
+                and now - entry.get("last_spawn", 0) >= respawn
+            ):
+                ready.append({})
+            to_spawn = min(max_count - live_count, len(ready))
+            for _ in range(to_spawn):
+                npc = self._spawn(proto, room)
+                if npc:
+                    entry["active_mobs"].append(npc.id)
+                    entry["last_spawn"] = now
+                if ready:
+                    ready.pop(0)
+            entry["dead_mobs"] = remaining + ready
+            entries[idx] = entry
+            updated = True
+        if updated:
+            room.db.spawn_entries = entries
+            room.save()
+
+    def process(self) -> None:
+        for room in list(self.rooms.values()):
+            if not room.pk:
+                self.remove_room(room)
+                continue
+            if not (room.db.spawn_entries):
+                continue
+            self.process_room(room)
+
+    # ------------------------------------------------------------
+    # helpers
+    # ------------------------------------------------------------
+    def _normalize_proto(self, proto: Any) -> Any:
+        if isinstance(proto, int):
+            return proto
+        try:
+            if str(proto).isdigit():
+                return int(proto)
+        except Exception:
+            pass
+        return proto
+
+    def _spawn(self, proto: Any, room: Room):
+        npc = None
+        proto = self._normalize_proto(proto)
+        proto_is_digit = isinstance(proto, int)
+        try:
+            if proto_is_digit:
+                from world.scripts.mob_db import get_mobdb
+
+                mob_db = get_mobdb()
+                if mob_db.get_proto(proto):
+                    npc = spawn_from_vnum(int(proto), location=room)
+                    npc.db.prototype_key = int(proto)
+                else:
+                    p_data = prototypes.get_npc_prototypes().get(str(proto))
+                    if not p_data:
+                        logger.log_warn(
+                            f"RespawnManager: prototype {proto} not found for room {room.dbref}"
+                        )
+                        return None
+                    logger.log_warn(
+                        f"RespawnManager: NPC VNUM '{proto}' missing from MobDB; using registry"
+                    )
+                    data = dict(p_data)
+                    base_cls = data.get("typeclass", "typeclasses.npcs.BaseNPC")
+                    if isinstance(base_cls, str):
+                        module, clsname = base_cls.rsplit(".", 1)
+                        base_cls = getattr(
+                            __import__(module, fromlist=[clsname]), clsname
+                        )
+                    data["typeclass"] = f"{base_cls.__module__}.{base_cls.__name__}"
+                    npc = spawner.spawn(data)[0]
+                    npc.location = room
+                    npc.db.prototype_key = proto
+                    apply_proto_items(npc, data)
+            else:
+                p_data = prototypes.get_npc_prototypes().get(str(proto))
+                if not p_data:
+                    logger.log_warn(
+                        f"RespawnManager: prototype {proto} not found for room {room.dbref}"
+                    )
+                    return None
+                data = dict(p_data)
+                base_cls = data.get("typeclass", "typeclasses.npcs.BaseNPC")
+                if isinstance(base_cls, str):
+                    module, clsname = base_cls.rsplit(".", 1)
+                    base_cls = getattr(__import__(module, fromlist=[clsname]), clsname)
+                data["typeclass"] = f"{base_cls.__module__}.{base_cls.__name__}"
+                npc = spawner.spawn(data)[0]
+                npc.location = room
+                npc.db.prototype_key = proto
+                apply_proto_items(npc, data)
+        except Exception as err:
+            logger.log_err(
+                f"RespawnManager: failed to spawn {proto} in room {room.dbref}: {err}"
+            )
+            return None
+
+        if npc:
+            npc.db.spawn_room = room
+            npc.db.area_tag = room.db.area
+            try:
+                from commands.npc_builder import finalize_mob_prototype
+
+                if not proto_is_digit:
+                    finalize_mob_prototype(npc, npc)
+            except Exception as err:
+                logger.log_err(f"Finalize error on {npc}: {err}")
+        return npc
+
+
+class MobRespawnManager(Script):
+    """Global script handling mob respawns for all areas."""
+
+    def at_script_creation(self):
+        if self.pk:
+            self.key = "mob_respawn_manager"
+            self.desc = "Handles mob respawning"
+        else:
+            self.db_key = "mob_respawn_manager"
+            self.db_desc = "Handles mob respawning"
+        self.interval = 60
+        self.persistent = True
+        self.repeats = -1
+        self.start_delay = False
+        self.db.trackers = self.db.trackers or {}
+
+    # ------------------------------------------------------------
+    # public API
+    # ------------------------------------------------------------
+    def get_tracker(self, area: str) -> MobRespawnTracker:
+        area = (area or "").lower()
+        trackers = self.db.trackers or {}
+        tracker = trackers.get(area)
+        if not tracker:
+            tracker = MobRespawnTracker(area)
+            trackers[area] = tracker
+            self.db.trackers = trackers
+        return tracker
+
+    def register_room_spawn(self, proto: Dict[str, Any]) -> None:
+        spawns = proto.get("spawns") or []
+        room_id = proto.get("room_id") or proto.get("vnum")
+        if room_id is None:
+            return
+        objs = ObjectDB.objects.get_by_attribute(key="room_id", value=int(room_id))
+        room = objs[0] if objs else None
+        if not room:
+            return
+        entries: List[Dict[str, Any]] = []
+        for entry in spawns:
+            proto_key = entry.get("prototype") or entry.get("proto")
+            if not proto_key:
+                continue
+            entries.append(
+                {
+                    "area": (proto.get("area") or "").lower(),
+                    "prototype": (
+                        int(proto_key) if str(proto_key).isdigit() else proto_key
+                    ),
+                    "room_id": int(room_id),
+                    "max_count": int(
+                        entry.get("max_spawns", entry.get("max_count", 1))
+                    ),
+                    "respawn_rate": int(
+                        entry.get("spawn_interval", entry.get("respawn_rate", 60))
+                    ),
+                    "active_mobs": [],
+                    "dead_mobs": [],
+                    "last_spawn": 0.0,
+                }
+            )
+        room.db.spawn_entries = entries
+        room.save()
+        tracker = self.get_tracker(room.db.area)
+        tracker.add_room(room)
+
+    def force_respawn(self, room_vnum: int) -> None:
+        objs = ObjectDB.objects.get_by_attribute(key="room_id", value=room_vnum)
+        room = objs[0] if objs else None
+        if not room:
+            return
+        tracker = self.get_tracker(room.db.area)
+        tracker.add_room(room)
+        tracker.process_room(room)
+
+    def record_death(
+        self, prototype: Any, room: Room, npc_id: int | None = None
+    ) -> None:
+        tracker = self.get_tracker(room.db.area)
+        tracker.record_death(prototype, room, npc_id)
+
+    def record_spawn(
+        self, prototype: Any, room: Room, npc_id: int | None = None
+    ) -> None:
+        tracker = self.get_tracker(room.db.area)
+        tracker.record_spawn(prototype, room, npc_id)
+
+    # ------------------------------------------------------------
+    # script hooks
+    # ------------------------------------------------------------
+    def at_repeat(self):
+        trackers = self.db.trackers or {}
+        from evennia.objects.models import ObjectDB
+
+        objs = ObjectDB.objects.get_by_attribute(key="spawn_entries")
+        area_map: Dict[str, List[Room]] = {}
+        for room in objs:
+            if not room.db.spawn_entries:
+                continue
+            area = (room.db.area or "").lower()
+            area_map.setdefault(area, []).append(room)
+        for area, rooms in area_map.items():
+            tracker = self.get_tracker(area)
+            tracker.rooms = {getattr(r.db, "room_id", 0): r for r in rooms}
+            tracker.process()
+        self.db.trackers = trackers

--- a/typeclasses/tests/test_asave_spawn_manager.py
+++ b/typeclasses/tests/test_asave_spawn_manager.py
@@ -1,10 +1,12 @@
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
+
 from django.test import override_settings
 from evennia.utils.test_resources import EvenniaTest
+
+from commands import aedit
 from commands.admin import BuilderCmdSet
 from typeclasses.rooms import Room
 from world.areas import Area
-from commands import aedit
 
 
 @override_settings(DEFAULT_HOME=None)
@@ -18,14 +20,14 @@ class TestASaveSpawnManager(EvenniaTest):
     @patch("commands.aedit.update_area")
     @patch("commands.aedit.save_prototype")
     @patch("commands.aedit.proto_from_room")
-    @patch("commands.aedit.get_spawn_manager")
+    @patch("commands.aedit.get_respawn_manager")
     @patch("commands.aedit.ObjectDB.objects.filter")
     @patch("commands.aedit.get_areas")
     def test_spawn_manager_called(
         self,
         mock_get_areas,
         mock_obj_filter,
-        mock_get_spawn_manager,
+        mock_get_respawn_manager,
         mock_proto,
         mock_save,
         mock_update,
@@ -39,7 +41,7 @@ class TestASaveSpawnManager(EvenniaTest):
         proto = {"vnum": room.db.room_id}
         mock_proto.return_value = proto
         mock_script = MagicMock()
-        mock_get_spawn_manager.return_value = mock_script
+        mock_get_respawn_manager.return_value = mock_script
 
         cmd = aedit.CmdASave()
         cmd.caller = self.char1

--- a/typeclasses/tests/test_redit_spawns.py
+++ b/typeclasses/tests/test_redit_spawns.py
@@ -1,10 +1,12 @@
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
+
 from django.test import override_settings
-from evennia.utils.test_resources import EvenniaTest
 from evennia.utils import create
-from typeclasses.rooms import Room
+from evennia.utils.test_resources import EvenniaTest
+
 from commands import redit
 from commands.admin import BuilderCmdSet
+from typeclasses.rooms import Room
 
 
 @override_settings(DEFAULT_HOME=None)
@@ -18,8 +20,12 @@ class TestReditSpawns(EvenniaTest):
         self.char1.cmdset.add_default(BuilderCmdSet)
 
     def test_spawn_edit_keeps_exits(self):
-        room1 = create.create_object(Room, key="R1", location=self.char1.location, home=self.char1.location)
-        room2 = create.create_object(Room, key="R2", location=self.char1.location, home=self.char1.location)
+        room1 = create.create_object(
+            Room, key="R1", location=self.char1.location, home=self.char1.location
+        )
+        room2 = create.create_object(
+            Room, key="R2", location=self.char1.location, home=self.char1.location
+        )
         room1.db.room_id = 5
         room2.db.room_id = 6
         room1.db.area = "zone"
@@ -27,17 +33,22 @@ class TestReditSpawns(EvenniaTest):
         room1.db.exits = {"north": room2}
         self.char1.location = room1
 
-        with patch("commands.redit.load_prototype", return_value=None), patch("commands.redit.OLCEditor"):
+        with (
+            patch("commands.redit.load_prototype", return_value=None),
+            patch("commands.redit.OLCEditor"),
+        ):
             self.char1.execute_cmd("redit 5")
 
         proto = self.char1.ndb.room_protos[5]
         assert proto["exits"] == {"north": 6}
-        proto.setdefault("spawns", []).append({
-            "prototype": "goblin",
-            "max_spawns": 2,
-            "spawn_interval": 10,
-            "location": 5,
-        })
+        proto.setdefault("spawns", []).append(
+            {
+                "prototype": "goblin",
+                "max_spawns": 2,
+                "spawn_interval": 10,
+                "location": 5,
+            }
+        )
         self.char1.ndb.room_protos[5] = proto
 
         with patch("commands.redit.save_prototype") as mock_save:
@@ -49,12 +60,17 @@ class TestReditSpawns(EvenniaTest):
         assert room1.db.exits == {"north": room2}
 
     def test_register_room_spawn_uses_proto_vnum(self):
-        room = create.create_object(Room, key="R1", location=self.char1.location, home=self.char1.location)
+        room = create.create_object(
+            Room, key="R1", location=self.char1.location, home=self.char1.location
+        )
         room.db.room_id = 5
         room.db.area = "zone"
         self.char1.location = room
 
-        with patch("commands.redit.load_prototype", return_value=None), patch("commands.redit.OLCEditor"):
+        with (
+            patch("commands.redit.load_prototype", return_value=None),
+            patch("commands.redit.OLCEditor"),
+        ):
             self.char1.execute_cmd("redit 5")
 
         proto = self.char1.ndb.room_protos[5]
@@ -62,9 +78,11 @@ class TestReditSpawns(EvenniaTest):
         self.char1.ndb.room_protos[5] = proto
 
         mock_script = MagicMock()
-        with patch("commands.redit.save_prototype"), patch(
-            "commands.redit.ObjectDB.objects.filter", return_value=[room]
-        ), patch("commands.redit.get_spawn_manager", return_value=mock_script):
+        with (
+            patch("commands.redit.save_prototype"),
+            patch("commands.redit.ObjectDB.objects.filter", return_value=[room]),
+            patch("commands.redit.get_respawn_manager", return_value=mock_script),
+        ):
             redit.menunode_done(self.char1)
             mock_script.register_room_spawn.assert_called_with(proto)
             assert proto["vnum"] == 5
@@ -83,4 +101,3 @@ class TestReditSpawns(EvenniaTest):
         assert result == "menunode_spawns"
         self.char1.msg.assert_called_with("Spawn rate must be positive.")
         assert self.char1.ndb.room_protos[5].get("spawns", []) == []
-

--- a/utils/script_utils.py
+++ b/utils/script_utils.py
@@ -2,13 +2,15 @@
 
 from typing import Iterable, List
 
-from evennia.utils import logger
 from evennia.scripts.models import ScriptDB
+from evennia.utils import logger
 
 
-def resume_paused_scripts(keys: Iterable[str] | None = None,
-                           paths: Iterable[str] | None = None,
-                           log: bool = True) -> List[ScriptDB]:
+def resume_paused_scripts(
+    keys: Iterable[str] | None = None,
+    paths: Iterable[str] | None = None,
+    log: bool = True,
+) -> List[ScriptDB]:
     """Resume paused scripts.
 
     Parameters
@@ -45,21 +47,23 @@ def resume_paused_scripts(keys: Iterable[str] | None = None,
         resumed.append(script)
         if log:
             obj_name = getattr(script.obj, "key", None)
-            logger.log_info(f"[Startup] Resuming paused script: {script.key} ({obj_name})")
+            logger.log_info(
+                f"[Startup] Resuming paused script: {script.key} ({obj_name})"
+            )
 
     return resumed
 
 
-def get_spawn_manager() -> ScriptDB | None:
-    """Return the global ``SpawnManager`` script if it exists."""
+def get_respawn_manager() -> ScriptDB | None:
+    """Return the global ``MobRespawnManager`` script if it exists."""
 
-    return ScriptDB.objects.filter(db_key="spawn_manager").first()
+    return ScriptDB.objects.filter(db_key="mob_respawn_manager").first()
 
 
 def respawn_area(area_key: str) -> None:
     """Force respawn of all rooms in ``area_key`` using ``SpawnManager``."""
 
-    script = get_spawn_manager()
+    script = get_respawn_manager()
     if not script or not hasattr(script, "force_respawn"):
         return
     key = area_key.lower()
@@ -76,7 +80,7 @@ def respawn_area(area_key: str) -> None:
 def respawn_world() -> None:
     """Force respawn of every defined area."""
 
-    script = get_spawn_manager()
+    script = get_respawn_manager()
     if not script or not hasattr(script, "force_respawn"):
         return
     from evennia.objects.models import ObjectDB

--- a/utils/tests/test_script_utils.py
+++ b/utils/tests/test_script_utils.py
@@ -1,9 +1,11 @@
 import os
+
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "server.conf.settings")
+import unittest
+from unittest.mock import MagicMock, patch
+
 import django
 import evennia
-import unittest
-from unittest.mock import patch, MagicMock
 
 django.setup()
 if getattr(evennia, "SESSION_HANDLER", None) is None:
@@ -13,12 +15,12 @@ from utils import script_utils
 
 
 class TestScriptUtils(unittest.TestCase):
-    def test_get_spawn_manager_filters_key(self):
+    def test_get_respawn_manager_filters_key(self):
         with patch("utils.script_utils.ScriptDB.objects.filter") as mock_filter:
             mock_filter.return_value.first.return_value = "script"
-            result = script_utils.get_spawn_manager()
+            result = script_utils.get_respawn_manager()
             self.assertEqual(result, "script")
-            mock_filter.assert_called_with(db_key="spawn_manager")
+            mock_filter.assert_called_with(db_key="mob_respawn_manager")
 
     def test_respawn_area_calls_force_respawn(self):
         mock_script = MagicMock()
@@ -30,14 +32,18 @@ class TestScriptUtils(unittest.TestCase):
         room3.db.spawn_entries = [1]
         room3.db.room_id = 3
         room3.attributes.get.return_value = "zone"
-        with patch("utils.script_utils.get_spawn_manager", return_value=mock_script), \
-             patch("utils.script_utils.ObjectDB.objects.get_by_attribute", return_value=[room1, room3]):
+        with (
+            patch("utils.script_utils.get_respawn_manager", return_value=mock_script),
+            patch(
+                "utils.script_utils.ObjectDB.objects.get_by_attribute",
+                return_value=[room1, room3],
+            ),
+        ):
             script_utils.respawn_area("zone")
         mock_script.force_respawn.assert_any_call(1)
         mock_script.force_respawn.assert_any_call(3)
         self.assertEqual(mock_script.force_respawn.call_count, 2)
 
     def test_respawn_area_missing_manager(self):
-        with patch("utils.script_utils.get_spawn_manager", return_value=None):
+        with patch("utils.script_utils.get_respawn_manager", return_value=None):
             script_utils.respawn_area("zone")
-


### PR DESCRIPTION
## Summary
- add new `MobRespawnManager` script with per-area tracking
- wire server start-up to create the new manager
- update helper functions and commands to use `MobRespawnManager`
- adjust NPC death handling and related tests

## Testing
- `black scripts/mob_respawn_manager.py scripts/__init__.py server/conf/at_server_startstop.py utils/script_utils.py commands/admin/spawncontrol.py commands/admin/resetworld.py commands/areas.py commands/redit.py commands/aedit.py commands/npc_builder.py typeclasses/characters.py tests/test_redit_spawn_integration.py utils/tests/test_script_utils.py typeclasses/tests/test_redit_spawns.py typeclasses/tests/test_asave_spawn_manager.py`
- `isort scripts/mob_respawn_manager.py scripts/__init__.py server/conf/at_server_startstop.py utils/script_utils.py commands/admin/spawncontrol.py commands/admin/resetworld.py commands/areas.py commands/redit.py commands/aedit.py commands/npc_builder.py typeclasses/characters.py tests/test_redit_spawn_integration.py utils/tests/test_script_utils.py typeclasses/tests/test_redit_spawns.py typeclasses/tests/test_asave_spawn_manager.py`
- `pytest -q` *(fails: OperationalError: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_685e8abcdc44832c81b75422842789d7