### PR TITLE
Set respawn manager interval

### DIFF
--- a/server/conf/at_server_startstop.py
+++ b/server/conf/at_server_startstop.py
@@ -161,7 +161,9 @@ def at_server_start():
         if spawn_script:
             spawn_script.delete()
         spawn_script = create.create_script(
-            "scripts.mob_respawn_manager.MobRespawnManager", key="mob_respawn_manager"
+            "scripts.mob_respawn_manager.MobRespawnManager",
+            key="mob_respawn_manager",
+            interval=60,
         )
     else:
         if not spawn_script.is_active:


### PR DESCRIPTION
## Summary
- set `interval=60` when creating `MobRespawnManager`

## Testing
- `pytest tests/test_redit_spawn_integration.py::TestReditSpawnIntegration::test_spawn_manager_integration -q` *(fails: no such table `accounts_accountdb`)*

------
https://chatgpt.com/codex/tasks/task_e_685e919b95b4832cbfc9028c492accef