### PR TITLE
Add logging for global_tick startup

### DIFF
--- a/server/conf/at_server_startstop.py
+++ b/server/conf/at_server_startstop.py
@@ -119,13 +119,20 @@ def at_server_start():
     if not script or script.typeclass_path != "typeclasses.scripts.GlobalTick":
         if script:
             script.delete()
+        logger.log_info("[Startup] Creating global_tick script (key=global_tick)")
         script = create.create_script(
             "typeclasses.scripts.GlobalTick", key="global_tick"
         )
     else:
         if not script.is_active:
+            logger.log_info(
+                f"[Startup] Starting global_tick script {script.dbref}"
+            )
             script.start()
         elif getattr(script.db, "_paused_time", None):
+            logger.log_info(
+                f"[Startup] Unpausing global_tick script {script.dbref}"
+            )
             script.unpause()
 
     script = ScriptDB.objects.filter(db_key="global_npc_ai").first()


### PR DESCRIPTION
## Summary
- add new log_info messages before creating, starting or unpausing global_tick script

## Testing
- `pytest -q` *(fails: no such table: accounts_accountdb)*

------
https://chatgpt.com/codex/tasks/task_e_685e9edf5500832c842badfc05b92964