### PR TITLE
Remove old SpawnManager script at startup

### DIFF
--- a/server/conf/at_server_startstop.py
+++ b/server/conf/at_server_startstop.py
@@ -152,6 +152,17 @@ def at_server_start():
         elif getattr(script.db, "_paused_time", None):
             script.unpause()
 
+    # remove legacy SpawnManager script if it still exists
+    legacy_script = (
+        ScriptDB.objects.filter(db_key="spawn_manager").first()
+        or ScriptDB.objects.filter(
+            typeclass_path="scripts.spawn_manager.SpawnManager"
+        ).first()
+    )
+    if legacy_script:
+        logger.log_info("[Startup] Removing legacy SpawnManager script")
+        legacy_script.delete()
+
     spawn_script = get_respawn_manager()
     if (
         not spawn_script


### PR DESCRIPTION
## Summary
- cleanup stray SpawnManager script before creating the new MobRespawnManager

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: evennia)*

------
https://chatgpt.com/codex/tasks/task_e_685e95cc5420832c954c698598d6c567