### PR TITLE
Add Smart MUD settings API compatibility

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -1,0 +1,32 @@
+const INITIAL_API_ENDPOINTS = Object.freeze([
+  "/api/settings/global",
+]);
+
+async function loadGlobalSettings(fetchImpl = fetch) {
+  const response = await fetchImpl("/api/settings/global");
+  if (!response.ok) {
+    throw new Error(`Unable to load Smart MUD settings: ${response.status}`);
+  }
+  return response.json();
+}
+
+async function bootSmartMud() {
+  const settings = await loadGlobalSettings();
+  document.documentElement.dataset.theme = settings.theme || "dark";
+  document.title = settings.app_name || "Smart MUD";
+  return settings;
+}
+
+if (typeof window !== "undefined") {
+  window.SmartMudApi = {
+    INITIAL_API_ENDPOINTS,
+    loadGlobalSettings,
+    bootSmartMud,
+  };
+
+  window.addEventListener("DOMContentLoaded", () => {
+    bootSmartMud().catch((error) => console.error(error));
+  });
+}
+
+export { INITIAL_API_ENDPOINTS, loadGlobalSettings, bootSmartMud };

--- a/app/web.py
+++ b/app/web.py
@@ -1,0 +1,83 @@
+"""Minimal Smart MUD web endpoints.
+
+The desktop shell loads this module for the Phase 1 browser UI.  Keep the API
+surface intentionally small and MUD-specific; do not expose legacy Adventure
+Guild AI, campaign, image generation, or ComfyUI settings here.
+"""
+
+from __future__ import annotations
+
+import json
+from http import HTTPStatus
+from typing import Any, Callable
+from urllib.parse import parse_qs
+
+SMART_MUD_SETTINGS: dict[str, Any] = {
+    "app_name": "Smart MUD",
+    "theme": "dark",
+    "terminal_colors": {
+        "background": "#05070a",
+        "foreground": "#d7e1ff",
+        "accent": "#7dd3fc",
+        "error": "#f87171",
+    },
+    "developer_tools_enabled": False,
+    "default_world_id": "shattered_realms",
+    "runtime_mode": "smart_mud",
+    "smart_mud_settings": {
+        "terminal_prompt": ">",
+        "startup_view": "terminal",
+    },
+}
+
+LEGACY_SETTING_KEYS = frozenset(
+    {
+        "campaign",
+        "campaign_settings",
+        "campaign_runtime",
+        "image",
+        "image_settings",
+        "image_generation",
+        "comfyui",
+        "comfyui_settings",
+        "adventure_guild_ai",
+        "ai_settings",
+    }
+)
+
+
+def get_global_settings() -> dict[str, Any]:
+    """Return compatibility settings for the Smart MUD frontend."""
+    return json.loads(json.dumps(SMART_MUD_SETTINGS))
+
+
+def _json_response(payload: dict[str, Any], status: HTTPStatus = HTTPStatus.OK) -> tuple[int, dict[str, str], bytes]:
+    body = json.dumps(payload, sort_keys=True).encode("utf-8")
+    return int(status), {"content-type": "application/json; charset=utf-8"}, body
+
+
+def handle_request(path: str, method: str = "GET") -> tuple[int, dict[str, str], bytes]:
+    """Handle the small Smart MUD HTTP API used during initial page load."""
+    normalized_method = method.upper()
+    if normalized_method != "GET":
+        return _json_response({"error": "method not allowed"}, HTTPStatus.METHOD_NOT_ALLOWED)
+    if path == "/api/settings/global":
+        return _json_response(get_global_settings())
+    if path in {"/", "/index.html"}:
+        return (
+            int(HTTPStatus.OK),
+            {"content-type": "text/html; charset=utf-8"},
+            b'<!doctype html><div id="app">Smart MUD</div><script src="/static/app.js"></script>',
+        )
+    return _json_response({"error": "not found"}, HTTPStatus.NOT_FOUND)
+
+
+def application(environ: dict[str, Any], start_response: Callable[[str, list[tuple[str, str]]], None]) -> list[bytes]:
+    """WSGI adapter for the desktop runtime."""
+    path = environ.get("PATH_INFO", "/")
+    if environ.get("QUERY_STRING"):
+        parse_qs(environ["QUERY_STRING"])
+    status_code, headers, body = handle_request(path, environ.get("REQUEST_METHOD", "GET"))
+    reason = HTTPStatus(status_code).phrase
+    start_response(f"{status_code} {reason}", list(headers.items()))
+    return [body]

--- a/tests/test_smart_mud_web_api.py
+++ b/tests/test_smart_mud_web_api.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from app.web import LEGACY_SETTING_KEYS, get_global_settings, handle_request
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_JS = ROOT / "app" / "static" / "app.js"
+
+
+def frontend_endpoints() -> set[str]:
+    source = APP_JS.read_text(encoding="utf-8")
+    return set(re.findall(r'["\'](/api/[^"\']+)["\']', source))
+
+
+def test_smart_mud_home_page_loads_without_expected_api_404s():
+    status, _headers, body = handle_request("/")
+
+    assert status == 200
+    assert b"Smart MUD" in body
+    for endpoint in frontend_endpoints():
+        endpoint_status, _endpoint_headers, _endpoint_body = handle_request(endpoint)
+        assert endpoint_status != 404, endpoint
+
+
+def test_frontend_settings_call_succeeds():
+    status, headers, body = handle_request("/api/settings/global")
+
+    assert status == 200
+    assert headers["content-type"].startswith("application/json")
+    assert b"Smart MUD" in body
+
+
+def test_global_settings_are_smart_mud_specific():
+    settings = get_global_settings()
+
+    assert settings["app_name"] == "Smart MUD"
+    assert settings["default_world_id"] == "shattered_realms"
+    assert settings["runtime_mode"] == "smart_mud"
+    assert "terminal_colors" in settings
+    assert "smart_mud_settings" in settings
+
+
+def test_global_settings_do_not_return_legacy_campaign_image_or_comfyui_settings():
+    settings = get_global_settings()
+    lowered_keys = {key.lower() for key in settings}
+
+    assert lowered_keys.isdisjoint(LEGACY_SETTING_KEYS)
+
+
+def test_no_old_campaign_runtime_settings_are_required_by_frontend():
+    source = APP_JS.read_text(encoding="utf-8").lower()
+
+    assert "campaign" not in source
+    assert "comfy" not in source
+    assert "image_generation" not in source
+    assert frontend_endpoints() == {"/api/settings/global"}


### PR DESCRIPTION
### Motivation
- The frontend was requesting a removed legacy endpoint (`/api/settings/global`) which produced 404s during startup, so the runtime needs a minimal, MUD-focused compatibility surface for initial UI boot. 
- Keep the API intentionally small and avoid reintroducing legacy campaign, image/ComfyUI, or Adventure Guild AI settings.

### Description
- Add a minimal web API module `app/web.py` exposing a compatibility `GET /api/settings/global` that returns a small, Smart MUD-specific settings payload via `get_global_settings()` and `handle_request()` and a simple WSGI `application()` adapter. 
- Add frontend boot code `app/static/app.js` that enumerates initial endpoints, calls `/api/settings/global`, applies theme/title, and exposes `bootSmartMud` for the desktop runtime. 
- Add tests `tests/test_smart_mud_web_api.py` that extract frontend `/api/` usage from `app/static/app.js`, assert the home page and every initial endpoint do not return 404, validate the settings response is present and MUD-specific, and assert legacy keys are not returned or required. 
- Include `LEGACY_SETTING_KEYS` in `app/web.py` to document and guard against returning campaign/image/ComfyUI/AI settings; add an empty `app/__init__.py` to make `app` importable.

### Testing
- Ran `pytest tests/test_smart_mud_web_api.py tests/test_smart_mud_world_registry.py -q` and the test run completed successfully with all tests passing. 
- The added tests confirm the frontend settings call succeeds, the returned settings are Smart MUD-specific, and no legacy campaign/image/ComfyUI settings are present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f3f6aa95c832c9a423165ff027caf)