### PR TITLE
Separate runtime validation from Builder workspace initialization

### DIFF
--- a/smart_mud/__init__.py
+++ b/smart_mud/__init__.py
@@ -1,0 +1,5 @@
+"""Smart MUD package-driven runtime helpers."""
+
+from .world_registry import WorldRegistry, WorldValidationError
+
+__all__ = ["WorldRegistry", "WorldValidationError"]

--- a/smart_mud/startup.py
+++ b/smart_mud/startup.py
@@ -1,0 +1,33 @@
+"""Startup orchestration for the Smart MUD runtime."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+
+from .world_registry import WorldRegistry
+
+
+LogFn = Callable[[str], None]
+
+BANNER = """====================================
+          Smart MUD
+===================================="""
+
+
+def initialize_engine(worlds_root: str | Path, *, logger: LogFn = print) -> WorldRegistry:
+    """Initialize the runtime and return a populated world registry."""
+    for line in BANNER.splitlines():
+        logger(line)
+    logger("")
+    logger("[startup] Loading configuration...")
+    logger("[startup] Opening SQLite...")
+    logger("[startup] Discovering plugins...")
+    logger("[startup] Scanning installed worlds...")
+    logger("")
+    registry = WorldRegistry(worlds_root, logger=logger)
+    registry.load_all_worlds()
+    logger("")
+    logger("[startup] Initializing runtime...")
+    logger("[startup] Ready.")
+    return registry

--- a/smart_mud/world_registry.py
+++ b/smart_mud/world_registry.py
@@ -1,0 +1,176 @@
+"""World package discovery, validation, and Builder workspace setup."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Iterable
+
+
+RUNTIME_ASSET_DIRS: tuple[str, ...] = (
+    "rooms",
+    "areas",
+    "npcs",
+    "items",
+    "quests",
+    "zones",
+    "races",
+    "classes",
+    "skills",
+    "spells",
+    "abilities",
+    "factions",
+    "shops",
+    "trainers",
+    "dialogue",
+    "lore",
+    "rules",
+)
+
+BUILDER_WORKSPACE_DIRS: tuple[str, ...] = (
+    "builder",
+    "builder/audit",
+    "builder/history",
+    "builder/snapshots",
+    "builder/exports",
+    "builder/imports",
+    "builder/templates",
+)
+
+
+class WorldValidationError(Exception):
+    """Raised when a world package is missing fatal gameplay assets."""
+
+
+@dataclass(frozen=True)
+class WorldManifest:
+    """Loaded world manifest data."""
+
+    name: str
+    path: Path
+    data: dict
+
+
+@dataclass
+class RegisteredWorld:
+    """Runtime representation of a validated and prepared world package."""
+
+    name: str
+    path: Path
+    manifest: WorldManifest
+    assets: dict[str, list[Path]] = field(default_factory=dict)
+    created_workspace_dirs: list[Path] = field(default_factory=list)
+
+
+LogFn = Callable[[str], None]
+
+
+class WorldRegistry:
+    """Owns the installed-world lifecycle from scan through registration."""
+
+    def __init__(self, worlds_root: str | Path, *, logger: LogFn | None = None) -> None:
+        self.worlds_root = Path(worlds_root)
+        self.logger = logger or (lambda _message: None)
+        self.worlds: dict[str, RegisteredWorld] = {}
+
+    def scan_installed_worlds(self) -> list[Path]:
+        """Return directories under the worlds root that look like world packages."""
+        if not self.worlds_root.exists():
+            return []
+        return sorted(path for path in self.worlds_root.iterdir() if path.is_dir())
+
+    def load_manifest(self, world_path: str | Path) -> WorldManifest:
+        """Load and minimally parse a world's manifest.json file."""
+        path = Path(world_path)
+        manifest_path = path / "manifest.json"
+        if not manifest_path.is_file():
+            raise WorldValidationError(f"World package '{path.name}' is missing manifest.json")
+        try:
+            data = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as err:
+            raise WorldValidationError(
+                f"World package '{path.name}' has invalid manifest.json: {err}"
+            ) from err
+        name = str(data.get("name") or path.name)
+        return WorldManifest(name=name, path=manifest_path, data=data)
+
+    def validate_runtime_package(self, world_path: str | Path) -> None:
+        """Validate fatal gameplay assets without considering Builder workspace."""
+        path = Path(world_path)
+        missing: list[str] = []
+        if not (path / "manifest.json").is_file():
+            missing.append("manifest.json")
+        for rel_path in RUNTIME_ASSET_DIRS:
+            if not (path / rel_path).is_dir():
+                missing.append(f"{rel_path}/")
+        if missing:
+            joined = ", ".join(missing)
+            raise WorldValidationError(
+                f"World package '{path.name}' is missing required runtime assets: {joined}"
+            )
+
+    def prepare_builder_workspace(self, world_path: str | Path) -> list[Path]:
+        """Create non-fatal Builder workspace directories and empty .gitkeep files."""
+        path = Path(world_path)
+        created: list[Path] = []
+        for rel_path in BUILDER_WORKSPACE_DIRS:
+            directory = path / rel_path
+            existed = directory.exists()
+            directory.mkdir(parents=True, exist_ok=True)
+            if not existed:
+                created.append(directory)
+                self.logger(f"[startup] Created Builder workspace directory: {rel_path}/")
+            gitkeep = directory / ".gitkeep"
+            if not existed and not any(directory.iterdir()) and not gitkeep.exists():
+                gitkeep.touch()
+        return created
+
+    def load_world_assets(self, world_path: str | Path) -> dict[str, list[Path]]:
+        """Load asset file paths for each runtime asset category.
+
+        The registry intentionally records paths only; gameplay systems remain
+        responsible for interpreting their data formats, preserving behavior.
+        """
+        path = Path(world_path)
+        assets: dict[str, list[Path]] = {}
+        for rel_path in RUNTIME_ASSET_DIRS:
+            asset_dir = path / rel_path
+            assets[rel_path] = sorted(child for child in asset_dir.iterdir() if child.is_file())
+        return assets
+
+    def load_world(self, world_path: str | Path) -> RegisteredWorld:
+        """Load one world using the validated runtime/workspace lifecycle."""
+        path = Path(world_path)
+        self.logger("[startup] Loading world package:")
+        self.logger(f"    {path.name}")
+        manifest = self.load_manifest(path)
+        self.logger("[startup] Validating runtime package...")
+        self.validate_runtime_package(path)
+        self.logger("    ✓ Runtime package valid")
+        self.logger("[startup] Preparing builder workspace...")
+        created = self.prepare_builder_workspace(path)
+        if created:
+            for directory in created:
+                self.logger(f"    ✓ {directory.relative_to(path).as_posix()}/")
+        else:
+            self.logger("[startup] Builder workspace already prepared.")
+        self.logger("[startup] Loading world assets...")
+        assets = self.load_world_assets(path)
+        for label in ("rooms", "npcs", "items", "quests", "rules"):
+            self.logger(f"    ✓ {label.title()}")
+        world = RegisteredWorld(
+            name=manifest.name,
+            path=path,
+            manifest=manifest,
+            assets=assets,
+            created_workspace_dirs=created,
+        )
+        self.worlds[world.name] = world
+        self.logger("[startup] World package loaded successfully.")
+        return world
+
+    def load_all_worlds(self, world_paths: Iterable[str | Path] | None = None) -> list[RegisteredWorld]:
+        """Scan/load all installed worlds or a provided set of world directories."""
+        paths = list(world_paths) if world_paths is not None else self.scan_installed_worlds()
+        return [self.load_world(path) for path in paths]

--- a/tests/test_smart_mud_world_registry.py
+++ b/tests/test_smart_mud_world_registry.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from smart_mud.startup import initialize_engine
+from smart_mud.world_registry import (
+    BUILDER_WORKSPACE_DIRS,
+    RUNTIME_ASSET_DIRS,
+    WorldRegistry,
+    WorldValidationError,
+)
+
+
+def make_world(root: Path, name: str = "shattered_realms") -> Path:
+    world = root / name
+    world.mkdir()
+    (world / "manifest.json").write_text(json.dumps({"name": name}), encoding="utf-8")
+    for directory in RUNTIME_ASSET_DIRS:
+        (world / directory).mkdir()
+    return world
+
+
+def test_missing_builder_folders_are_recreated_with_gitkeep(tmp_path: Path):
+    world = make_world(tmp_path)
+    registry = WorldRegistry(tmp_path)
+
+    created = registry.prepare_builder_workspace(world)
+
+    assert [path.relative_to(world).as_posix() for path in created] == list(BUILDER_WORKSPACE_DIRS)
+    for directory in BUILDER_WORKSPACE_DIRS:
+        assert (world / directory).is_dir()
+        assert (world / directory / ".gitkeep").is_file()
+
+
+def test_existing_builder_folders_remain_unchanged(tmp_path: Path):
+    world = make_world(tmp_path)
+    existing = world / "builder" / "history"
+    existing.mkdir(parents=True)
+    marker = existing / "existing.txt"
+    marker.write_text("keep me", encoding="utf-8")
+
+    WorldRegistry(tmp_path).prepare_builder_workspace(world)
+
+    assert marker.read_text(encoding="utf-8") == "keep me"
+    assert not (existing / ".gitkeep").exists()
+
+
+def test_runtime_validation_still_fails_when_gameplay_folder_missing(tmp_path: Path):
+    world = make_world(tmp_path)
+    (world / "rooms").rmdir()
+
+    with pytest.raises(WorldValidationError, match="rooms/"):
+        WorldRegistry(tmp_path).validate_runtime_package(world)
+
+
+def test_startup_succeeds_after_workspace_creation(tmp_path: Path):
+    world = make_world(tmp_path)
+    messages: list[str] = []
+
+    registry = initialize_engine(tmp_path, logger=messages.append)
+
+    assert "shattered_realms" in registry.worlds
+    assert all((world / directory).is_dir() for directory in BUILDER_WORKSPACE_DIRS)
+    assert "[startup] Ready." in messages
+
+
+def test_startup_logging_reports_workspace_initialization(tmp_path: Path):
+    make_world(tmp_path)
+    messages: list[str] = []
+
+    initialize_engine(tmp_path, logger=messages.append)
+
+    assert "[startup] Validating runtime package..." in messages
+    assert "    ✓ Runtime package valid" in messages
+    assert "[startup] Preparing builder workspace..." in messages
+    assert "    ✓ builder/" in messages
+    assert "    ✓ builder/history/" in messages
+    assert "[startup] Loading world assets..." in messages
+
+
+def test_startup_logging_reports_already_prepared_workspace(tmp_path: Path):
+    world = make_world(tmp_path)
+    WorldRegistry(tmp_path).prepare_builder_workspace(world)
+    messages: list[str] = []
+
+    initialize_engine(tmp_path, logger=messages.append)
+
+    assert "[startup] Builder workspace already prepared." in messages
+    assert "    ✓ builder/" not in messages
+
+
+def test_multiple_installed_worlds_each_receive_workspace(tmp_path: Path):
+    first = make_world(tmp_path, "first")
+    second = make_world(tmp_path, "second")
+
+    registry = initialize_engine(tmp_path, logger=lambda _message: None)
+
+    assert set(registry.worlds) == {"first", "second"}
+    for world in (first, second):
+        assert all((world / directory).is_dir() for directory in BUILDER_WORKSPACE_DIRS)


### PR DESCRIPTION
### Motivation
- World package validation must remain strict for gameplay assets while Builder workspace folders should not block startup. 
- Builder workspace directories should be auto-created for future Builder Mode without changing gameplay behavior. 
- Startup logging should clearly show validation and workspace preparation phases to aid debugging and future development.

### Description
- Add a new `smart_mud` package with `world_registry.py` implementing `WorldRegistry`, `WorldValidationError`, `RUNTIME_ASSET_DIRS`, and `BUILDER_WORKSPACE_DIRS` to centralize world scanning, validation, workspace preparation, asset loading, and registration. 
- Implement `validate_runtime_package` to keep fatal runtime checks for gameplay assets (e.g. `manifest.json`, `rooms/`, `areas/`, `npcs/`, etc.) that raise `WorldValidationError` when missing. 
- Implement `prepare_builder_workspace` to non-fatally create missing Builder workspace folders, create a `.gitkeep` only for newly created empty folders without overwriting existing files, and log each created directory. 
- Add `startup.initialize_engine` which prints a clear startup banner and ordered lifecycle logs, and add tests in `tests/test_smart_mud_world_registry.py` covering workspace creation, `.gitkeep` behavior, preservation of existing folders, strict runtime validation failures, logging, startup success, and multiple worlds.

### Testing
- Compiled the new package with `python -m compileall -q smart_mud` which succeeded. 
- Ran the new test suite with `pytest -q tests/test_smart_mud_world_registry.py` which resulted in `7 passed, 2 warnings`. 
- All added tests passed and existing behavior for runtime validation remained strict.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f39c248fc832cac5ac5f11661c31f)