### PR TITLE
Update default player prompt and reset handling

### DIFF
--- a/commands/info.py
+++ b/commands/info.py
@@ -784,6 +784,11 @@ class CmdPrompt(Command):
             caller.msg(f"Current prompt: {current}")
             caller.msg("Set a new prompt with |wprompt <format>|n.")
             return
+        if self.args.strip().lower() == "reset":
+            caller.db.prompt_format = None
+            caller.msg("Prompt reset to default.")
+            caller.refresh_prompt()
+            return
         caller.db.prompt_format = self.args.strip()
         caller.msg("Prompt updated.")
         caller.refresh_prompt()

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -765,6 +765,7 @@ class Character(TriggerMixin, ObjectParent, ClothedCharacter):
         mp_max = int(self.traits.mana.max)
         sp_cur = int(self.traits.stamina.current)
         sp_max = int(self.traits.stamina.max)
+        tnl = int(self.db.tnl or 0)
 
         coins = self.db.coins or {}
         data = {
@@ -777,6 +778,7 @@ class Character(TriggerMixin, ObjectParent, ClothedCharacter):
             "level": self.db.level or 1,
             "xp": self.db.experience or 0,
             "experience": self.db.experience or 0,
+            "tnl": tnl,
             "copper": coins.get("copper", 0),
             "silver": coins.get("silver", 0),
             "gold": coins.get("gold", 0),
@@ -795,7 +797,8 @@ class Character(TriggerMixin, ObjectParent, ClothedCharacter):
         return (
             f"[|r{hp_cur}|n/{hp_max}] "
             f"[|b{mp_cur}|n/{mp_max}] "
-            f"[|g{sp_cur}|n/{sp_max}] >"
+            f"[|g{sp_cur}|n/{sp_max}] "
+            f"[|y{self.db.experience or 0}|n tnl {tnl}] >"
         )
 
     def at_character_arrive(self, chara, **kwargs):


### PR DESCRIPTION
## Summary
- add XP-to-next-level values to the default resource prompt and format it with the requested brackets and slashes
- allow `prompt reset` to clear custom formats and restore the default prompt

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ebe088dc8832ca0ad595f2cff0fa6)